### PR TITLE
feat: introduce serverCertificateValiditySeconds config

### DIFF
--- a/src/main/java/com/aws/greengrass/certificatemanager/certificate/CertificateGenerator.java
+++ b/src/main/java/com/aws/greengrass/certificatemanager/certificate/CertificateGenerator.java
@@ -20,8 +20,6 @@ import java.util.List;
 import java.util.function.Supplier;
 
 public abstract class CertificateGenerator {
-    static final long DEFAULT_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 7; // 1 week
-
     protected final X500Name subject;
     protected final PublicKey publicKey;
     protected final CertificateStore certificateStore;

--- a/src/main/java/com/aws/greengrass/certificatemanager/certificate/CertificatesConfig.java
+++ b/src/main/java/com/aws/greengrass/certificatemanager/certificate/CertificatesConfig.java
@@ -11,6 +11,7 @@ import com.aws.greengrass.util.Coerce;
 
 public class CertificatesConfig {
     static final int MAX_SERVER_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 10; // 10 days
+    static final int MIN_SERVER_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 2; // 2 days
     static final int DEFAULT_SERVER_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 7; // 7 days
     static final int DEFAULT_CLIENT_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 7; // 7 days
 
@@ -34,10 +35,12 @@ public class CertificatesConfig {
     public int getServerCertValiditySeconds() {
         int configuredValidityPeriod = Coerce.toInt(configuration.findOrDefault(DEFAULT_SERVER_CERT_EXPIRY_SECONDS,
                 PATH_SERVER_CERT_EXPIRY_SECONDS));
-        if (configuredValidityPeriod < MAX_SERVER_CERT_EXPIRY_SECONDS) {
-            return configuredValidityPeriod;
+        if (configuredValidityPeriod > MAX_SERVER_CERT_EXPIRY_SECONDS) {
+            return MAX_SERVER_CERT_EXPIRY_SECONDS;
+        } else if (configuredValidityPeriod < MIN_SERVER_CERT_EXPIRY_SECONDS) {
+            return MIN_SERVER_CERT_EXPIRY_SECONDS;
         }
-        return MAX_SERVER_CERT_EXPIRY_SECONDS;
+        return configuredValidityPeriod;
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/certificatemanager/certificate/CertificatesConfig.java
+++ b/src/main/java/com/aws/greengrass/certificatemanager/certificate/CertificatesConfig.java
@@ -10,8 +10,9 @@ import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.util.Coerce;
 
 public class CertificatesConfig {
-    static final int DEFAULT_SERVER_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 7; // 1 week
-    static final int DEFAULT_CLIENT_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 7; // 1 week
+    static final int MAX_SERVER_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 10; // 10 days
+    static final int DEFAULT_SERVER_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 7; // 7 days
+    static final int DEFAULT_CLIENT_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 7; // 7 days
 
     private static final String CERTIFICATES_CONFIGURATION = "certificates";
     private static final String SERVER_CERT_VALIDITY_SECONDS = "server_cert_validity_seconds";
@@ -31,8 +32,12 @@ public class CertificatesConfig {
      * @return Server certificate validity in seconds
      */
     public int getServerCertValiditySeconds() {
-        return Coerce.toInt(configuration.findOrDefault(DEFAULT_SERVER_CERT_EXPIRY_SECONDS,
+        int configuredValidityPeriod = Coerce.toInt(configuration.findOrDefault(DEFAULT_SERVER_CERT_EXPIRY_SECONDS,
                 PATH_SERVER_CERT_EXPIRY_SECONDS));
+        if (configuredValidityPeriod < MAX_SERVER_CERT_EXPIRY_SECONDS) {
+            return configuredValidityPeriod;
+        }
+        return MAX_SERVER_CERT_EXPIRY_SECONDS;
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/certificatemanager/certificate/CertificatesConfig.java
+++ b/src/main/java/com/aws/greengrass/certificatemanager/certificate/CertificatesConfig.java
@@ -15,7 +15,7 @@ public class CertificatesConfig {
     static final int DEFAULT_CLIENT_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 7; // 7 days
 
     private static final String CERTIFICATES_CONFIGURATION = "certificates";
-    private static final String SERVER_CERT_VALIDITY_SECONDS = "server_cert_validity_seconds";
+    private static final String SERVER_CERT_VALIDITY_SECONDS = "serverCertificateValiditySeconds";
 
     static final String[] PATH_SERVER_CERT_EXPIRY_SECONDS =
             {KernelConfigResolver.CONFIGURATION_CONFIG_KEY, CERTIFICATES_CONFIGURATION, SERVER_CERT_VALIDITY_SECONDS};

--- a/src/main/java/com/aws/greengrass/certificatemanager/certificate/CertificatesConfig.java
+++ b/src/main/java/com/aws/greengrass/certificatemanager/certificate/CertificatesConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.certificatemanager.certificate;
+
+import com.aws.greengrass.componentmanager.KernelConfigResolver;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.util.Coerce;
+
+public class CertificatesConfig {
+    static final int DEFAULT_SERVER_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 7; // 1 week
+    static final int DEFAULT_CLIENT_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 7; // 1 week
+
+    private static final String CERTIFICATES_CONFIGURATION = "certificates";
+    private static final String SERVER_CERT_VALIDITY_SECONDS = "server_cert_validity_seconds";
+
+    static final String[] PATH_SERVER_CERT_EXPIRY_SECONDS =
+            {KernelConfigResolver.CONFIGURATION_CONFIG_KEY, CERTIFICATES_CONFIGURATION, SERVER_CERT_VALIDITY_SECONDS};
+
+    private final Topics configuration;
+
+    public CertificatesConfig(Topics configuration) {
+        this.configuration = configuration;
+    }
+
+    /**
+     * Get server certificate validity period.
+     *
+     * @return Server certificate validity in seconds
+     */
+    public int getServerCertValiditySeconds() {
+        return Coerce.toInt(configuration.findOrDefault(DEFAULT_SERVER_CERT_EXPIRY_SECONDS,
+                PATH_SERVER_CERT_EXPIRY_SECONDS));
+    }
+
+    /**
+     * Get server certificate validity period.
+     *
+     * @return Client certificate validity in seconds
+     */
+    public int getClientCertValiditySeconds() {
+        return DEFAULT_CLIENT_CERT_EXPIRY_SECONDS;
+    }
+}

--- a/src/main/java/com/aws/greengrass/certificatemanager/certificate/ClientCertificateGenerator.java
+++ b/src/main/java/com/aws/greengrass/certificatemanager/certificate/ClientCertificateGenerator.java
@@ -23,19 +23,22 @@ import java.util.function.Supplier;
 public class ClientCertificateGenerator extends CertificateGenerator {
 
     private final Consumer<X509Certificate[]> callback;
+    private final CertificatesConfig certificatesConfig;
 
     /**
      * Constructor.
      *
-     * @param subject          X500 subject
-     * @param publicKey        Public Key
-     * @param callback         Callback that consumes generated certificate
-     * @param certificateStore CertificateStore instance
+     * @param subject            X500 subject
+     * @param publicKey          Public Key
+     * @param callback           Callback that consumes generated certificate
+     * @param certificateStore   CertificateStore instance
+     * @param certificatesConfig Certificate configuration
      */
     public ClientCertificateGenerator(X500Name subject, PublicKey publicKey, Consumer<X509Certificate[]> callback,
-                                      CertificateStore certificateStore) {
+                                      CertificateStore certificateStore, CertificatesConfig certificatesConfig) {
         super(subject, publicKey, certificateStore);
         this.callback = callback;
+        this.certificatesConfig = certificatesConfig;
     }
 
     /**
@@ -55,7 +58,7 @@ public class ClientCertificateGenerator extends CertificateGenerator {
                     subject,
                     publicKey,
                     Date.from(now),
-                    Date.from(now.plusSeconds(DEFAULT_CERT_EXPIRY_SECONDS)));
+                    Date.from(now.plusSeconds(certificatesConfig.getClientCertValiditySeconds())));
         } catch (NoSuchAlgorithmException | OperatorCreationException | CertificateException | IOException e) {
             throw new CertificateGenerationException(e);
         }

--- a/src/main/java/com/aws/greengrass/certificatemanager/certificate/ServerCertificateGenerator.java
+++ b/src/main/java/com/aws/greengrass/certificatemanager/certificate/ServerCertificateGenerator.java
@@ -26,19 +26,22 @@ import java.util.function.Supplier;
 public class ServerCertificateGenerator extends CertificateGenerator {
     private static final Logger logger = LogManager.getLogger(ServerCertificateGenerator.class);
     private final Consumer<X509Certificate> callback;
+    private final CertificatesConfig certificatesConfig;
 
     /**
      * Constructor.
      *
-     * @param subject          X500 subject
-     * @param publicKey        Public Key
-     * @param callback         Callback that consumes generated certificate
-     * @param certificateStore CertificateStore instance
+     * @param subject            X500 subject
+     * @param publicKey          Public Key
+     * @param callback           Callback that consumes generated certificate
+     * @param certificateStore   CertificateStore instance
+     * @param certificatesConfig Certificate configuration
      */
     public ServerCertificateGenerator(X500Name subject, PublicKey publicKey, Consumer<X509Certificate> callback,
-                                      CertificateStore certificateStore) {
+                                      CertificateStore certificateStore, CertificatesConfig certificatesConfig) {
         super(subject, publicKey, certificateStore);
         this.callback = callback;
+        this.certificatesConfig = certificatesConfig;
     }
 
     /**
@@ -69,7 +72,7 @@ public class ServerCertificateGenerator extends CertificateGenerator {
                     publicKey,
                     connectivityInfo,
                     Date.from(now),
-                    Date.from(now.plusSeconds(DEFAULT_CERT_EXPIRY_SECONDS)));
+                    Date.from(now.plusSeconds(certificatesConfig.getServerCertValiditySeconds())));
         } catch (NoSuchAlgorithmException | OperatorCreationException | CertificateException | IOException e) {
             logger.atError().cause(e).log("Failed to generate new server certificate");
             throw new CertificateGenerationException(e);

--- a/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.device;
 
 import com.aws.greengrass.certificatemanager.CertificateManager;
 import com.aws.greengrass.certificatemanager.certificate.CertificateStore;
+import com.aws.greengrass.certificatemanager.certificate.CertificatesConfig;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.config.WhatHappened;
@@ -78,6 +79,7 @@ public class ClientDevicesAuthService extends PluginService {
         this.certificateManager = certificateManager;
         this.clientFactory = clientFactory;
         this.deviceConfiguration = deviceConfiguration;
+        certificateManager.updateCertificatesConfiguration(new CertificatesConfig(this.getConfig()));
     }
 
     /**
@@ -87,15 +89,15 @@ public class ClientDevicesAuthService extends PluginService {
      *  |         |---- definitions : {}
      *  |         |---- policies : {}
      *  |    |---- ca_type: [...]
+     *  |    |---- certificates: {}
      *  |---- runtime
      *  |    |---- ca_passphrase: "..."
-     *  |    |---- certificates
+     *  |    |---- certificates:
      *  |         |---- authorities: [...]
      */
     @Override
     protected void install() throws InterruptedException {
         super.install();
-        //handleConfiguration
         this.config.lookupTopics(CONFIGURATION_CONFIG_KEY).subscribe((whatHappened, node) -> {
             if (whatHappened == WhatHappened.timestampUpdated || whatHappened == WhatHappened.interiorAdded) {
                 return;

--- a/src/test/java/com/aws/greengrass/certificatemanager/CertificateManagerTest.java
+++ b/src/test/java/com/aws/greengrass/certificatemanager/CertificateManagerTest.java
@@ -8,8 +8,12 @@ package com.aws.greengrass.certificatemanager;
 import com.aws.greengrass.certificatemanager.certificate.CISShadowMonitor;
 import com.aws.greengrass.certificatemanager.certificate.CertificateExpiryMonitor;
 import com.aws.greengrass.certificatemanager.certificate.CertificateStore;
+import com.aws.greengrass.certificatemanager.certificate.CertificatesConfig;
 import com.aws.greengrass.certificatemanager.certificate.CsrProcessingException;
 import com.aws.greengrass.cisclient.ConnectivityInfoProvider;
+import com.aws.greengrass.componentmanager.KernelConfigResolver;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.TestUtils;
 import com.aws.greengrass.util.Pair;
@@ -110,6 +114,9 @@ public class CertificateManagerTest {
         certificateManager = new CertificateManager(new CertificateStore(tmpPath), mockConnectivityInfoProvider, mockCertExpiryMonitor,
                 mockShadowMonitor);
         certificateManager.update("", CertificateStore.CAType.RSA_2048);
+        CertificatesConfig certificatesConfig = new CertificatesConfig(Topics.of(new Context(),
+                KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null));
+        certificateManager.updateCertificatesConfiguration(certificatesConfig);
     }
 
     public static PrivateKey getRsaPrivateKeyFromPem(String privateKeyString)

--- a/src/test/java/com/aws/greengrass/certificatemanager/certificate/CertificateExpiryMonitorTest.java
+++ b/src/test/java/com/aws/greengrass/certificatemanager/certificate/CertificateExpiryMonitorTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.security.PublicKey;
 import java.security.cert.X509Certificate;
@@ -50,6 +51,7 @@ public class CertificateExpiryMonitorTest {
     private ConnectivityInfoProvider mockConnectivityInfoProvider;
 
     private final ScheduledExecutorService ses = new ScheduledThreadPoolExecutor(1);
+    private Topics configurationTopics;
     private CertificatesConfig certificatesConfig;
 
     @TempDir
@@ -57,13 +59,14 @@ public class CertificateExpiryMonitorTest {
 
     @BeforeEach
     void setup() {
-        certificatesConfig = new CertificatesConfig(Topics.of(new Context(),
-                KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null));
+        configurationTopics = Topics.of(new Context(), KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null);
+        certificatesConfig = new CertificatesConfig(configurationTopics);
     }
 
     @AfterEach
-    void afterEach() {
+    void afterEach() throws IOException {
         ses.shutdownNow();
+        configurationTopics.getContext().close();
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/certificatemanager/certificate/CertificateExpiryMonitorTest.java
+++ b/src/test/java/com/aws/greengrass/certificatemanager/certificate/CertificateExpiryMonitorTest.java
@@ -6,9 +6,13 @@
 package com.aws.greengrass.certificatemanager.certificate;
 
 import com.aws.greengrass.cisclient.ConnectivityInfoProvider;
+import com.aws.greengrass.componentmanager.KernelConfigResolver;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -28,7 +32,6 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
-import static com.aws.greengrass.certificatemanager.certificate.CertificateGenerator.DEFAULT_CERT_EXPIRY_SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -45,10 +48,18 @@ public class CertificateExpiryMonitorTest {
 
     @Mock
     private ConnectivityInfoProvider mockConnectivityInfoProvider;
+
     private final ScheduledExecutorService ses = new ScheduledThreadPoolExecutor(1);
+    private CertificatesConfig certificatesConfig;
 
     @TempDir
     Path tmpPath;
+
+    @BeforeEach
+    void setup() {
+        certificatesConfig = new CertificatesConfig(Topics.of(new Context(),
+                KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null));
+    }
 
     @AfterEach
     void afterEach() {
@@ -68,17 +79,17 @@ public class CertificateExpiryMonitorTest {
         certExpiryMonitor.startMonitor(Duration.ofMillis(100));
 
         //add certs to monitor
-        CertificateGenerator cg1 = new ServerCertificateGenerator(subject, key1, mockCallback, certificateStore);
+        CertificateGenerator cg1 = new ServerCertificateGenerator(subject, key1, mockCallback, certificateStore, certificatesConfig);
         cg1.generateCertificate(Collections::emptyList);
         certExpiryMonitor.addToMonitor(cg1);
         X509Certificate cert1initial = cg1.getCertificate();
-        CertificateGenerator cg2 = new ServerCertificateGenerator(subject, key2, mockCallback, certificateStore);
+        CertificateGenerator cg2 = new ServerCertificateGenerator(subject, key2, mockCallback, certificateStore, certificatesConfig);
         cg2.generateCertificate(Collections::emptyList);
         certExpiryMonitor.addToMonitor(cg2);
         X509Certificate cert2initial = cg2.getCertificate();
 
         //cert1 expires -> it is regenerated
-        Clock mockClock = Clock.fixed(Instant.now().plus(Duration.ofSeconds(DEFAULT_CERT_EXPIRY_SECONDS)),
+        Clock mockClock = Clock.fixed(Instant.now().plus(Duration.ofSeconds(CertificatesConfig.DEFAULT_SERVER_CERT_EXPIRY_SECONDS)),
                 ZoneId.of("UTC"));
         cg1.setClock(mockClock);
         TimeUnit.MILLISECONDS.sleep(TEST_CERT_EXPIRY_CHECK_MILLIS);
@@ -88,7 +99,7 @@ public class CertificateExpiryMonitorTest {
         assertThat(cert2second, is(cert2initial));
 
         //cert2 expires -> it is regenerated
-        mockClock = Clock.fixed(Instant.now().plus(Duration.ofSeconds(DEFAULT_CERT_EXPIRY_SECONDS)), ZoneId.of("UTC"));
+        mockClock = Clock.fixed(Instant.now().plus(Duration.ofSeconds(CertificatesConfig.DEFAULT_SERVER_CERT_EXPIRY_SECONDS)), ZoneId.of("UTC"));
         cg2.setClock(mockClock);
         TimeUnit.MILLISECONDS.sleep(TEST_CERT_EXPIRY_CHECK_MILLIS);
         X509Certificate cert1third = cg1.getCertificate();
@@ -98,7 +109,7 @@ public class CertificateExpiryMonitorTest {
 
         //stop monitor, certs expire -> certs not regenerated
         certExpiryMonitor.stopMonitor();
-        mockClock = Clock.fixed(Instant.now().plus(Duration.ofSeconds(2*DEFAULT_CERT_EXPIRY_SECONDS)), ZoneId.of("UTC"));
+        mockClock = Clock.fixed(Instant.now().plus(Duration.ofSeconds(2*CertificatesConfig.DEFAULT_SERVER_CERT_EXPIRY_SECONDS)), ZoneId.of("UTC"));
         cg1.setClock(mockClock);
         cg2.setClock(mockClock);
         TimeUnit.MILLISECONDS.sleep(TEST_CERT_EXPIRY_CHECK_MILLIS);

--- a/src/test/java/com/aws/greengrass/certificatemanager/certificate/CertificatesConfigTest.java
+++ b/src/test/java/com/aws/greengrass/certificatemanager/certificate/CertificatesConfigTest.java
@@ -9,10 +9,13 @@ import com.aws.greengrass.componentmanager.KernelConfigResolver;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -24,9 +27,14 @@ public class CertificatesConfigTest {
     private CertificatesConfig certificatesConfig;
 
     @BeforeEach
-    public void beforeEach() {
+    void beforeEach() {
         configurationTopics = Topics.of(new Context(), KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null);
         certificatesConfig = new CertificatesConfig(configurationTopics);
+    }
+
+    @AfterEach
+    void afterEach() throws IOException {
+        configurationTopics.getContext().close();
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/certificatemanager/certificate/CertificatesConfigTest.java
+++ b/src/test/java/com/aws/greengrass/certificatemanager/certificate/CertificatesConfigTest.java
@@ -44,11 +44,18 @@ public class CertificatesConfigTest {
     }
 
     @Test
-    public void GIVEN_100DayServerValidity_WHEN_getServerCertValiditySeconds_THEN_returnsMaxExpiry() {
+    public void GIVEN_largeServerCertValidity_WHEN_getServerCertValiditySeconds_THEN_returnsMaxExpiry() {
         configurationTopics.lookup(CertificatesConfig.PATH_SERVER_CERT_EXPIRY_SECONDS)
                 .withValue(2 * CertificatesConfig.MAX_SERVER_CERT_EXPIRY_SECONDS);
         assertThat(certificatesConfig.getServerCertValiditySeconds(),
                 is(equalTo(CertificatesConfig.MAX_SERVER_CERT_EXPIRY_SECONDS)));
+    }
+
+    @Test
+    public void GIVEN_smallServerCertValidity_WHEN_getServerCertValiditySeconds_THEN_returnsMinExpiry() {
+        configurationTopics.lookup(CertificatesConfig.PATH_SERVER_CERT_EXPIRY_SECONDS).withValue(60 * 60 * 24); // 1 day
+        assertThat(certificatesConfig.getServerCertValiditySeconds(),
+                is(equalTo(CertificatesConfig.MIN_SERVER_CERT_EXPIRY_SECONDS)));
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/certificatemanager/certificate/CertificatesConfigTest.java
+++ b/src/test/java/com/aws/greengrass/certificatemanager/certificate/CertificatesConfigTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.certificatemanager.certificate;
+
+import com.aws.greengrass.componentmanager.KernelConfigResolver;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.dependency.Context;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+public class CertificatesConfigTest {
+    private Topics configurationTopics;
+    private CertificatesConfig certificatesConfig;
+
+    @BeforeEach
+    public void beforeEach() {
+        configurationTopics = Topics.of(new Context(), KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null);
+        certificatesConfig = new CertificatesConfig(configurationTopics);
+    }
+
+    @Test
+    public void GIVEN_defaultConfiguration_WHEN_getServerCertValiditySeconds_THEN_returnsDefaultExpiry() {
+        assertThat(certificatesConfig.getServerCertValiditySeconds(),
+                is(equalTo(CertificatesConfig.DEFAULT_SERVER_CERT_EXPIRY_SECONDS)));
+    }
+
+    @Test
+    public void GIVEN_100DayServerValidity_WHEN_getServerCertValiditySeconds_THEN_returnsMaxExpiry() {
+        configurationTopics.lookup(CertificatesConfig.PATH_SERVER_CERT_EXPIRY_SECONDS)
+                .withValue(2 * CertificatesConfig.MAX_SERVER_CERT_EXPIRY_SECONDS);
+        assertThat(certificatesConfig.getServerCertValiditySeconds(),
+                is(equalTo(CertificatesConfig.MAX_SERVER_CERT_EXPIRY_SECONDS)));
+    }
+
+    @Test
+    public void GIVEN_defaultConfiguration_WHEN_getClientCertValiditySeconds_THEN_returnsDefaultExpiry() {
+        assertThat(certificatesConfig.getClientCertValiditySeconds(),
+                is(equalTo(CertificatesConfig.DEFAULT_CLIENT_CERT_EXPIRY_SECONDS)));
+    }
+
+}

--- a/src/test/java/com/aws/greengrass/certificatemanager/certificate/ClientCertificateGeneratorTest.java
+++ b/src/test/java/com/aws/greengrass/certificatemanager/certificate/ClientCertificateGeneratorTest.java
@@ -11,6 +11,7 @@ import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.KeyPurposeId;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -42,6 +44,7 @@ public class ClientCertificateGeneratorTest {
     private Consumer<X509Certificate[]> mockCallback;
 
     private PublicKey publicKey;
+    private Topics configurationTopics;
     private CertificateGenerator certificateGenerator;
     private CertificateStore certificateStore;
 
@@ -49,15 +52,20 @@ public class ClientCertificateGeneratorTest {
     Path tmpPath;
 
     @BeforeEach
-    public void setup() throws KeyStoreException, NoSuchAlgorithmException {
+    void setup() throws KeyStoreException, NoSuchAlgorithmException {
         X500Name subject = new X500Name(SUBJECT_PRINCIPAL);
         publicKey = CertificateStore.newRSAKeyPair().getPublic();
         certificateStore = new CertificateStore(tmpPath);
         certificateStore.update(TEST_PASSPHRASE, CertificateStore.CAType.RSA_2048);
-        CertificatesConfig certificatesConfig = new CertificatesConfig(Topics.of(new Context(),
-                KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null));
+        configurationTopics = Topics.of(new Context(), KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null);
+        CertificatesConfig certificatesConfig = new CertificatesConfig(configurationTopics);
         certificateGenerator = new ClientCertificateGenerator(subject, publicKey, mockCallback, certificateStore,
                 certificatesConfig);
+    }
+
+    @AfterEach
+    void afterEach() throws IOException {
+        configurationTopics.getContext().close();
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/certificatemanager/certificate/ClientCertificateGeneratorTest.java
+++ b/src/test/java/com/aws/greengrass/certificatemanager/certificate/ClientCertificateGeneratorTest.java
@@ -5,6 +5,9 @@
 
 package com.aws.greengrass.certificatemanager.certificate;
 
+import com.aws.greengrass.componentmanager.KernelConfigResolver;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.KeyPurposeId;
@@ -51,7 +54,10 @@ public class ClientCertificateGeneratorTest {
         publicKey = CertificateStore.newRSAKeyPair().getPublic();
         certificateStore = new CertificateStore(tmpPath);
         certificateStore.update(TEST_PASSPHRASE, CertificateStore.CAType.RSA_2048);
-        certificateGenerator = new ClientCertificateGenerator(subject, publicKey, mockCallback, certificateStore);
+        CertificatesConfig certificatesConfig = new CertificatesConfig(Topics.of(new Context(),
+                KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null));
+        certificateGenerator = new ClientCertificateGenerator(subject, publicKey, mockCallback, certificateStore,
+                certificatesConfig);
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/certificatemanager/certificate/ServerCertificateGeneratorTest.java
+++ b/src/test/java/com/aws/greengrass/certificatemanager/certificate/ServerCertificateGeneratorTest.java
@@ -11,6 +11,7 @@ import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.KeyPurposeId;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -51,6 +53,7 @@ public class ServerCertificateGeneratorTest {
     private Consumer<X509Certificate> mockCallback;
 
     private PublicKey publicKey;
+    private Topics configurationTopics;
     private CertificateGenerator certificateGenerator;
 
     @TempDir
@@ -62,10 +65,15 @@ public class ServerCertificateGeneratorTest {
         publicKey = CertificateStore.newRSAKeyPair().getPublic();
         CertificateStore certificateStore = new CertificateStore(tmpPath);
         certificateStore.update(TEST_PASSPHRASE, CertificateStore.CAType.RSA_2048);
-        CertificatesConfig certificatesConfig = new CertificatesConfig(Topics.of(new Context(),
-                KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null));
+        configurationTopics = Topics.of(new Context(), KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null);
+        CertificatesConfig certificatesConfig = new CertificatesConfig(configurationTopics);
         certificateGenerator = new ServerCertificateGenerator(subject, publicKey, mockCallback, certificateStore,
                 certificatesConfig);
+    }
+
+    @AfterEach
+    void afterEach() throws IOException {
+        configurationTopics.getContext().close();
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/device/DeviceAuthClientTest.java
+++ b/src/test/java/com/aws/greengrass/device/DeviceAuthClientTest.java
@@ -11,7 +11,11 @@ import com.aws.greengrass.certificatemanager.certificate.CISShadowMonitor;
 import com.aws.greengrass.certificatemanager.certificate.CertificateHelper;
 import com.aws.greengrass.certificatemanager.certificate.CertificateRequestGenerator;
 import com.aws.greengrass.certificatemanager.certificate.CertificateStore;
+import com.aws.greengrass.certificatemanager.certificate.CertificatesConfig;
 import com.aws.greengrass.cisclient.ConnectivityInfoProvider;
+import com.aws.greengrass.componentmanager.KernelConfigResolver;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.device.configuration.GroupManager;
 import com.aws.greengrass.device.configuration.Permission;
 import com.aws.greengrass.device.exception.AuthenticationException;
@@ -209,6 +213,8 @@ public class DeviceAuthClientTest {
         certificateStore.update("password", CertificateStore.CAType.RSA_2048);
         CertificateManager certificateManager = new CertificateManager(certificateStore, mockConnectivityInfoProvider,
                 mockCertExpiryMonitor, mockShadowMonitor);
+        certificateManager.updateCertificatesConfiguration(new CertificatesConfig(Topics.of(new Context(),
+                KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null)));
         KeyPair clientKeyPair = CertificateStore.newRSAKeyPair();
         String csr = CertificateRequestGenerator.createCSR(clientKeyPair, "Thing", null, null);
 

--- a/src/test/java/com/aws/greengrass/device/DeviceAuthClientTest.java
+++ b/src/test/java/com/aws/greengrass/device/DeviceAuthClientTest.java
@@ -26,6 +26,8 @@ import com.aws.greengrass.device.iot.IotAuthClient;
 import com.aws.greengrass.device.iot.Thing;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.Digest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -84,6 +86,18 @@ public class DeviceAuthClientTest {
 
     @TempDir
     Path tempDir;
+
+    private Topics configurationTopics;
+
+    @BeforeEach
+    void beforeEach() {
+        configurationTopics = Topics.of(new Context(), KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null);
+    }
+
+    @AfterEach
+    void afterEach() throws IOException {
+        configurationTopics.getContext().close();
+    }
 
     @Test
     void GIVEN_emptySessionManager_WHEN_createSession_THEN_sessionReturned() throws Exception {
@@ -213,8 +227,7 @@ public class DeviceAuthClientTest {
         certificateStore.update("password", CertificateStore.CAType.RSA_2048);
         CertificateManager certificateManager = new CertificateManager(certificateStore, mockConnectivityInfoProvider,
                 mockCertExpiryMonitor, mockShadowMonitor);
-        certificateManager.updateCertificatesConfiguration(new CertificatesConfig(Topics.of(new Context(),
-                KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null)));
+        certificateManager.updateCertificatesConfiguration(new CertificatesConfig(configurationTopics));
         KeyPair clientKeyPair = CertificateStore.newRSAKeyPair();
         String csr = CertificateRequestGenerator.createCSR(clientKeyPair, "Thing", null, null);
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This change adds a CertificatesConfiguration class for managing configuration related to certificate generation. Refactoring was required in order to plumb this all the way through.

This change also introduces a `serverCertificateValiditySeconds` configuration for controlling how long server certificates are valid for. Currently this value is only configurable up to 10 days. We can increase this further after consulting with AppSec.

**Why is this change necessary:**
We have industrial customers who cannot tolerate MQTT broker restarts outside of scheduled maintenance windows. This change is needed in order so that customers can manually restart the MQTT broker once a week to retrieve a new certificate and avoid automatic rotation.

**How was this change tested:**
Unit tests

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
