### PR TITLE
chore: rename policyDescription to statementDescription

### DIFF
--- a/src/main/java/com/aws/greengrass/device/configuration/AuthorizationPolicyStatement.java
+++ b/src/main/java/com/aws/greengrass/device/configuration/AuthorizationPolicyStatement.java
@@ -18,7 +18,7 @@ import java.util.Set;
 @JsonDeserialize(builder = AuthorizationPolicyStatement.AuthorizationPolicyStatementBuilder.class)
 public class AuthorizationPolicyStatement {
 
-    String policyDescription;
+    String statementDescription;
 
     @Builder.Default
     Effect effect = Effect.ALLOW;

--- a/src/test/java/com/aws/greengrass/device/ClientDevicesAuthServiceTest.java
+++ b/src/test/java/com/aws/greengrass/device/ClientDevicesAuthServiceTest.java
@@ -176,7 +176,7 @@ class ClientDevicesAuthServiceTest {
     }
 
     @Test
-    void GIVEN_GG_with_dsc_WHEN_subscribing_to_ca_updates_THEN_get_list_of_certs() throws Exception {
+    void GIVEN_GG_with_cda_WHEN_subscribing_to_ca_updates_THEN_get_list_of_certs() throws Exception {
         startNucleusWithConfig("config.yaml");
         CountDownLatch countDownLatch = new CountDownLatch(1);
 
@@ -222,7 +222,7 @@ class ClientDevicesAuthServiceTest {
     }
 
     @Test
-    void GIVEN_GG_with_dsc_WHEN_restart_kernel_THEN_ca_is_persisted()
+    void GIVEN_GG_with_cda_WHEN_restart_kernel_THEN_ca_is_persisted()
             throws InterruptedException, CertificateEncodingException, KeyStoreException, IOException,
             ServiceLoadException {
         startNucleusWithConfig("config.yaml");
@@ -260,7 +260,7 @@ class ClientDevicesAuthServiceTest {
 
 
     @Test
-    void GIVEN_GG_with_dsc_WHEN_updated_ca_type_THEN_ca_is_updated()
+    void GIVEN_GG_with_cda_WHEN_updated_ca_type_THEN_ca_is_updated()
             throws InterruptedException, ServiceLoadException, KeyStoreException, CertificateException, IOException {
         startNucleusWithConfig("config.yaml");
 
@@ -302,7 +302,7 @@ class ClientDevicesAuthServiceTest {
     }
 
     @Test
-    void GIVEN_GG_with_dsc_WHEN_ca_type_provided_in_config_THEN_valid_ca_created()
+    void GIVEN_GG_with_cda_WHEN_ca_type_provided_in_config_THEN_valid_ca_created()
             throws IOException, InterruptedException, ServiceLoadException, CertificateException, KeyStoreException {
         startNucleusWithConfig("config_with_ec_ca.yaml");
 

--- a/src/test/resources/com/aws/greengrass/device/config.yaml
+++ b/src/test/resources/com/aws/greengrass/device/config.yaml
@@ -21,14 +21,14 @@ services:
         policies:
           sensorAccessPolicy:
             policyStatement1:
-              policyDescription: "mqtt connect"
+              statementDescription: "mqtt connect"
               effect: ALLOW
               operations:
                 - "mqtt:connect"
               resources:
                 - "mqtt:clientId:foo"
             policyStatement2:
-              policyDescription: "mqtt publish"
+              statementDescription: "mqtt publish"
               effect: ALLOW
               operations:
                 - "mqtt:publish"

--- a/src/test/resources/com/aws/greengrass/device/noGroupPolicyConfig.yaml
+++ b/src/test/resources/com/aws/greengrass/device/noGroupPolicyConfig.yaml
@@ -21,14 +21,14 @@ services:
         policies:
           policyNameTypo:
             policyStatement1:
-              policyDescription: "mqtt connect"
+              statementDescription: "mqtt connect"
               effect: ALLOW
               operations:
                 - "mqtt:connect"
               resources:
                 - "mqtt:broker:localBroker"
             policyStatement2:
-              policyDescription: "mqtt publish"
+              statementDescription: "mqtt publish"
               effect: ALLOW
               operations:
                 - "mqtt:publish"


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
rename `policyDescription` to `statementDescription`

**Why is this change necessary:**
`statementDescription` makes more sense to be the field name

**How was this change tested:**
unit tests pass

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
