### PR TITLE
fix: support "thingName: *" in ruleExpression

### DIFF
--- a/src/main/java/com/aws/greengrass/device/configuration/parser/RuleExpression.jj
+++ b/src/main/java/com/aws/greengrass/device/configuration/parser/RuleExpression.jj
@@ -38,7 +38,7 @@ TOKEN:
 {
     < OR:           "OR" >
 |   < AND:          "AND" >
-|   < THINGNAME:    (<ALPHANUMERIC> | "-" | "_" | "\\:")+("*")? > // Only allow escaped colons
+|   < THINGNAME:    (<ALPHANUMERIC> | "-" | "_" | "\\:")+("*")? | "*" > // Only allow escaped colons
 |   < ALPHANUMERIC: [ "a"-"z" ] | [ "A"-"Z" ] | [ "0"-"9" ] >
 }
 

--- a/src/main/java/com/aws/greengrass/device/configuration/parser/RuleExpressionTokenManager.java
+++ b/src/main/java/com/aws/greengrass/device/configuration/parser/RuleExpressionTokenManager.java
@@ -307,7 +307,7 @@ private int jjMoveNfa_0(int startState, int curPos)
          {
             switch(jjstateSet[--i])
             {
-               case 5:
+               case 4:
                   if ((0x3ff200000000000L & l) != 0L)
                   {
                      if (kind > 6)
@@ -319,18 +319,23 @@ private int jjMoveNfa_0(int startState, int curPos)
                      if (kind > 6)
                         kind = 6;
                   }
+                  if ((0x3ff000000000000L & l) != 0L)
+                  {
+                     if (kind > 7)
+                        kind = 7;
+                  }
                   break;
-               case 4:
+               case 5:
                   if ((0x3ff200000000000L & l) != 0L)
                   {
                      if (kind > 6)
                         kind = 6;
                      { jjCheckNAddStates(0, 2); }
                   }
-                  if ((0x3ff000000000000L & l) != 0L)
+                  else if (curChar == 42)
                   {
-                     if (kind > 7)
-                        kind = 7;
+                     if (kind > 6)
+                        kind = 6;
                   }
                   break;
                case 0:
@@ -361,16 +366,6 @@ private int jjMoveNfa_0(int startState, int curPos)
          {
             switch(jjstateSet[--i])
             {
-               case 5:
-                  if ((0x7fffffe87fffffeL & l) != 0L)
-                  {
-                     if (kind > 6)
-                        kind = 6;
-                     { jjCheckNAddStates(0, 2); }
-                  }
-                  else if (curChar == 92)
-                     jjstateSet[jjnewStateCnt++] = 1;
-                  break;
                case 4:
                   if ((0x7fffffe87fffffeL & l) != 0L)
                   {
@@ -385,6 +380,16 @@ private int jjMoveNfa_0(int startState, int curPos)
                      if (kind > 7)
                         kind = 7;
                   }
+                  break;
+               case 5:
+                  if ((0x7fffffe87fffffeL & l) != 0L)
+                  {
+                     if (kind > 6)
+                        kind = 6;
+                     { jjCheckNAddStates(0, 2); }
+                  }
+                  else if (curChar == 92)
+                     jjstateSet[jjnewStateCnt++] = 1;
                   break;
                case 0:
                   if ((0x7fffffe87fffffeL & l) == 0L)

--- a/src/main/javacc/RuleExpression.jjt
+++ b/src/main/javacc/RuleExpression.jjt
@@ -34,7 +34,7 @@ TOKEN:
 {
     < OR:           "OR" >
 |   < AND:          "AND" >
-|   < THINGNAME:    (<ALPHANUMERIC> | "-" | "_" | "\\:")+("*")? > // Only allow escaped colons
+|   < THINGNAME:    (<ALPHANUMERIC> | "-" | "_" | "\\:")+("*")? | "*" > // Only allow escaped colons
 |   < ALPHANUMERIC: [ "a"-"z" ] | [ "A"-"Z" ] | [ "0"-"9" ] >
 }
 

--- a/src/test/java/com/aws/greengrass/device/configuration/parser/BasicRuleExpressionTest.java
+++ b/src/test/java/com/aws/greengrass/device/configuration/parser/BasicRuleExpressionTest.java
@@ -18,106 +18,117 @@ public class BasicRuleExpressionTest {
 
     void expectValidExpression(String expressionString) throws ParseException {
         RuleExpression parser = new RuleExpression(new StringReader(expressionString));
-        parser.expression();
+        parser.Start();
     }
 
     void expectParseException(String expressionString) {
         RuleExpression parser = new RuleExpression(new StringReader(expressionString));
-        Assertions.assertThrows(ParseException.class, () -> parser.expression());
+        Assertions.assertThrows(ParseException.class, () -> parser.Start());
     }
 
     void expectTokenMgrError(String expressionString) throws TokenMgrError {
         RuleExpression parser = new RuleExpression(new StringReader(expressionString));
-        Assertions.assertThrows(TokenMgrError.class, () -> parser.expression());
+        Assertions.assertThrows(TokenMgrError.class, () -> parser.Start());
     }
 
     @Test
-    public void GIVEN_lowerCaseThingName_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
+    void GIVEN_lowerCaseThingName_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
         expectValidExpression("thingName: lowercase");
     }
 
     @Test
-    public void GIVEN_upperCaseThingName_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
+    void GIVEN_upperCaseThingName_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
         expectValidExpression("thingName: UPPERCASE");
     }
 
     @Test
-    public void GIVEN_upperAndLowerCaseThingName_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
+    void GIVEN_upperAndLowerCaseThingName_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
         expectValidExpression("thingName: lowerUPPER");
     }
 
     @Test
-    public void GIVEN_thingNameWithTrailingDigits_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
+    void GIVEN_thingNameWithTrailingDigits_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
         expectValidExpression("thingName: thing1");
     }
 
     @Test
-    public void GIVEN_thingNameWithDashAndDigit_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
+    void GIVEN_thingNameWithDashAndDigit_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
         expectValidExpression("thingName: thing-1");
     }
 
     @Test
