### PR TITLE
fix: add back CA storage on disk in order to not break UAT

### DIFF
--- a/src/main/java/com/aws/greengrass/certificatemanager/certificate/CertificateStore.java
+++ b/src/main/java/com/aws/greengrass/certificatemanager/certificate/CertificateStore.java
@@ -47,6 +47,7 @@ public class CertificateStore {
     private static final String CA_KEY_ALIAS = "CA";
     private static final String DEVICE_CERTIFICATE_DIR = "devices";
     private static final String DEFAULT_KEYSTORE_FILENAME = "ca.jks";
+    private static final String DEFAULT_CA_CERTIFICATE_FILENAME = "ca.pem";
 
     // Current NIST recommendation is to provide at least 112 bits
     // of security strength through 2030
@@ -256,6 +257,11 @@ public class CertificateStore {
         }
 
         platform.setPermissions(OWNER_RW_ONLY, caPath);
+
+        // TODO: Clean this up
+        // Temporarily store public CA since CA information is not yet available in cloud
+        X509Certificate caCert = getCACertificate();
+        saveCertificatePem(workPath.resolve(DEFAULT_CA_CERTIFICATE_FILENAME), CertificateHelper.toPem(caCert));
     }
 
     private String loadCertificatePem(Path filePath) throws IOException {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
add back CA storage on disk for now in order to not break UAT

**Why is this change necessary:**
before switching UAT to use cloud discovery, this workaround should be kept.

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
