### PR TITLE
fix(cert-sub): deduplicate server certificate callbacks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.10</version>
+            <version>1.18.22</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitor.java
+++ b/src/main/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitor.java
@@ -148,6 +148,15 @@ public class CISShadowMonitor {
         monitoredCertificateGenerators.add(certificateGenerator);
     }
 
+    /**
+     * Remove cert from CIS shadow monitor.
+     *
+     * @param certificateGenerator CertificateGenerator instance for the certificate
+     */
+    public void removeFromMonitor(CertificateGenerator certificateGenerator) {
+        monitoredCertificateGenerators.remove(certificateGenerator);
+    }
+
     private void subscribeToShadowTopics() throws InterruptedException {
         while (true) {
             if (Thread.currentThread().isInterrupted()) {

--- a/src/main/java/com/aws/greengrass/certificatemanager/certificate/CertificateExpiryMonitor.java
+++ b/src/main/java/com/aws/greengrass/certificatemanager/certificate/CertificateExpiryMonitor.java
@@ -14,6 +14,8 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -33,6 +35,7 @@ public class CertificateExpiryMonitor {
             PriorityBlockingQueue<>(QUEUE_INITIAL_CAPACITY, Comparator.comparing(CertificateGenerator::getExpiryTime));
 
     private ScheduledFuture<?> monitorFuture;
+    private final Set<CertificateGenerator> removedCgs = new CopyOnWriteArraySet<>();
 
     /**
      * Constructor.
@@ -78,7 +81,11 @@ public class CertificateExpiryMonitor {
             monitoredCertificateGenerators.poll();
         }
 
-        monitoredCertificateGenerators.addAll(triedCertificateGenerators);
+        synchronized (this) {
+            monitoredCertificateGenerators.addAll(triedCertificateGenerators);
+            monitoredCertificateGenerators.removeAll(removedCgs);
+            removedCgs.clear();
+        }
     }
 
     /**
@@ -96,5 +103,14 @@ public class CertificateExpiryMonitor {
         if (monitorFuture != null) {
             monitorFuture.cancel(true);
         }
+    }
+
+    /**
+     * Remove cert from cert expiry monitor.
+     * @param cg CertificateGenerator instance for the certificate
+     */
+    public synchronized void removeFromMonitor(CertificateGenerator cg) {
+        monitoredCertificateGenerators.remove(cg);
+        removedCgs.add(cg);
     }
 }

--- a/src/main/java/com/aws/greengrass/certificatemanager/certificate/CertificateExpiryMonitor.java
+++ b/src/main/java/com/aws/greengrass/certificatemanager/certificate/CertificateExpiryMonitor.java
@@ -110,6 +110,13 @@ public class CertificateExpiryMonitor {
      * @param cg CertificateGenerator instance for the certificate
      */
     public synchronized void removeFromMonitor(CertificateGenerator cg) {
+        // If this runs before the synchronized block in watchForCertExpiryOnce
+        // then monitoredCertificateGenerators will be correct because removedCgs will drop it again.
+
+        // If this runs after the synchronized block in watchForCertExpiryOnce then
+        // monitoredCertificateGenerators will be correct because we remove it from monitoredCertificateGenerators
+        // right here. removedCgs will get cleaned up the next time that watchForCertExpiryOnce runs. This does
+        // extend the lifetime of the CertificateGenerator by at most DEFAULT_CERT_EXPIRY_CHECK_SECONDS.
         monitoredCertificateGenerators.remove(cg);
         removedCgs.add(cg);
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Deduplicates server certificate subscriptions based on the pair of csr and callback. Also implements the unsubscribe method in order to remove the subscription.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