-    public void GIVEN_thingNameWithUnderscoreAndDigit_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
+    void GIVEN_thingNameWithUnderscoreAndDigit_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
         expectValidExpression("thingName: thing_1");
     }
 
     @Test
-    public void GIVEN_thingNameWithLeadingDigit_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
+    void GIVEN_thingNameWithLeadingDigit_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
         expectValidExpression("thingName: 1thing");
     }
 
     @Test
-    public void GIVEN_thingNameWithLeadingDash_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
+    void GIVEN_thingNameWithLeadingDash_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
         expectValidExpression("thingName: -thing");
     }
 
     @Test
-    public void GIVEN_thingNameWithLeadingUnderscore_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
+    void GIVEN_thingNameWithLeadingUnderscore_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
         expectValidExpression("thingName: _thing");
     }
 
     @Test
-    public void GIVEN_thingNameWithEscapedColon_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
+    void GIVEN_thingNameWithEscapedColon_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
         expectValidExpression("thingName: thi\\:ng");
     }
 
     @Test
-    public void GIVEN_thingNameWithAllCharacters_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
+    void GIVEN_thingNameWithAllCharacters_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
         expectValidExpression("thingName: abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_\\:");
     }
 
     @Test
-    public void GIVEN_thingNameWithNoSpace_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
+    void GIVEN_thingNameWithNoSpace_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
         expectValidExpression("thingName:thing");
     }
 
     @Test
-    public void GIVEN_basicLogicalORExpression_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
+    void GIVEN_wildcardAsThingName_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
+        expectValidExpression("thingName: *");
+    }
+
+    @Test
+    void GIVEN_basicLogicalORExpression_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
         expectValidExpression("thingName: Thing1 OR thingName: Thing2");
     }
 
     @Test
-    public void GIVEN_basicLogicalANDExpression_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
+    void GIVEN_basicLogicalANDExpression_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
         expectValidExpression("thingName: Thing1 AND thingName: Thing2");
     }
 
     @Test
