### PR TITLE
fix: subscribe to configuration topic instead of child topics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M5</version>
                 <configuration>
+                    <reuseForks>false</reuseForks>
                     <skipTests>true</skipTests>
                     <trimStackTrace>false</trimStackTrace>
                     <argLine>${surefire.argLine} -Xms1m</argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M5</version>
                 <configuration>
-                    <reuseForks>false</reuseForks>
                     <skipTests>true</skipTests>
                     <trimStackTrace>false</trimStackTrace>
                     <argLine>${surefire.argLine} -Xms1m</argLine>

--- a/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
@@ -7,7 +7,6 @@ package com.aws.greengrass.device;
 
 import com.aws.greengrass.certificatemanager.CertificateManager;
 import com.aws.greengrass.certificatemanager.certificate.CertificateStore;
-import com.aws.greengrass.config.Node;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.config.WhatHappened;
@@ -108,9 +107,9 @@ public class ClientDevicesAuthService extends PluginService {
             if (whatHappened == WhatHappened.initialized) {
                 updateDeviceGroups(whatHappened, deviceGroupTopics);
                 updateCAType(whatHappened, caTypeTopic);
-            } else if (isParentTopic(node, deviceGroupTopics)) {
+            } else if (node.childOf(deviceGroupTopics.getName())) {
                 updateDeviceGroups(whatHappened, deviceGroupTopics);
-            } else if (isParentTopic(node, caTypeTopic)) {
+            } else if (node.childOf(caTypeTopic.getName())) {
                 if (caTypeTopic.toPOJO() == null) {
                     return;
                 }
@@ -214,10 +213,5 @@ public class ClientDevicesAuthService extends PluginService {
             throw new CloudServiceInteractionException(
                     String.format("Failed to put core %s CA certificates to cloud", thingName), e);
         }
-    }
-
-    // Check if the changed node belongs to the topics.
-    private boolean isParentTopic(Node changedNode, Node topics) {
-        return changedNode != null && changedNode.getFullName().startsWith(topics.getFullName());
     }
 }

