### PR TITLE
refactor: remove DENY effect

### DIFF
--- a/src/main/java/com/aws/greengrass/device/configuration/AuthorizationPolicyStatement.java
+++ b/src/main/java/com/aws/greengrass/device/configuration/AuthorizationPolicyStatement.java
@@ -34,6 +34,6 @@ public class AuthorizationPolicyStatement {
     }
 
     public enum Effect {
-        ALLOW, DENY
+        ALLOW
     }
 }

--- a/src/test/resources/com/aws/greengrass/device/config.yaml
+++ b/src/test/resources/com/aws/greengrass/device/config.yaml
@@ -29,7 +29,6 @@ services:
                 - "mqtt:clientId:foo"
             policyStatement2:
               statementDescription: "mqtt publish"
-              effect: ALLOW
               operations:
                 - "mqtt:publish"
               resources:


### PR DESCRIPTION
This change removes the DENY effect, since this functionality is not yet
implemented. The Effect field in policy statements is optional and
defaults to ALLOW so that we can safely re-introduce this in the future
in a backward compatible manner.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**
Unit tests

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