-    public void GIVEN_logicalExpressionWithAndOr_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
+    void GIVEN_logicalExpressionWithAndOr_WHEN_RuleExpression_THEN_ruleIsParsed() throws ParseException {
         expectValidExpression("thingName: Thing1 AND thingName: Thing2 OR thingName: Thing3");
     }
 
     @Test
-    public void GIVEN_expressionWithoutThingName_WHEN_RuleExpression_THEN_exceptionIsThrown() {
+    void GIVEN_expressionWithoutThingName_WHEN_RuleExpression_THEN_exceptionIsThrown() {
         expectParseException("thingName:");
     }
 
     @Test
-    public void GIVEN_expressionWithoutSeparatingColon_WHEN_RuleExpression_THEN_exceptionIsThrown() {
+    void GIVEN_expressionWithoutSeparatingColon_WHEN_RuleExpression_THEN_exceptionIsThrown() {
         expectParseException("ThingName thing");
     }
 
     @Test
-    public void GIVEN_thingNameWithUnescapedColon_WHEN_RuleExpression_THEN_exceptionIsThrown() {
+    void GIVEN_thingNameWithUnescapedColon_WHEN_RuleExpression_THEN_exceptionIsThrown() {
         expectTokenMgrError("thingName: :");
+    }
+
+    @Test
+    void GIVEN_thingNameWithNonTrailingWildcard_WHEN_RuleExpression_THEN_exceptionIsThrown() {
+        expectParseException("thingName: *thing");
+        expectParseException("thingName: thing*2");
     }
 }

--- a/src/test/java/com/aws/greengrass/device/configuration/parser/RuleExpressionEvaluationTest.java
+++ b/src/test/java/com/aws/greengrass/device/configuration/parser/RuleExpressionEvaluationTest.java
@@ -36,7 +36,7 @@ public class RuleExpressionEvaluationTest {
     }
 
     @Test
-    public void GIVEN_unaryExpressionWithSessionContainingThing_WHEN_RuleExpressionEvaluated_THEN_EvaluatesTrue() throws ParseException {
+    void GIVEN_unaryExpressionWithSessionContainingThing_WHEN_RuleExpressionEvaluated_THEN_EvaluatesTrue() throws ParseException {
         ASTStart tree = getTree("thingName: Thing");
         Session session = getSessionWithThing("Thing");
         RuleExpressionVisitor visitor = new ExpressionVisitor();
@@ -44,7 +44,7 @@ public class RuleExpressionEvaluationTest {
     }
 
     @Test
-    public void GIVEN_unaryExpression_WHEN_RuleExpressionEvaluatedWithSessionNotContainingThing_THEN_EvaluatesFalse() throws ParseException {
+    void GIVEN_unaryExpression_WHEN_RuleExpressionEvaluatedWithSessionNotContainingThing_THEN_EvaluatesFalse() throws ParseException {
         ASTStart tree = getTree("thingName: Thing1");
         Session session = getSessionWithThing("Thing");
         RuleExpressionVisitor visitor = new ExpressionVisitor();
@@ -52,7 +52,7 @@ public class RuleExpressionEvaluationTest {
     }
 
     @Test
-    public void GIVEN_basicOrExpression_WHEN_RuleExpressionEvaluatedWithSessionContainingOneThing_THEN_EvaluatesTrue() throws ParseException {
+    void GIVEN_basicOrExpression_WHEN_RuleExpressionEvaluatedWithSessionContainingOneThing_THEN_EvaluatesTrue() throws ParseException {
         ASTStart tree = getTree("thingName: Thing OR thingName: Thing1");
         Session session = getSessionWithThing("Thing");
         RuleExpressionVisitor visitor = new ExpressionVisitor();
@@ -60,7 +60,7 @@ public class RuleExpressionEvaluationTest {
     }
 
     @Test
-    public void GIVEN_basicAndExpression_WHEN_RuleExpressionEvaluatedWithSessionContainingOneThing_THEN_EvaluatesFalse() throws ParseException {
+    void GIVEN_basicAndExpression_WHEN_RuleExpressionEvaluatedWithSessionContainingOneThing_THEN_EvaluatesFalse() throws ParseException {
         ASTStart tree = getTree("thingName: Thing AND thingName: Thing1");
         Session session = getSessionWithThing("Thing");
         RuleExpressionVisitor visitor = new ExpressionVisitor();
@@ -68,7 +68,7 @@ public class RuleExpressionEvaluationTest {
     }
 
     @Test
-    public void GIVEN_logicalExpressionWithAndOr_WHEN_RuleExpressionEvaluatedWithSessionContainingThingInOR_THEN_EvaluatesTrue() throws ParseException {
+    void GIVEN_logicalExpressionWithAndOr_WHEN_RuleExpressionEvaluatedWithSessionContainingThingInOR_THEN_EvaluatesTrue() throws ParseException {
         ASTStart tree = getTree("thingName: Thing OR thingName: Thing1 AND thingName: Thing2");
         Session session = getSessionWithThing("Thing");
         RuleExpressionVisitor visitor = new ExpressionVisitor();
@@ -76,7 +76,7 @@ public class RuleExpressionEvaluationTest {
     }
 
     @Test
-    public void GIVEN_logicalExpressionWithAndOr_WHEN_RuleExpressionEvaluatedWithSessionContainingThingInAND_THEN_EvaluatesFalse() throws ParseException {
+    void GIVEN_logicalExpressionWithAndOr_WHEN_RuleExpressionEvaluatedWithSessionContainingThingInAND_THEN_EvaluatesFalse() throws ParseException {
         ASTStart tree = getTree("thingName: Thing AND thingName: Thing1 OR thingName: Thing2");
         Session session = getSessionWithThing("Thing");
         RuleExpressionVisitor visitor = new ExpressionVisitor();
@@ -84,7 +84,7 @@ public class RuleExpressionEvaluationTest {
     }
 
     @Test
-    public void GIVEN_unaryExpressionWithWildcard_WHEN_RuleExpressionEvaluated_THEN_EvaluatesTrue() throws ParseException {
+    void GIVEN_unaryExpressionWithWildcard_WHEN_RuleExpressionEvaluated_THEN_EvaluatesTrue() throws ParseException {
         ASTStart tree = getTree("thingName: Thing*");
         Session session = getSessionWithThing("Thing1");
         RuleExpressionVisitor visitor = new ExpressionVisitor();
@@ -95,7 +95,18 @@ public class RuleExpressionEvaluationTest {
     }
 
     @Test
-    public void GIVEN_unaryExpressionWithWildcard_WHEN_RuleExpressionEvaluatedWithSessionNotContainingThing_THEN_EvaluatesFalse() throws ParseException {
+    void GIVEN_unaryExpressionWithWildcardThingName_WHEN_RuleExpressionEvaluated_THEN_EvaluatesTrue() throws ParseException {
+        ASTStart tree = getTree("thingName: *");
+        Session session = getSessionWithThing("Thing1");
+        RuleExpressionVisitor visitor = new ExpressionVisitor();
+        Assertions.assertTrue((Boolean) visitor.visit(tree, session));
+
+        session = getSessionWithThing("ThingTwo");
+        Assertions.assertTrue((Boolean) visitor.visit(tree, session));
+    }
+
+    @Test
+    void GIVEN_unaryExpressionWithWildcard_WHEN_RuleExpressionEvaluatedWithSessionNotContainingThing_THEN_EvaluatesFalse() throws ParseException {
         ASTStart tree = getTree("thingName: Thing*");
         Session session = getSessionWithThing("FirstThing");
         RuleExpressionVisitor visitor = new ExpressionVisitor();


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This change fixes the rule expression grammar to allow "thingName: *" without a prefix. Previously wildcard support was present, but required at least a single character before the wildcard. This change will enable the creation of "allow all" type of policies.

**Why is this change necessary:**
Without this change, customer must specify a thing name prefix to be matched. E.g. "thing*"

**How was this change tested:**
Unit tests.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