--- a/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
@@ -110,7 +110,10 @@ public class ClientDevicesAuthService extends PluginService {
             } else if (node.childOf(deviceGroupTopics.getName())) {
                 updateDeviceGroups(whatHappened, deviceGroupTopics);
             } else if (node.childOf(caTypeTopic.getName())) {
-                if (caTypeTopic.toPOJO() == null) {
+                // Initialize event creates a childChanged event.
+                // Both events are trying to generate the cert.
+                // Skip the event until initialize event generates the cert.
+                if (Utils.isEmpty(Coerce.toStringList(caTypeTopic))) {
                     return;
                 }
                 updateCAType(whatHappened, caTypeTopic);

--- a/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
@@ -135,14 +135,14 @@ public class ClientDevicesAuthService extends PluginService {
         return certificateManager;
     }
 
-    @SuppressWarnings("PMD.UnusedFormalParameter")
     private void updateDeviceGroups(WhatHappened whatHappened, Topics deviceGroupsTopics) {
         try {
             groupManager.setGroupConfiguration(
                     OBJECT_MAPPER.convertValue(deviceGroupsTopics.toPOJO(), GroupConfiguration.class));
         } catch (IllegalArgumentException e) {
             logger.atError().kv("service", CLIENT_DEVICES_AUTH_SERVICE_NAME).kv("event", whatHappened)
-                    .kv("node", deviceGroupsTopics.getFullName()).kv("value", deviceGroupsTopics).setCause(e)
+                    .kv("node", deviceGroupsTopics.getFullName())
+                    .setCause(e)
                     .log("Unable to parse group configuration");
             serviceErrored(e);
         }

--- a/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
@@ -102,17 +102,16 @@ public class ClientDevicesAuthService extends PluginService {
             if (whatHappened == WhatHappened.timestampUpdated || whatHappened == WhatHappened.interiorAdded) {
                 return;
             }
-            logger.atDebug().kv("why", whatHappened).kv("node", node).log();
+            logger.atTrace().kv("why", whatHappened).kv("node", node).log();
             Topics deviceGroupTopics = this.config.lookupTopics(CONFIGURATION_CONFIG_KEY, DEVICE_GROUPS_TOPICS);
             Topic caTypeTopic = this.config.lookup(CONFIGURATION_CONFIG_KEY, CA_TYPE_TOPIC);
 
-            // Node is null during initialize event, but we need to initialize both the topics.
-            if (node == null) {
+            if (whatHappened == WhatHappened.initialized) {
                 handleConfigurationChange(whatHappened, deviceGroupTopics);
                 updateCAType(whatHappened, caTypeTopic);
-            } else if (node.getName().equals(DEVICE_GROUPS_TOPICS)) {
+            } else if (DEVICE_GROUPS_TOPICS.equals(node.getName())) {
                 handleConfigurationChange(whatHappened, deviceGroupTopics);
-            } else if (node.getName().equals(CA_TYPE_TOPIC)) {
+            } else if (CA_TYPE_TOPIC.equals(node.getName())) {
                 // Skip the first duplicate event of childChanged that is received after initialize.
                 // This event is same as the one received in initialize. Skip doing duplicate work.
                 // Parse any further childChanged events.

--- a/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
@@ -106,17 +106,14 @@ public class ClientDevicesAuthService extends PluginService {
 
             if (whatHappened == WhatHappened.initialized) {
                 updateDeviceGroups(whatHappened, deviceGroupTopics);
-                updateCAType(whatHappened, caTypeTopic);
-            } else if (node.childOf(deviceGroupTopics.getName())) {
+                updateCAType(caTypeTopic);
+            } else if (node.childOf(DEVICE_GROUPS_TOPICS)) {
                 updateDeviceGroups(whatHappened, deviceGroupTopics);
-            } else if (node.childOf(caTypeTopic.getName())) {
-                // Initialize event creates a childChanged event.
-                // Both events are trying to generate the cert.
-                // Skip the event until initialize event generates the cert.
+            } else if (node.childOf(CA_TYPE_TOPIC)) {
                 if (caTypeTopic.getOnce() == null) {
                     return;
                 }
-                updateCAType(whatHappened, caTypeTopic);
+                updateCAType(caTypeTopic);
             }
         });
 
@@ -143,7 +140,7 @@ public class ClientDevicesAuthService extends PluginService {
             groupManager.setGroupConfiguration(
                     OBJECT_MAPPER.convertValue(deviceGroupsTopics.toPOJO(), GroupConfiguration.class));
         } catch (IllegalArgumentException e) {
-            logger.atError().kv("service", CLIENT_DEVICES_AUTH_SERVICE_NAME).kv("event", whatHappened)
+            logger.atError().kv("event", whatHappened)
                     .kv("node", deviceGroupsTopics.getFullName())
                     .setCause(e)
                     .log("Unable to parse group configuration");
@@ -151,8 +148,7 @@ public class ClientDevicesAuthService extends PluginService {
         }
     }
 
-    @SuppressWarnings("PMD.UnusedFormalParameter")
-    private void updateCAType(WhatHappened what, Topic topic) {
+    private void updateCAType(Topic topic) {
         try {
             List<String> caTypeList = Coerce.toStringList(topic);
             logger.atDebug().kv("CA type", caTypeList).log("CA type list updated");

--- a/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
@@ -60,8 +60,6 @@ public class ClientDevicesAuthService extends PluginService {
 
     private final DeviceConfiguration deviceConfiguration;
 
-    private boolean hasChildChangedAfterInitialize = false;
-
     /**
      * Constructor.
      *
@@ -102,7 +100,7 @@ public class ClientDevicesAuthService extends PluginService {
             if (whatHappened == WhatHappened.timestampUpdated || whatHappened == WhatHappened.interiorAdded) {
                 return;
             }
-            logger.atTrace().kv("why", whatHappened).kv("node", node).log();
+            logger.atDebug().kv("why", whatHappened).kv("node", node).log();
             Topics deviceGroupTopics = this.config.lookupTopics(CONFIGURATION_CONFIG_KEY, DEVICE_GROUPS_TOPICS);
             Topic caTypeTopic = this.config.lookup(CONFIGURATION_CONFIG_KEY, CA_TYPE_TOPIC);
 
@@ -112,11 +110,7 @@ public class ClientDevicesAuthService extends PluginService {
             } else if (DEVICE_GROUPS_TOPICS.equals(node.getName())) {
                 handleConfigurationChange(whatHappened, deviceGroupTopics);
             } else if (CA_TYPE_TOPIC.equals(node.getName())) {
-                // Skip the first duplicate event of childChanged that is received after initialize.
-                // This event is same as the one received in initialize. Skip doing duplicate work.
-                // Parse any further childChanged events.
-                if (!hasChildChangedAfterInitialize && whatHappened == WhatHappened.childChanged) {
-                    hasChildChangedAfterInitialize = true;
+                if (caTypeTopic.toPOJO() == null) {
                     return;
                 }
                 updateCAType(whatHappened, caTypeTopic);

--- a/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
@@ -113,7 +113,7 @@ public class ClientDevicesAuthService extends PluginService {
                 // Initialize event creates a childChanged event.
                 // Both events are trying to generate the cert.
                 // Skip the event until initialize event generates the cert.
-                if (Utils.isEmpty(Coerce.toStringList(caTypeTopic))) {
+                if (caTypeTopic.getOnce() == null) {
                     return;
                 }
                 updateCAType(whatHappened, caTypeTopic);

--- a/src/test/java/com/aws/greengrass/device/ClientDevicesAuthServiceTest.java
+++ b/src/test/java/com/aws/greengrass/device/ClientDevicesAuthServiceTest.java
@@ -141,7 +141,7 @@ class ClientDevicesAuthServiceTest {
             throws Exception {
         startNucleusWithConfig("emptyGroupConfig.yaml");
 
-        verify(groupManager, times(2)).setGroupConfiguration(configurationCaptor.capture());
+        verify(groupManager).setGroupConfiguration(configurationCaptor.capture());
         GroupConfiguration groupConfiguration = configurationCaptor.getValue();
         assertThat(groupConfiguration.getDefinitions(), IsMapWithSize.anEmptyMap());
         assertThat(groupConfiguration.getPolicies(), IsMapWithSize.anEmptyMap());
@@ -163,7 +163,7 @@ class ClientDevicesAuthServiceTest {
             throws Exception {
         startNucleusWithConfig("config.yaml");
 
-        verify(groupManager, times(2)).setGroupConfiguration(configurationCaptor.capture());
+        verify(groupManager).setGroupConfiguration(configurationCaptor.capture());
         GroupConfiguration groupConfiguration = configurationCaptor.getValue();
         assertThat(groupConfiguration.getFormatVersion(), is(ConfigurationFormatVersion.MAR_05_2021));
         assertThat(groupConfiguration.getDefinitions(), IsMapWithSize.aMapWithSize(2));
@@ -327,12 +327,12 @@ class ClientDevicesAuthServiceTest {
         assertThat(initialCA, not(thirdCA));
         assertThat(getCaPassphrase(), not(initialCaPassPhrase));
 
-        verify(client, times(4)).putCertificateAuthorities(putCARequestArgumentCaptor.capture());
+        verify(client, times(3)).putCertificateAuthorities(putCARequestArgumentCaptor.capture());
         List<List<String>> certificatesInRequests =
                 putCARequestArgumentCaptor.getAllValues().stream().map(
                         PutCertificateAuthoritiesRequest::coreDeviceCertificates).collect(
                         Collectors.toList());
-        assertThat(certificatesInRequests, contains(initialCACerts, initialCACerts, secondCACerts, thirdCACerts));
+        assertThat(certificatesInRequests, contains(initialCACerts, secondCACerts, thirdCACerts));
     }
 
     @Test
@@ -343,7 +343,7 @@ class ClientDevicesAuthServiceTest {
         List<String> initialCACerts = getCaCertificates();
         X509Certificate initialCA = pemToX509Certificate(initialCACerts.get(0));
         assertThat(initialCA.getSigAlgName(), is(CertificateHelper.ECDSA_SIGNING_ALGORITHM));
-        verify(client, times(2)).putCertificateAuthorities(putCARequestArgumentCaptor.capture());
+        verify(client).putCertificateAuthorities(putCARequestArgumentCaptor.capture());
         PutCertificateAuthoritiesRequest request = putCARequestArgumentCaptor.getValue();
         assertThat(request.coreDeviceCertificates(), is(initialCACerts));
     }

--- a/src/test/java/com/aws/greengrass/device/ClientDevicesAuthServiceTest.java
+++ b/src/test/java/com/aws/greengrass/device/ClientDevicesAuthServiceTest.java
@@ -303,9 +303,13 @@ class ClientDevicesAuthServiceTest {
         assertThat(initialCA.getSigAlgName(), is(CertificateHelper.RSA_SIGNING_ALGORITHM));
         String initialCaPassPhrase = getCaPassphrase();
 
-        kernel.locate(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME).getConfig()
-                .find(KernelConfigResolver.CONFIGURATION_CONFIG_KEY,
-                        ClientDevicesAuthService.CA_TYPE_TOPIC).withValue(Collections.singletonList("RSA_2048"));
+        kernel.getContext().runOnPublishQueueAndWait(() -> {
+            kernel.locate(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME).getConfig()
+                    .lookup(KernelConfigResolver.CONFIGURATION_CONFIG_KEY, ClientDevicesAuthService.CA_TYPE_TOPIC);
+        });
+        Topic topic = kernel.locate(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME).getConfig()
+                .lookup(KernelConfigResolver.CONFIGURATION_CONFIG_KEY, ClientDevicesAuthService.CA_TYPE_TOPIC);
+        topic.withValue(Collections.singletonList("RSA_2048"));
         // Block until subscriber has finished updating
         kernel.getContext().waitForPublishQueueToClear();
 
@@ -315,9 +319,7 @@ class ClientDevicesAuthServiceTest {
         assertThat(initialCA, is(secondCA));
         assertThat(getCaPassphrase(), is(initialCaPassPhrase));
 
-        kernel.locate(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME).getConfig()
-                .find(KernelConfigResolver.CONFIGURATION_CONFIG_KEY,
-                        ClientDevicesAuthService.CA_TYPE_TOPIC).withValue(Collections.singletonList("ECDSA_P256"));
+        topic.withValue(Collections.singletonList("ECDSA_P256"));
         // Block until subscriber has finished updating
         kernel.getContext().waitForPublishQueueToClear();
 

--- a/src/test/java/com/aws/greengrass/device/ClientDevicesAuthServiceTest.java
+++ b/src/test/java/com/aws/greengrass/device/ClientDevicesAuthServiceTest.java
@@ -141,7 +141,7 @@ class ClientDevicesAuthServiceTest {
             throws Exception {
         startNucleusWithConfig("emptyGroupConfig.yaml");
 
-        verify(groupManager).setGroupConfiguration(configurationCaptor.capture());
+        verify(groupManager, times(2)).setGroupConfiguration(configurationCaptor.capture());
         GroupConfiguration groupConfiguration = configurationCaptor.getValue();
         assertThat(groupConfiguration.getDefinitions(), IsMapWithSize.anEmptyMap());
         assertThat(groupConfiguration.getPolicies(), IsMapWithSize.anEmptyMap());
@@ -163,7 +163,7 @@ class ClientDevicesAuthServiceTest {
             throws Exception {
         startNucleusWithConfig("config.yaml");
 
-        verify(groupManager).setGroupConfiguration(configurationCaptor.capture());
+        verify(groupManager, times(2)).setGroupConfiguration(configurationCaptor.capture());
         GroupConfiguration groupConfiguration = configurationCaptor.getValue();
         assertThat(groupConfiguration.getFormatVersion(), is(ConfigurationFormatVersion.MAR_05_2021));
         assertThat(groupConfiguration.getDefinitions(), IsMapWithSize.aMapWithSize(2));
@@ -327,12 +327,12 @@ class ClientDevicesAuthServiceTest {
         assertThat(initialCA, not(thirdCA));
         assertThat(getCaPassphrase(), not(initialCaPassPhrase));
 
-        verify(client, times(3)).putCertificateAuthorities(putCARequestArgumentCaptor.capture());
+        verify(client, times(4)).putCertificateAuthorities(putCARequestArgumentCaptor.capture());
         List<List<String>> certificatesInRequests =
                 putCARequestArgumentCaptor.getAllValues().stream().map(
                         PutCertificateAuthoritiesRequest::coreDeviceCertificates).collect(
                         Collectors.toList());
-        assertThat(certificatesInRequests, contains(initialCACerts, secondCACerts, thirdCACerts));
+        assertThat(certificatesInRequests, contains(initialCACerts, initialCACerts, secondCACerts, thirdCACerts));
     }
 
     @Test
@@ -343,7 +343,7 @@ class ClientDevicesAuthServiceTest {
         List<String> initialCACerts = getCaCertificates();
         X509Certificate initialCA = pemToX509Certificate(initialCACerts.get(0));
         assertThat(initialCA.getSigAlgName(), is(CertificateHelper.ECDSA_SIGNING_ALGORITHM));
-        verify(client).putCertificateAuthorities(putCARequestArgumentCaptor.capture());
+        verify(client, times(2)).putCertificateAuthorities(putCARequestArgumentCaptor.capture());
         PutCertificateAuthoritiesRequest request = putCARequestArgumentCaptor.getValue();
         assertThat(request.coreDeviceCertificates(), is(initialCACerts));
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Currently we subscribe to `ca_type` and `deviceGroups` separately.
When we reset the configuration using `[""]`, we lose the subscription in the process.
Subscribing to `configuration` allows us to preserve the subscription.

**Why is this change necessary:**
When we reset the configuration for `deviceGroups` using `[""]`, we lose the subscription in the process.
Any further updates to the config are not parsed by CDA

**How was this change tested:**
`mvn clean verify`

**Any additional information or context required to review the change:**
Currently there are 2 tests that are failing.
One of those tests (ClientDevicesAuthServiceTest.GIVEN_GG_with_cda_WHEN_updated_ca_type_THEN_ca_is_updated) passes when run independently but fails when running all tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
