### PR TITLE
fix: add logging when rotating client certificates

### DIFF
--- a/src/main/java/com/aws/greengrass/certificatemanager/certificate/ClientCertificateGenerator.java
+++ b/src/main/java/com/aws/greengrass/certificatemanager/certificate/ClientCertificateGenerator.java
@@ -5,6 +5,8 @@
 
 package com.aws.greengrass.certificatemanager.certificate;
 
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.operator.OperatorCreationException;
 
@@ -21,6 +23,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 public class ClientCertificateGenerator extends CertificateGenerator {
+    private static final Logger logger = LogManager.getLogger(ClientCertificateGenerator.class);
 
     private final Consumer<X509Certificate[]> callback;
     private final CertificatesConfig certificatesConfig;
@@ -51,6 +54,9 @@ public class ClientCertificateGenerator extends CertificateGenerator {
     public synchronized void generateCertificate(Supplier<List<String>> connectivityInfoSupplier)
             throws KeyStoreException {
         Instant now = Instant.now(clock);
+
+        logger.atInfo().kv("subject", subject)
+                .log("Generating new client certificate");
         try {
             certificate = CertificateHelper.signClientCertificateRequest(
                     certificateStore.getCACertificate(),


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add logging when client certificates are rotated to aid in debugging

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
