### PR TITLE
test: fix CertificateExpiryMonitorTests to not use ses

### DIFF
--- a/src/main/java/com/aws/greengrass/certificatemanager/certificate/CertificateExpiryMonitor.java
+++ b/src/main/java/com/aws/greengrass/certificatemanager/certificate/CertificateExpiryMonitor.java
@@ -56,7 +56,7 @@ public class CertificateExpiryMonitor {
                 certExpiryCheck.toMillis(), TimeUnit.MILLISECONDS);
     }
 
-    private void watchForCertExpiryOnce() {
+    void watchForCertExpiryOnce() {
         for (CertificateGenerator cg : monitoredCertificateGenerators) {
             if (!cg.shouldRegenerate()) {
                 continue;


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Remove timeouts and use of ScheduledExecutorService. Replace it with mock 

**Why is this change necessary:**
Fix indeterministic behavior of the tests

**How was this change tested:**
`mvn clean verify`

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
