### PR TITLE
feat: add IPC agent and expose cert updates over IPC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>client-devices-auth</artifactId>
     <name>greengrass-client-devices-auth</name>
     <packaging>jar</packaging>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
 
     <licenses>
         <license>
@@ -73,13 +73,13 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.2.0-SNAPSHOT</version>
+            <version>2.6.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.2.0-SNAPSHOT</version>
+            <version>2.6.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
@@ -132,6 +132,39 @@
                     <source>8</source>
                     <target>8</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>add-integration-test-source</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/integrationtests/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-integration-test-resource</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>add-test-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>src/integrationtests/resources</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/SubscribeToCertificateUpdatesTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/SubscribeToCertificateUpdatesTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.integrationtests.ipc;
+
+import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.device.ClientDevicesAuthService;
+import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
+import com.aws.greengrass.lifecyclemanager.GreengrassService;
+import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.logging.impl.config.LogConfig;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.testcommons.testutilities.UniqueRootPathExtension;
+import com.aws.greengrass.util.GreengrassServiceClientFactory;
+import com.aws.greengrass.util.Pair;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCClient;
+import software.amazon.awssdk.aws.greengrass.model.CertificateOptions;
+import software.amazon.awssdk.aws.greengrass.model.CertificateType;
+import software.amazon.awssdk.aws.greengrass.model.CertificateUpdate;
+import software.amazon.awssdk.aws.greengrass.model.CertificateUpdateEvent;
+import software.amazon.awssdk.aws.greengrass.model.InvalidArgumentsError;
+import software.amazon.awssdk.aws.greengrass.model.SubscribeToCertificateUpdatesRequest;
+import software.amazon.awssdk.aws.greengrass.model.UnauthorizedError;
+import software.amazon.awssdk.eventstreamrpc.EventStreamRPCConnection;
+import software.amazon.awssdk.eventstreamrpc.StreamResponseHandler;
+import software.amazon.awssdk.services.greengrassv2data.GreengrassV2DataClient;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static com.aws.greengrass.testcommons.testutilities.TestUtils.asyncAssertOnConsumer;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith({GGExtension.class, UniqueRootPathExtension.class, MockitoExtension.class})
+class SubscribeToCertificateUpdatesTest {
+    private static GlobalStateChangeListener listener;
+    @TempDir
+    Path rootDir;
+    private Kernel kernel;
+    @Mock
+    private GreengrassServiceClientFactory clientFactory;
+    @Mock
+    private GreengrassV2DataClient client;
+
+    private static void subscribeToCertUpdates(GreengrassCoreIPCClient ipcClient,
+                                              SubscribeToCertificateUpdatesRequest request,
+                                              Consumer<CertificateUpdate> consumer) throws Exception {
+        ipcClient.subscribeToCertificateUpdates(request,
+                Optional.of(new StreamResponseHandler<CertificateUpdateEvent>() {
+                    @Override
+                    public void onStreamEvent(CertificateUpdateEvent certificateUpdateEvent) {
+                        consumer.accept(certificateUpdateEvent.getCertificateUpdate());
+                    }
+
+                    @Override
+                    public boolean onStreamError(Throwable error) {
+                        return false;
+                    }
+
+                    @Override
+                    public void onStreamClosed() {
+                    }
+                })).getResponse().get(10, TimeUnit.SECONDS);
+    }
+
+    private static SubscribeToCertificateUpdatesRequest getSampleSubsRequest() {
+        SubscribeToCertificateUpdatesRequest subscribeToCertificateUpdatesRequest =
+                new SubscribeToCertificateUpdatesRequest();
+        subscribeToCertificateUpdatesRequest.setCertificateOptions(new CertificateOptions().withCertificateType(
+                CertificateType.SERVER));
+        return subscribeToCertificateUpdatesRequest;
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        // Set this property for kernel to scan its own classpath to find plugins
+        System.setProperty("aws.greengrass.scanSelfClasspath", "true");
+        kernel = new Kernel();
+        kernel.getContext().put(GreengrassServiceClientFactory.class, clientFactory);
+        lenient().when(clientFactory.getGreengrassV2DataClient()).thenReturn(client);
+    }
+
+    private void startNucleusWithConfig(String configFileName) throws InterruptedException {
+        startNucleusWithConfig(configFileName, State.RUNNING);
+    }
+
+    private void startNucleusWithConfig(String configFileName, State expectedServiceState) throws InterruptedException {
+        CountDownLatch authServiceRunning = new CountDownLatch(1);
+        kernel.parseArgs("-r", rootDir.toAbsolutePath().toString(), "-i",
+                getClass().getResource(configFileName).toString());
+        listener = (GreengrassService service, State was, State newState) -> {
+            if (service.getName().equals(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME) &&
+                    service.getState().equals(expectedServiceState)) {
+                authServiceRunning.countDown();
+            }
+        };
+        kernel.getContext().addGlobalStateChangeListener(listener);
+        kernel.launch();
+        assertThat(authServiceRunning.await(30L, TimeUnit.SECONDS), is(true));
+        kernel.getContext().removeGlobalStateChangeListener(listener);
+    }
+
+    @AfterEach
+    void afterEach() {
+        LogConfig.getRootLogConfig().reset();
+        kernel.shutdown();
+    }
+
+    @Test
+    void GIVEN_two_brokers_WHEN_subscribed_to_certificate_updates_THEN_both_receive_updates_on_stream()
+            throws Exception {
+        startNucleusWithConfig("cda.yaml");
+        Map<String, String> broker1Certs = new HashMap<>();
+        Map<String, String> broker2Certs = new HashMap<>();
+        try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
+                "BrokerSubscribingToCertUpdates")) {
+            GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
+            SubscribeToCertificateUpdatesRequest request = getSampleSubsRequest();
+            Pair<CompletableFuture<Void>, Consumer<CertificateUpdate>> cb = asyncAssertOnConsumer((m) -> {
+                broker1Certs.put("certificate", m.getCertificate());
+                broker1Certs.put("ca-certificate", m.getCaCertificates().get(0));
+            });
+
+            subscribeToCertUpdates(ipcClient, request, cb.getRight());
+            cb.getLeft().get(10, TimeUnit.SECONDS);
+        }
+
+        try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
+                "Broker2SubscribingToCertUpdates")) {
+            GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
+            SubscribeToCertificateUpdatesRequest request = getSampleSubsRequest();
+            Pair<CompletableFuture<Void>, Consumer<CertificateUpdate>> cb = asyncAssertOnConsumer((m) -> {
+                broker2Certs.put("certificate", m.getCertificate());
+                broker2Certs.put("ca-certificate", m.getCaCertificates().get(0));
+            });
+
+            subscribeToCertUpdates(ipcClient, request, cb.getRight());
+            cb.getLeft().get(10, TimeUnit.SECONDS);
+            assertThat(broker1Certs.get("ca-certificate"), is(broker2Certs.get("ca-certificate")));
+            assertThat(broker1Certs.get("certificate"), is(not(broker2Certs.get("certificate"))));
+        }
+    }
+
+    @Test
+    void GIVEN_broker_WHEN_subscribed_to_certificate_updates_THEN_certificate_is_generated() throws Exception {
+        startNucleusWithConfig("cda.yaml");
+        try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
+                "BrokerSubscribingToCertUpdates")) {
+            GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
+            SubscribeToCertificateUpdatesRequest request = getSampleSubsRequest();
+            Pair<CompletableFuture<Void>, Consumer<CertificateUpdate>> cb = asyncAssertOnConsumer((m) -> {
+                assertThat(m.getCertificate(), startsWith("-----BEGIN CERTIFICATE-----"));
+                assertThat(m.getCaCertificates().get(0), startsWith("-----BEGIN CERTIFICATE-----"));
+                assertThat(m.getPrivateKey(), startsWith("-----BEGIN PRIVATE KEY-----"));
+                assertThat(m.getPublicKey(), startsWith("-----BEGIN PUBLIC KEY-----"));
+
+                assertThat(m.getCertificate(), endsWith("-----END CERTIFICATE-----" + System.lineSeparator()));
+                assertThat(m.getCaCertificates().get(0), endsWith("-----END CERTIFICATE-----" + System.lineSeparator()));
+                assertThat(m.getPrivateKey(), endsWith("-----END PRIVATE KEY-----" + System.lineSeparator()));
+                assertThat(m.getPublicKey(), endsWith("-----END PUBLIC KEY-----" + System.lineSeparator()));
+
+            });
+
+            subscribeToCertUpdates(ipcClient, request, cb.getRight());
+            cb.getLeft().get(10, TimeUnit.SECONDS);
+        }
+    }
+
+
+    @Test
+    void GIVEN_broker_with_no_config_WHEN_subscribed_to_certificate_updates_THEN_error_is_thrown()
+            throws ExecutionException, InterruptedException {
+        startNucleusWithConfig("BrokerNotAuthorized.yaml");
+        try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
+                "BrokerWithNoConfig")) {
+            GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
+            SubscribeToCertificateUpdatesRequest request = getSampleSubsRequest();
+            Pair<CompletableFuture<Void>, Consumer<CertificateUpdate>> cb = asyncAssertOnConsumer((m) -> {
+            });
+            Exception err = Assertions.assertThrows(Exception.class, () -> {
+                subscribeToCertUpdates(ipcClient, request, cb.getRight());
+            });
+            assertThat(err.getCause(), is(instanceOf(UnauthorizedError.class)));
+        }
+    }
+
+    @Test
+    void GIVEN_broker_WHEN_subscribed_to_cert_update_with_invalid_cert_type_THEN_error_is_thrown()
+            throws ExecutionException, InterruptedException {
+        startNucleusWithConfig("cda.yaml");
+        try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
+                "BrokerSubscribingToCertUpdates")) {
+            GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
+                SubscribeToCertificateUpdatesRequest request = new SubscribeToCertificateUpdatesRequest();
+                request.withCertificateOptions(new CertificateOptions().withCertificateType("INVALID-TYPE"));
+
+
+            Pair<CompletableFuture<Void>, Consumer<CertificateUpdate>> cb = asyncAssertOnConsumer((m) -> {
+            });
+            Exception err = Assertions.assertThrows(Exception.class, () -> {
+                subscribeToCertUpdates(ipcClient, request, cb.getRight());
+            });
+            assertThat(err.getCause(), is(instanceOf(InvalidArgumentsError.class)));
+            assertThat(err.getMessage(),containsString("Valid certificate type is required."));
+        }
+    }
+
+    // TODO: Integ test to check if rotated cert updates are received (update cert expiry values)
+}

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/ipc/BrokerNotAuthorized.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/ipc/BrokerNotAuthorized.yaml
@@ -1,0 +1,55 @@
+---
+services:
+  aws.greengrass.Nucleus:
+    configuration:
+      runWithDefault:
+        posixUser: nobody
+        windowsUser: integ-tester
+  aws.greengrass.clientdevices.Auth:
+    configuration:
+      deviceGroups:
+        formatVersion: "2021-03-05"
+        definitions:
+          myTemperatureSensors:
+            selectionRule: "thingName:mySensor1 OR thingName:mySensor2"
+            policyName: "sensorAccessPolicy"
+          myHumiditySensors:
+            selectionRule: "thingName:mySensor3 OR thingName:mySensor4"
+            policyName: "sensorAccessPolicy"
+        policies:
+          sensorAccessPolicy:
+            policyStatement1:
+              statementDescription: "mqtt connect"
+              effect: ALLOW
+              operations:
+                - "mqtt:connect"
+              resources:
+                - "mqtt:clientId:foo"
+            policyStatement2:
+              statementDescription: "mqtt publish"
+              operations:
+                - "mqtt:publish"
+              resources:
+                - "mqtt:topic:temperature"
+                - "mqtt:topic:humidity"
+  main:
+    dependencies:
+      - BrokerWithNoConfig
+  BrokerWithNoConfig:
+    dependencies:
+      - aws.greengrass.clientdevices.Auth
+    lifecycle:
+      run:
+        windows:
+          powershell -command sleep 1
+        posix:
+          sleep 1
+    configuration:
+      accessControl:
+        aws.greengrass.ipc.pubsub:
+          policyId1:BrokerWithNoConfig:
+            policyDescription: access to pubsub topics for ServiceName
+            operations:
+              - '*'
+            resources:
+              - '*'

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/ipc/cda.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/ipc/cda.yaml
@@ -1,0 +1,88 @@
+---
+services:
+  aws.greengrass.Nucleus:
+    configuration:
+      runWithDefault:
+        posixUser: nobody
+        windowsUser: integ-tester
+  aws.greengrass.clientdevices.Auth:
+    configuration:
+      deviceGroups:
+        formatVersion: "2021-03-05"
+        definitions:
+          myTemperatureSensors:
+            selectionRule: "thingName:mySensor1 OR thingName:mySensor2"
+            policyName: "sensorAccessPolicy"
+          myHumiditySensors:
+            selectionRule: "thingName:mySensor3 OR thingName:mySensor4"
+            policyName: "sensorAccessPolicy"
+        policies:
+          sensorAccessPolicy:
+            policyStatement1:
+              statementDescription: "mqtt connect"
+              effect: ALLOW
+              operations:
+                - "mqtt:connect"
+              resources:
+                - "mqtt:clientId:foo"
+            policyStatement2:
+              statementDescription: "mqtt publish"
+              operations:
+                - "mqtt:publish"
+              resources:
+                - "mqtt:topic:temperature"
+                - "mqtt:topic:humidity"
+  main:
+    dependencies:
+      - BrokerSubscribingToCertUpdates
+      - Broker2SubscribingToCertUpdates
+  BrokerSubscribingToCertUpdates:
+    dependencies:
+      - aws.greengrass.clientdevices.Auth
+    lifecycle:
+      run:
+        windows:
+          powershell -command sleep 1
+        posix:
+          sleep 1
+    configuration:
+      accessControl:
+        aws.greengrass.clientdevices.Auth:
+          policyId1:
+            policyDescription: access to certificate updates
+            operations:
+              - '*'
+            resources:
+              - '*'
+        aws.greengrass.ipc.pubsub:
+          policyId2:
+            policyDescription: access to pubsub topics for ServiceName
+            operations:
+              - '*'
+            resources:
+              - '*'
+  Broker2SubscribingToCertUpdates:
+    dependencies:
+      - aws.greengrass.clientdevices.Auth
+    lifecycle:
+      run:
+        windows:
+          powershell -command sleep 1
+        posix:
+          sleep 1
+    configuration:
+      accessControl:
+        aws.greengrass.clientdevices.Auth:
+          policyId1:Broker2SubscribingToCertUpdates:
+            policyDescription: access to certificate updates
+            operations:
+              - '*'
+            resources:
+              - '*'
+        aws.greengrass.ipc.pubsub:
+          policyId2:Broker2SubscribingToCertUpdates:
+            policyDescription: access to pubsub topics for ServiceName
+            operations:
+              - '*'
+            resources:
+              - '*'

