### PR TITLE
feat: introduce clientCertificateValiditySeconds config

### DIFF
--- a/src/main/java/com/aws/greengrass/certificatemanager/certificate/CertificatesConfig.java
+++ b/src/main/java/com/aws/greengrass/certificatemanager/certificate/CertificatesConfig.java
@@ -7,19 +7,28 @@ package com.aws.greengrass.certificatemanager.certificate;
 
 import com.aws.greengrass.componentmanager.KernelConfigResolver;
 import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.util.Coerce;
 
 public class CertificatesConfig {
+    private static final Logger LOGGER = LogManager.getLogger(CertificatesConfig.class);
+
     static final int MAX_SERVER_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 10; // 10 days
     static final int MIN_SERVER_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 2; // 2 days
+    static final int MAX_CLIENT_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 10; // 10 days
+    static final int MIN_CLIENT_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 2; // 2 days
     static final int DEFAULT_SERVER_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 7; // 7 days
     static final int DEFAULT_CLIENT_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 7; // 7 days
 
     private static final String CERTIFICATES_CONFIGURATION = "certificates";
     private static final String SERVER_CERT_VALIDITY_SECONDS = "serverCertificateValiditySeconds";
+    private static final String CLIENT_CERT_VALIDITY_SECONDS = "clientCertificateValiditySeconds";
 
     static final String[] PATH_SERVER_CERT_EXPIRY_SECONDS =
             {KernelConfigResolver.CONFIGURATION_CONFIG_KEY, CERTIFICATES_CONFIGURATION, SERVER_CERT_VALIDITY_SECONDS};
+    static final String[] PATH_CLIENT_CERT_EXPIRY_SECONDS =
+            {KernelConfigResolver.CONFIGURATION_CONFIG_KEY, CERTIFICATES_CONFIGURATION, CLIENT_CERT_VALIDITY_SECONDS};
 
     private final Topics configuration;
 
@@ -36,19 +45,40 @@ public class CertificatesConfig {
         int configuredValidityPeriod = Coerce.toInt(configuration.findOrDefault(DEFAULT_SERVER_CERT_EXPIRY_SECONDS,
                 PATH_SERVER_CERT_EXPIRY_SECONDS));
         if (configuredValidityPeriod > MAX_SERVER_CERT_EXPIRY_SECONDS) {
+            LOGGER.atWarn()
+                    .kv(SERVER_CERT_VALIDITY_SECONDS, configuredValidityPeriod)
+                    .kv("maxAllowable", MAX_SERVER_CERT_EXPIRY_SECONDS)
+                    .log("Using maximum allowable duration for server certificate validity period");
             return MAX_SERVER_CERT_EXPIRY_SECONDS;
         } else if (configuredValidityPeriod < MIN_SERVER_CERT_EXPIRY_SECONDS) {
+            LOGGER.atWarn()
+                    .kv(SERVER_CERT_VALIDITY_SECONDS, configuredValidityPeriod)
+                    .kv("minAllowable", MIN_SERVER_CERT_EXPIRY_SECONDS)
+                    .log("Using minimum allowable duration for server certificate validity period");
             return MIN_SERVER_CERT_EXPIRY_SECONDS;
         }
         return configuredValidityPeriod;
     }
 
     /**
-     * Get server certificate validity period.
+     * Get client certificate validity period.
      *
      * @return Client certificate validity in seconds
      */
     public int getClientCertValiditySeconds() {
-        return DEFAULT_CLIENT_CERT_EXPIRY_SECONDS;
+        int configuredValidityPeriod = Coerce.toInt(configuration.findOrDefault(DEFAULT_CLIENT_CERT_EXPIRY_SECONDS,
+                PATH_CLIENT_CERT_EXPIRY_SECONDS));
+        if (configuredValidityPeriod > MAX_CLIENT_CERT_EXPIRY_SECONDS) {
+            LOGGER.atWarn().kv(CLIENT_CERT_VALIDITY_SECONDS, configuredValidityPeriod)
+                    .kv("maxAllowable", MAX_CLIENT_CERT_EXPIRY_SECONDS)
+                    .log("Using maximum allowable duration for client certificate validity period");
+            return MAX_CLIENT_CERT_EXPIRY_SECONDS;
+        } else if (configuredValidityPeriod < MIN_CLIENT_CERT_EXPIRY_SECONDS) {
+            LOGGER.atWarn().kv(CLIENT_CERT_VALIDITY_SECONDS, configuredValidityPeriod)
+                    .kv("minAllowable", MAX_CLIENT_CERT_EXPIRY_SECONDS)
+                    .log("Using minimum allowable duration for client certificate validity period");
+            return MIN_CLIENT_CERT_EXPIRY_SECONDS;
+        }
+        return configuredValidityPeriod;
     }
 }

--- a/src/test/java/com/aws/greengrass/certificatemanager/certificate/CertificatesConfigTest.java
+++ b/src/test/java/com/aws/greengrass/certificatemanager/certificate/CertificatesConfigTest.java
@@ -64,4 +64,18 @@ public class CertificatesConfigTest {
                 is(equalTo(CertificatesConfig.DEFAULT_CLIENT_CERT_EXPIRY_SECONDS)));
     }
 
+    @Test
+    public void GIVEN_largeClientCertValidity_WHEN_getClientCertValiditySeconds_THEN_returnsMaxExpiry() {
+        configurationTopics.lookup(CertificatesConfig.PATH_CLIENT_CERT_EXPIRY_SECONDS)
+                .withValue(2 * CertificatesConfig.MAX_CLIENT_CERT_EXPIRY_SECONDS);
+        assertThat(certificatesConfig.getClientCertValiditySeconds(),
+                is(equalTo(CertificatesConfig.MAX_CLIENT_CERT_EXPIRY_SECONDS)));
+    }
+
+    @Test
+    public void GIVEN_smallClientCertValidity_WHEN_getClientCertValiditySeconds_THEN_returnsMinExpiry() {
+        configurationTopics.lookup(CertificatesConfig.PATH_CLIENT_CERT_EXPIRY_SECONDS).withValue(60 * 60 * 24); // 1 day
+        assertThat(certificatesConfig.getClientCertValiditySeconds(),
+                is(equalTo(CertificatesConfig.MIN_CLIENT_CERT_EXPIRY_SECONDS)));
+    }
 }


### PR DESCRIPTION
This change introduces a clientCertificateValiditySeconds configuration for
controlling how long client certificates are valid for. Currently this value is only
configurable up to 10 days.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
