### PR TITLE
fix: group manager adds group to immutable set

### DIFF
--- a/src/main/java/com/aws/greengrass/device/configuration/GroupManager.java
+++ b/src/main/java/com/aws/greengrass/device/configuration/GroupManager.java
@@ -8,15 +8,16 @@ package com.aws.greengrass.device.configuration;
 import com.aws.greengrass.device.Session;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 /**
- * a singleton manager class for managing device group roles. It listens to configuration update through nucleus, On the
- * hand, for each request in a session, it iterate through the configurations to find match group(s), returning the
- * authorization policies of group(s).
+ * Singleton manager class for managing device group roles and retrieving permissions associated
+ * with Sessions. To determine device permissions, the GroupManager first determines which device
+ * groups a Session belongs to, and then merges device group permissions.
  */
 public class GroupManager {
     private final AtomicReference<GroupConfiguration> groupConfigurationRef = new AtomicReference<>();
@@ -42,7 +43,7 @@ public class GroupManager {
     }
 
     private Set<String> findMatchingGroups(Map<String, GroupDefinition> groupDefinitionMap, Session session) {
-        Set<String> matchingGroups = Collections.emptySet();
+        Set<String> matchingGroups = new HashSet<>();
 
         for (String groupName : groupDefinitionMap.keySet()) {
             GroupDefinition group = groupDefinitionMap.get(groupName);

--- a/src/test/java/com/aws/greengrass/device/configuration/GroupDefinitionTest.java
+++ b/src/test/java/com/aws/greengrass/device/configuration/GroupDefinitionTest.java
@@ -12,13 +12,14 @@ import com.aws.greengrass.device.configuration.parser.ParseException;
 import com.aws.greengrass.device.iot.Certificate;
 import com.aws.greengrass.device.iot.IotAuthClient;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
@@ -27,18 +28,18 @@ public class GroupDefinitionTest {
     private IotAuthClient mockIotClient;
 
     @Test
-    public void GIVEN_groupDefinitionAndMatchingSession_WHEN_containsSession_THEN_returnsTrue() throws ParseException {
+    void GIVEN_groupDefinitionAndMatchingSession_WHEN_containsSession_THEN_returnsTrue() throws ParseException {
         GroupDefinition groupDefinition = new GroupDefinition("thingName: thing", "Policy1");
         Session session = Mockito.mock(Session.class);
         DeviceAttribute attribute = new StringLiteralAttribute("thing");
         Mockito.when(session.getSessionAttribute(any(), any())).thenReturn(attribute);
-        Assertions.assertTrue(groupDefinition.containsClientDevice(session));
+        assertThat(groupDefinition.containsClientDevice(session), is(true));
     }
 
     @Test
-    public void GIVEN_groupDefinitionAndNonMatchingSession_WHEN_containsSession_THEN_returnsFalse() throws ParseException {
+    void GIVEN_groupDefinitionAndNonMatchingSession_WHEN_containsSession_THEN_returnsFalse() throws ParseException {
         GroupDefinition groupDefinition = new GroupDefinition("thingName: thing", "Policy1");
-        Assertions.assertFalse(groupDefinition.containsClientDevice(
-                new Session(new Certificate("FAKE PEM", mockIotClient))));
+        assertThat(groupDefinition.containsClientDevice(
+                new Session(new Certificate("FAKE_PEM", mockIotClient))), is(false));
     }
 }

--- a/src/test/java/com/aws/greengrass/device/configuration/GroupManagerTest.java
+++ b/src/test/java/com/aws/greengrass/device/configuration/GroupManagerTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.device.configuration;
+
+import com.aws.greengrass.device.Session;
+import com.aws.greengrass.device.configuration.parser.ParseException;
+import com.aws.greengrass.device.exception.AuthorizationException;
+import com.aws.greengrass.device.iot.Certificate;
+import com.aws.greengrass.device.iot.IotAuthClient;
+import com.aws.greengrass.device.iot.Thing;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+public class GroupManagerTest {
+    @Test
+    void GIVEN_emptyGroupConfiguration_WHEN_getApplicablePolicyPermissions_THEN_returnEmptySet()
+            throws AuthorizationException {
+        GroupManager groupManager = new GroupManager();
+        groupManager.setGroupConfiguration(new GroupConfiguration(null, null, null));
+
+        assertThat(groupManager.getApplicablePolicyPermissions(getSessionFromThing("thingName")),
+                is(Collections.emptyMap()));
+    }
+
+    @Test
+    void GIVEN_sessionInNoGroup_WHEN_getApplicablePolicyPermissions_THEN_returnEmptySet()
+            throws AuthorizationException, ParseException {
+        GroupConfiguration groupConfiguration = GroupConfiguration.builder()
+                .definitions(Collections.singletonMap("group1", getGroupDefinition("differentThingName", "policy1")))
+                .policies(Collections.singletonMap("policy1",
+                        Collections.singletonMap("Statement1", getPolicyStatement("connect", "clientId"))))
+                .build();
+        GroupManager groupManager = new GroupManager();
+        groupManager.setGroupConfiguration(groupConfiguration);
+
+        assertThat(groupManager.getApplicablePolicyPermissions(getSessionFromThing("thingName")),
+                is(Collections.emptyMap()));
+    }
+
+    @Test
+    void GIVEN_sessionInSingleGroup_WHEN_getApplicablePolicyPermissions_THEN_returnGroupPermissions()
+            throws AuthorizationException, ParseException {
+        Session session = getSessionFromThing("thingName");
+        GroupConfiguration groupConfiguration = GroupConfiguration.builder()
+                .definitions(Collections.singletonMap("group1", getGroupDefinition("thingName", "policy1")))
+                .policies(Collections.singletonMap("policy1",
+                        Collections.singletonMap("Statement1", getPolicyStatement("connect", "clientId"))))
+                .build();
+        GroupManager groupManager = new GroupManager();
+        Map<String, Set<Permission>> permissionsMap = new HashMap<>(
+                Collections.singletonMap("group1",
+                        new HashSet<>(Collections.singleton(new Permission("group1", "connect", "clientId")))));
+
+        groupManager.setGroupConfiguration(groupConfiguration);
+
+        assertThat(groupManager.getApplicablePolicyPermissions(session), is(permissionsMap));
+    }
+
+    @Test
+    void GIVEN_sessionInMultipleGroups_WHEN_getApplicablePolicyPermissions_THEN_returnMergedGroupPermissions()
+            throws AuthorizationException, ParseException {
+        Session session = getSessionFromThing("thingName");
+        GroupConfiguration groupConfiguration = GroupConfiguration.builder()
+                .definitions(new HashMap<String, GroupDefinition>(){{
+                    put("group1", getGroupDefinition("thingName", "policy1"));
+                    put("group2", getGroupDefinition("thingName", "policy2"));
+                    put("group3", getGroupDefinition("differentThingName", "policy3"));
+                }})
+                .policies(new HashMap<String, Map<String, AuthorizationPolicyStatement>>() {{
+                    put("policy1", Collections.singletonMap("Statement1", getPolicyStatement("connect", "clientId")));
+                    put("policy2", Collections.singletonMap("Statement1", getPolicyStatement("publish", "topic")));
+                    put("policy3", Collections.singletonMap("Statement1", getPolicyStatement("subscribe", "topic")));
+                }})
+                .build();
+        GroupManager groupManager = new GroupManager();
+
+        Map<String, Set<Permission>> permissionsMap = new HashMap<>();
+        permissionsMap.put("group1",
+                new HashSet<>(Collections.singleton(new Permission("group1", "connect", "clientId"))));
+        permissionsMap.put("group2",
+                new HashSet<>(Collections.singleton(new Permission("group2", "publish", "topic"))));
+
+        groupManager.setGroupConfiguration(groupConfiguration);
+
+        assertThat(groupManager.getApplicablePolicyPermissions(session), is(permissionsMap));
+    }
+
+    private Session getSessionFromThing(String thingName) {
+        Thing thing = new Thing(thingName);
+        Session session = new Session(new Certificate("FAKE_PEM", Mockito.mock(IotAuthClient.Default.class)));
+        session.put(thing.getNamespace(), thing);
+        return session;
+    }
+
+    private GroupDefinition getGroupDefinition(String thingName, String policyName) throws ParseException {
+        return GroupDefinition.builder()
+                .selectionRule("thingName: " + thingName)
+                .policyName(policyName)
+                .build();
+    }
+
+    private AuthorizationPolicyStatement getPolicyStatement(String operation, String resource) {
+        return new AuthorizationPolicyStatement("Policy description",
+                AuthorizationPolicyStatement.Effect.ALLOW,
+                new HashSet<>(Collections.singleton(operation)),
+                new HashSet<>(Collections.singleton(resource)));
+    }
+}


### PR DESCRIPTION
This change fixes a bug in the GroupManager class, where groups
containing the given session are added to an immutable set. This
prevents client devices from obtaining any permissions.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