--- a/src/main/java/com/aws/greengrass/certificatemanager/certificate/CertificateHelper.java
+++ b/src/main/java/com/aws/greengrass/certificatemanager/certificate/CertificateHelper.java
@@ -69,6 +69,9 @@ public final class CertificateHelper {
     private static final String X500_DISTINGUISHED_NAME_LOCALITY_NAME = "Seattle";
     private static final String X500_DISTINGUISHED_NAME_ORGANIZATION_NAME = "Amazon.com Inc.";
     private static final String X500_DISTINGUISHED_NAME_ORGANIZATION_UNIT_NAME = "Amazon Web Services";
+    public static final String PEM_BOUNDARY_CERTIFICATE = "CERTIFICATE";
+    public static final String PEM_BOUNDARY_PUBLIC_KEY = "PUBLIC KEY";
+    public static final String PEM_BOUNDARY_PRIVATE_KEY = "PRIVATE KEY";
 
     private CertificateHelper() {
     }
@@ -218,6 +221,7 @@ public final class CertificateHelper {
         }
     }
 
+
     /**
      * Convert an X509Certificate into a PEM encoded string.
      *
@@ -227,7 +231,7 @@ public final class CertificateHelper {
      * @throws CertificateEncodingException If unable to get certificate encoding
      */
     public static String toPem(X509Certificate certificate) throws IOException, CertificateEncodingException {
-        PemObject pemObject = new PemObject("CERTIFICATE", certificate.getEncoded());
+        PemObject pemObject = new PemObject(PEM_BOUNDARY_CERTIFICATE, certificate.getEncoded());
 
         try (StringWriter str = new StringWriter();
              JcaPEMWriter pemWriter = new JcaPEMWriter(str)) {

--- a/src/main/java/com/aws/greengrass/ipc/SubscribeToCertificateUpdatesOperationHandler.java
+++ b/src/main/java/com/aws/greengrass/ipc/SubscribeToCertificateUpdatesOperationHandler.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.ipc;
+
+
+import com.aws.greengrass.authorization.AuthorizationHandler;
+import com.aws.greengrass.authorization.Permission;
+import com.aws.greengrass.authorization.exceptions.AuthorizationException;
+import com.aws.greengrass.certificatemanager.CertificateManager;
+import com.aws.greengrass.certificatemanager.certificate.CertificateRequestGenerator;
+import com.aws.greengrass.certificatemanager.certificate.CertificateStore;
+import com.aws.greengrass.certificatemanager.certificate.CsrProcessingException;
+import com.aws.greengrass.device.ClientDevicesAuthService;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.util.EncryptionUtils;
+import org.bouncycastle.operator.OperatorCreationException;
+import software.amazon.awssdk.aws.greengrass.GeneratedAbstractSubscribeToCertificateUpdatesOperationHandler;
+import software.amazon.awssdk.aws.greengrass.model.CertificateOptions;
+import software.amazon.awssdk.aws.greengrass.model.CertificateType;
+import software.amazon.awssdk.aws.greengrass.model.CertificateUpdate;
+import software.amazon.awssdk.aws.greengrass.model.CertificateUpdateEvent;
+import software.amazon.awssdk.aws.greengrass.model.InvalidArgumentsError;
+import software.amazon.awssdk.aws.greengrass.model.ServiceError;
+import software.amazon.awssdk.aws.greengrass.model.SubscribeToCertificateUpdatesRequest;
+import software.amazon.awssdk.aws.greengrass.model.SubscribeToCertificateUpdatesResponse;
+import software.amazon.awssdk.aws.greengrass.model.UnauthorizedError;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
+import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
+
+import java.io.IOException;
+import java.security.KeyPair;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static com.aws.greengrass.certificatemanager.certificate.CertificateHelper.PEM_BOUNDARY_CERTIFICATE;
+import static com.aws.greengrass.certificatemanager.certificate.CertificateHelper.PEM_BOUNDARY_PRIVATE_KEY;
+import static com.aws.greengrass.certificatemanager.certificate.CertificateHelper.PEM_BOUNDARY_PUBLIC_KEY;
+import static com.aws.greengrass.ipc.common.ExceptionUtil.translateExceptions;
+import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.SUBSCRIBE_TO_CERTIFICATE_UPDATES;
+
+public class SubscribeToCertificateUpdatesOperationHandler
+        extends GeneratedAbstractSubscribeToCertificateUpdatesOperationHandler {
+    private static final Logger logger = LogManager.getLogger(SubscribeToCertificateUpdatesOperationHandler.class);
+    private static final String COMPONENT_NAME = "componentName";
+    private static final String NO_CERT_OPTIONS_ERROR = "Certificate options are required.";
+    private static final String INVALID_CERT_TYPE_ERROR = "Valid certificate type is required.";
+    private static final String UNAUTHORIZED_ERROR = "Not Authorized";
+    private static final int RSA_KEY_LENGTH_FOR_SERVER_CERT = 4096;
+    private final String serviceName;
+    private final CertificateManager certificateManager;
+    private final AtomicBoolean subscriptionResponseSent = new AtomicBoolean(false);
+    private final AtomicReference<CertificateUpdateEvent> firstStreamingEvent = new AtomicReference<>(null);
+    private final AuthorizationHandler authorizationHandler;
+    private KeyPair keyPair;
+    private final Consumer<X509Certificate> serverCertificateCallback = this::forwardServerCertificates;
+
+    /**
+     * Constructor.
+     *
+     * @param context              operation continuation handler
+     * @param certificateManager   certificate manager
+     * @param authorizationHandler authorization handler
+     */
+    public SubscribeToCertificateUpdatesOperationHandler(OperationContinuationHandlerContext context,
+                                                         CertificateManager certificateManager,
+                                                         AuthorizationHandler authorizationHandler) {
+        super(context);
+        serviceName = context.getAuthenticationData().getIdentityLabel();
+        this.certificateManager = certificateManager;
+        this.authorizationHandler = authorizationHandler;
+
+    }
+
+
+    @SuppressWarnings("PMD.PreserveStackTrace")
+    @Override
+    public SubscribeToCertificateUpdatesResponse handleRequest(
+            SubscribeToCertificateUpdatesRequest subscribeToCertificateUpdatesRequest) {
+        return translateExceptions(() -> {
+            try {
+                doAuthorizationForSubscribingToCertUpdates(serviceName);
+            } catch (AuthorizationException e) {
+                logger.atWarn().kv("error", e.getMessage()).kv(COMPONENT_NAME, serviceName).log(UNAUTHORIZED_ERROR);
+                throw new UnauthorizedError(e.getMessage());
+            }
+
+            CertificateType certificateType = getCertificateTypeFromCertificateOptions(
+                    subscribeToCertificateUpdatesRequest.getCertificateOptions());
+            if (CertificateType.SERVER.equals(certificateType)) {
+                try {
+                    final String csr = getCSRForServer();
+                    certificateManager.subscribeToServerCertificateUpdates(csr, serverCertificateCallback);
+                } catch (KeyStoreException | CsrProcessingException e) {
+                    logger.atError().cause(e).log("Unable to subscribe to the certificate updates.");
+                    throw new ServiceError(
+                            "Subscribe to certificate updates failed. Check Greengrass log for details.");
+                }
+            }
+            return new SubscribeToCertificateUpdatesResponse();
+        });
+    }
+
+    /**
+     * Checks if the component is authorized to make IPC calls for subscribing to cert updates.
+     *
+     * @param serviceName component name
+     * @throws AuthorizationException if the component is not authorized
+     */
+    private void doAuthorizationForSubscribingToCertUpdates(String serviceName) throws AuthorizationException {
+        authorizationHandler.isAuthorized(
+                ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME,
+                Permission.builder()
+                        .principal(serviceName)
+                        .operation(SUBSCRIBE_TO_CERTIFICATE_UPDATES)
+                        .resource("*")
+                        .build());
+    }
+
+    private CertificateType getCertificateTypeFromCertificateOptions(CertificateOptions certificateOptions) {
+        validateCertificateOptions(certificateOptions);
+        CertificateType certificateType = certificateOptions.getCertificateType();
+        if (certificateType == null) {
+            logger.atError().kv(COMPONENT_NAME, serviceName).log(INVALID_CERT_TYPE_ERROR);
+            throw new InvalidArgumentsError(INVALID_CERT_TYPE_ERROR);
+        }
+        return certificateType;
+    }
+
+    private void validateCertificateOptions(CertificateOptions certificateOptions) {
+        if (certificateOptions == null) {
+            logger.atError().kv(COMPONENT_NAME, serviceName).log(NO_CERT_OPTIONS_ERROR);
+            throw new InvalidArgumentsError(NO_CERT_OPTIONS_ERROR);
+        }
+    }
+    
+    @SuppressWarnings("PMD.PreserveStackTrace")
+    private String getCSRForServer() {
+        try {
+            this.keyPair = CertificateStore.newRSAKeyPair(RSA_KEY_LENGTH_FOR_SERVER_CERT);
+            return CertificateRequestGenerator
+                    .createCSR(keyPair, serviceName, Collections.emptyList(), Collections.singletonList("localhost"));
+        } catch (NoSuchAlgorithmException | OperatorCreationException | IOException e) {
+            logger.atError().cause(e).log("Unable to create the certificate signing request");
+            throw new ServiceError(
+                    "Subscribe to certificate update failed. Check Greengrass log for details.");
+        }
+    }
+
+    @SuppressWarnings("PMD.PreserveStackTrace")
+    private void forwardServerCertificates(X509Certificate certificate) {
+        CertificateUpdate certificateUpdate = new CertificateUpdate();
+        try {
+            certificateUpdate
+                    .withCertificate(EncryptionUtils.encodeToPem(PEM_BOUNDARY_CERTIFICATE, certificate.getEncoded()))
+                    .withCaCertificates(this.certificateManager.getCACertificates())
+                    .withPublicKey(
+                            EncryptionUtils.encodeToPem(PEM_BOUNDARY_PUBLIC_KEY, keyPair.getPublic().getEncoded()))
+                    .withPrivateKey(
+                            EncryptionUtils.encodeToPem(PEM_BOUNDARY_PRIVATE_KEY, keyPair.getPrivate().getEncoded()));
+        } catch (CertificateEncodingException | IOException | KeyStoreException e) {
+            logger.atError().cause(e).log("Unable to attach certificates to the response");
+            throw new ServiceError("Subscribe to certificate update failed. Check Greengrass log for details.");
+        }
+        CertificateUpdateEvent event = new CertificateUpdateEvent();
+        event.setCertificateUpdate(certificateUpdate);
+
+        // The subscription request has two types of event responses where the first response sent must be of type
+        // 'SubscribeToCertificateUpdatesResponse' and the following streaming responses must be of type
+        // 'CertificateUpdateEvent'.
+
+        // Since the first streaming response of CertificateUpdateEvent is created before we send the
+        // SubscribeToCertificateUpdatesResponse, we store and send that event in the afterHandleRequest.
+        synchronized (firstStreamingEvent) {
+            if (subscriptionResponseSent.get()) {
+                this.sendStreamEvent(event);
+            } else {
+                firstStreamingEvent.set(event);
+            }
+        }
+    }
+
+    @Override
+    public void handleStreamEvent(EventStreamJsonMessage eventStreamJsonMessage) {
+    }
+
+
+    /**
+     * <p>
+     * Here, since this method is called after handling the request successfully, we know that the initial
+     * SubscribeToCertificateUpdatesResponse response is sent. So, we send the first streaming response of
+     * CertificateUpdateEvent.
+     * </p>
+     */
+    @Override
+    public void afterHandleRequest() {
+        synchronized (firstStreamingEvent) {
+            if (subscriptionResponseSent.compareAndSet(false, true)) {
+                CertificateUpdateEvent event = firstStreamingEvent.get();
+                if (event != null) {
+                    sendStreamEvent(event);
+                }
+                firstStreamingEvent.set(null);
+            }
+        }
+    }
+
+    @Override
+    protected void onStreamClosed() {
+        certificateManager.unsubscribeFromServerCertificateUpdates(serverCertificateCallback);
+    }
+
+}

--- a/src/test/java/com/aws/greengrass/device/ClientDevicesAuthServiceTest.java
+++ b/src/test/java/com/aws/greengrass/device/ClientDevicesAuthServiceTest.java
@@ -104,6 +104,8 @@ class ClientDevicesAuthServiceTest {
 
     @BeforeEach
     void setup() {
+        // Set this property for kernel to scan its own classpath to find plugins
+        System.setProperty("aws.greengrass.scanSelfClasspath", "true");
         kernel = new Kernel();
         kernel.getContext().put(GroupManager.class, groupManager);
         kernel.getContext().put(CertificateExpiryMonitor.class, certExpiryMonitor);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This change registers the CDA component and possible operations it exposes with IPC. IPC agent for CDA is added to send server certificate update events to the components as a streaming response. 

**Why is this change necessary:**
We're exposing server certificate updates (both generation and rotation) over IPC to facilitate any authorized non-plugin component (such as new MQTT 5 broker or BYOB) to subscribe to its certificate updates from the CDA component. 

**How was this change tested:**

**Any additional information or context required to review the change:**
Flow:
1. An Mqtt broker server subscribes to its certificate updates over IPC using streaming response handler. The subscribe request consists of the following. 

```
SubscribeToCertificateUpdatesRequest
- CertificateOptions 
   - CertificateType
```
   
3. The CDA component receives this request and does the following in order. 
- Creates a new key pair and generates a CSR. 
- Generates certificate and monitors for expiry and regenerates if needed. 
- This generated certificates and keys are pem encoded and sent over a stream as an event. 
- Response is of the following format

```
SubscribeToCertificateUpdatesResponse
- CertificateUpdateEvent
   - CertificateUpdate
      - privateKey
      - publicKey
      - certificate
      - caCertificates[]

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
