### PR TITLE
feat: expose verifying client device identity over ipc

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/VerifyClientDeviceIdentityTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/VerifyClientDeviceIdentityTest.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.integrationtests.ipc;
+
+import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.device.ClientDevicesAuthService;
+import com.aws.greengrass.device.exception.CloudServiceInteractionException;
+import com.aws.greengrass.device.iot.IotAuthClient;
+import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
+import com.aws.greengrass.lifecyclemanager.GreengrassService;
+import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.logging.impl.config.LogConfig;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.testcommons.testutilities.UniqueRootPathExtension;
+import com.aws.greengrass.util.GreengrassServiceClientFactory;
+import com.aws.greengrass.util.Pair;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCClient;
+import software.amazon.awssdk.aws.greengrass.VerifyClientDeviceIdentityResponseHandler;
+import software.amazon.awssdk.aws.greengrass.model.ClientDeviceCredential;
+import software.amazon.awssdk.aws.greengrass.model.ServiceError;
+import software.amazon.awssdk.aws.greengrass.model.UnauthorizedError;
+import software.amazon.awssdk.aws.greengrass.model.VerifyClientDeviceIdentityRequest;
+import software.amazon.awssdk.aws.greengrass.model.VerifyClientDeviceIdentityResponse;
+import software.amazon.awssdk.eventstreamrpc.EventStreamRPCConnection;
+import software.amazon.awssdk.services.greengrassv2data.GreengrassV2DataClient;
+import software.amazon.awssdk.services.greengrassv2data.model.InternalServerException;
+import software.amazon.awssdk.services.greengrassv2data.model.ValidationException;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static com.aws.greengrass.testcommons.testutilities.TestUtils.asyncAssertOnConsumer;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({GGExtension.class, UniqueRootPathExtension.class, MockitoExtension.class})
+class VerifyClientDeviceIdentityTest {
+    private static GlobalStateChangeListener listener;
+    @TempDir
+    Path rootDir;
+    private Kernel kernel;
+    @Mock
+    private GreengrassServiceClientFactory clientFactory;
+    @Mock
+    private GreengrassV2DataClient client;
+    @Mock
+    private IotAuthClient iotAuthClient;
+
+    private static void verifyClientIdentity(GreengrassCoreIPCClient ipcClient,
+                                             VerifyClientDeviceIdentityRequest request,
+                                             Consumer<VerifyClientDeviceIdentityResponse> consumer) throws Exception {
+        VerifyClientDeviceIdentityResponseHandler handler =
+                ipcClient.verifyClientDeviceIdentity(request, Optional.empty());
+        VerifyClientDeviceIdentityResponse response = handler.getResponse().get(10, TimeUnit.SECONDS);
+        consumer.accept(response);
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        // Set this property for kernel to scan its own classpath to find plugins
+        System.setProperty("aws.greengrass.scanSelfClasspath", "true");
+        kernel = new Kernel();
+        kernel.getContext().put(GreengrassServiceClientFactory.class, clientFactory);
+
+        when(clientFactory.getGreengrassV2DataClient()).thenReturn(client);
+
+    }
+
+    private void startNucleusWithConfig(String configFileName) throws InterruptedException {
+        startNucleusWithConfig(configFileName, State.RUNNING);
+    }
+
+    private void startNucleusWithConfig(String configFileName, State expectedServiceState) throws InterruptedException {
+        CountDownLatch authServiceRunning = new CountDownLatch(1);
+        kernel.parseArgs("-r", rootDir.toAbsolutePath().toString(), "-i",
+                getClass().getResource(configFileName).toString());
+        listener = (GreengrassService service, State was, State newState) -> {
+            if (service.getName().equals(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME) &&
+                    service.getState().equals(expectedServiceState)) {
+                authServiceRunning.countDown();
+            }
+        };
+        kernel.getContext().addGlobalStateChangeListener(listener);
+        kernel.launch();
+        assertThat(authServiceRunning.await(30L, TimeUnit.SECONDS), is(true));
+        kernel.getContext().removeGlobalStateChangeListener(listener);
+    }
+
+    @AfterEach
+    void afterEach() {
+        LogConfig.getRootLogConfig().reset();
+        kernel.shutdown();
+    }
+
+    @Test
+    void GIVEN_broker_WHEN_verify_client_identity_THEN_verify() throws Exception {
+        kernel.getContext().put(IotAuthClient.class, iotAuthClient);
+        when(iotAuthClient.getActiveCertificateId("VALID PEM")).thenReturn(
+                Optional.of("SOME-CERT")
+        );
+        startNucleusWithConfig("cda.yaml");
+        try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
+                "BrokerSubscribingToCertUpdates")) {
+            GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
+
+            VerifyClientDeviceIdentityRequest request = new VerifyClientDeviceIdentityRequest()
+                    .withCredential(new ClientDeviceCredential()
+                            .withClientDeviceCertificate("VALID PEM"));
+
+            Pair<CompletableFuture<Void>, Consumer<VerifyClientDeviceIdentityResponse>> cb =
+                    asyncAssertOnConsumer((m) -> {
+                        assertTrue(m.isIsValidClientDevice());
+                    });
+
+            verifyClientIdentity(ipcClient, request, cb.getRight());
+            cb.getLeft().get(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void GIVEN_broker_WHEN_verify_client_identity_with_invalid_pem_THEN_verify() throws Exception {
+        kernel.getContext().put(IotAuthClient.class, iotAuthClient);
+        when(iotAuthClient.getActiveCertificateId("INVALID PEM")).thenReturn(
+                Optional.empty()
+        );
+        startNucleusWithConfig("cda.yaml");
+        try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
+                "BrokerSubscribingToCertUpdates")) {
+            GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
+
+            VerifyClientDeviceIdentityRequest request = new VerifyClientDeviceIdentityRequest()
+                    .withCredential(new ClientDeviceCredential()
+                            .withClientDeviceCertificate("INVALID PEM"));
+
+            Pair<CompletableFuture<Void>, Consumer<VerifyClientDeviceIdentityResponse>> cb =
+                    asyncAssertOnConsumer((m) -> {
+                        assertFalse(m.isIsValidClientDevice());
+
+                    });
+
+            verifyClientIdentity(ipcClient, request, cb.getRight());
+            cb.getLeft().get(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void GIVEN_broker_with_no_config_WHEN_verify_client_identity_THEN_error_is_thrown()
+            throws ExecutionException, InterruptedException {
+        kernel.getContext().put(IotAuthClient.class, iotAuthClient);
+        startNucleusWithConfig("BrokerNotAuthorized.yaml");
+        try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
+                "BrokerWithNoConfig")) {
+            GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
+            VerifyClientDeviceIdentityRequest request = new VerifyClientDeviceIdentityRequest()
+                    .withCredential(new ClientDeviceCredential()
+                            .withClientDeviceCertificate("VALID PEM"));
+            Exception err = Assertions.assertThrows(Exception.class, () -> {
+                verifyClientIdentity(ipcClient, request, null);
+            });
+            assertThat(err.getCause(), is(instanceOf(UnauthorizedError.class)));
+        }
+    }
+
+
+    @Test
+    void GIVEN_broker_WHEN_verify_client_identity_with_validation_exception_THEN_error_is_thrown(
+            ExtensionContext context)
+            throws Exception {
+        startNucleusWithConfig("cda.yaml");
+        software.amazon.awssdk.services.greengrassv2data.model.VerifyClientDeviceIdentityRequest re =
+                software.amazon.awssdk.services.greengrassv2data.model.VerifyClientDeviceIdentityRequest.builder()
+                        .clientDeviceCertificate("ValidationException PEM").build();
+        when(clientFactory.getGreengrassV2DataClient().verifyClientDeviceIdentity(re))
+                .thenThrow(ValidationException.class);
+        ignoreExceptionOfType(context, ValidationException.class);
+        try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
+                "BrokerSubscribingToCertUpdates")) {
+            GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
+            VerifyClientDeviceIdentityRequest request = new VerifyClientDeviceIdentityRequest()
+                    .withCredential(new ClientDeviceCredential()
+                            .withClientDeviceCertificate("ValidationException PEM"));
+
+            Pair<CompletableFuture<Void>, Consumer<VerifyClientDeviceIdentityResponse>> cb =
+                    asyncAssertOnConsumer((m) -> {
+                        assertFalse(m.isIsValidClientDevice());
+
+                    });
+
+            verifyClientIdentity(ipcClient, request, cb.getRight());
+            cb.getLeft().get(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void GIVEN_broker_WHEN_verify_client_identity_with_internal_server_exception_THEN_error_is_thrown(
+            ExtensionContext context)
+            throws Exception {
+        startNucleusWithConfig("cda.yaml");
+        software.amazon.awssdk.services.greengrassv2data.model.VerifyClientDeviceIdentityRequest re =
+                software.amazon.awssdk.services.greengrassv2data.model.VerifyClientDeviceIdentityRequest.builder()
+                        .clientDeviceCertificate("InternalServerException PEM").build();
+        when(client.verifyClientDeviceIdentity(re)).thenThrow(InternalServerException.class);
+        ignoreExceptionOfType(context, CloudServiceInteractionException.class);
+        ignoreExceptionOfType(context, InternalServerException.class);
+        try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
+                "BrokerSubscribingToCertUpdates")) {
+            GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
+            VerifyClientDeviceIdentityRequest request = new VerifyClientDeviceIdentityRequest()
+                    .withCredential(new ClientDeviceCredential()
+                            .withClientDeviceCertificate("InternalServerException PEM"));
+
+            Exception err = Assertions.assertThrows(Exception.class, () -> {
+                verifyClientIdentity(ipcClient, request, null);
+            });
+            assertEquals(err.getCause().getClass(), ServiceError.class);
+        }
+    }
+
+    @Test
+    void GIVEN_broker_WHEN_verify_client_identity_with_exception_THEN_error_is_thrown(ExtensionContext context)
+            throws ExecutionException, InterruptedException {
+        startNucleusWithConfig("cda.yaml");
+        ignoreExceptionOfType(context, NullPointerException.class);
+        ignoreExceptionOfType(context, CloudServiceInteractionException.class);
+        try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
+                "BrokerSubscribingToCertUpdates")) {
+            GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
+            VerifyClientDeviceIdentityRequest request = new VerifyClientDeviceIdentityRequest()
+                    .withCredential(new ClientDeviceCredential()
+                            .withClientDeviceCertificate("Generic Exception PEM"));
+
+            Exception err = Assertions.assertThrows(Exception.class, () -> {
+                verifyClientIdentity(ipcClient, request, null);
+            });
+            assertEquals(err.getCause().getClass(), ServiceError.class);
+        }
+    }
+}

--- a/src/main/java/com/aws/greengrass/ipc/VerifyClientDeviceIdentityOperationHandler.java
+++ b/src/main/java/com/aws/greengrass/ipc/VerifyClientDeviceIdentityOperationHandler.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.ipc;
+
+
+import com.aws.greengrass.authorization.AuthorizationHandler;
+import com.aws.greengrass.authorization.Permission;
+import com.aws.greengrass.authorization.exceptions.AuthorizationException;
+import com.aws.greengrass.device.ClientDevicesAuthService;
+import com.aws.greengrass.device.iot.IotAuthClient;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.util.Utils;
+import software.amazon.awssdk.aws.greengrass.GeneratedAbstractVerifyClientDeviceIdentityOperationHandler;
+import software.amazon.awssdk.aws.greengrass.model.ClientDeviceCredential;
+import software.amazon.awssdk.aws.greengrass.model.InvalidArgumentsError;
+import software.amazon.awssdk.aws.greengrass.model.ServiceError;
+import software.amazon.awssdk.aws.greengrass.model.UnauthorizedError;
+import software.amazon.awssdk.aws.greengrass.model.VerifyClientDeviceIdentityRequest;
+import software.amazon.awssdk.aws.greengrass.model.VerifyClientDeviceIdentityResponse;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
+import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
+
+import java.util.Optional;
+
+import static com.aws.greengrass.ipc.common.ExceptionUtil.translateExceptions;
+import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.VERIFY_CLIENT_DEVICE_IDENTITY;
+
+public class VerifyClientDeviceIdentityOperationHandler
+        extends GeneratedAbstractVerifyClientDeviceIdentityOperationHandler {
+    private static final Logger logger = LogManager.getLogger(VerifyClientDeviceIdentityOperationHandler.class);
+    private static final String COMPONENT_NAME = "componentName";
+    private static final String UNAUTHORIZED_ERROR = "Not Authorized";
+    private static final String NO_DEVICE_CREDENTIAL_ERROR = "Client device credential is required";
+    private static final String NO_DEVICE_CERTIFICATE_ERROR = "Client device certificate is required";
+    private final IotAuthClient iotAuthClient;
+    private final String serviceName;
+    private final AuthorizationHandler authorizationHandler;
+
+    /**
+     * Constructor.
+     *
+     * @param context              operation continuation handler
+     * @param iotAuthClient        auth client for client device calls
+     * @param authorizationHandler authorization handler
+     */
+    public VerifyClientDeviceIdentityOperationHandler(
+            OperationContinuationHandlerContext context, IotAuthClient iotAuthClient,
+            AuthorizationHandler authorizationHandler) {
+
+        super(context);
+        this.iotAuthClient = iotAuthClient;
+        serviceName = context.getAuthenticationData().getIdentityLabel();
+        this.authorizationHandler = authorizationHandler;
+    }
+
+    @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.PreserveStackTrace"})
+    @Override
+    public VerifyClientDeviceIdentityResponse handleRequest(VerifyClientDeviceIdentityRequest request) {
+        return translateExceptions(() -> {
+            try {
+                doAuthorizationForClientDevIdentity();
+            } catch (AuthorizationException e) {
+                logger.atWarn().kv("error", e.getMessage()).kv(COMPONENT_NAME, serviceName).log(UNAUTHORIZED_ERROR);
+                throw new UnauthorizedError(e.getMessage());
+            }
+            String certificate = getCertificateFromCredential(request.getCredential());
+            try {
+                Optional<String> certificateId = iotAuthClient.getActiveCertificateId(certificate);
+                VerifyClientDeviceIdentityResponse response = new VerifyClientDeviceIdentityResponse();
+                return response.withIsValidClientDevice(certificateId.isPresent());
+            } catch (Exception e) {
+                logger.atError().cause(e).log("Unable to verify client device identity");
+                throw new ServiceError(
+                        "Verifying client device identity failed. Check Greengrass log for details.");
+            }
+        });
+    }
+
+    private void doAuthorizationForClientDevIdentity() throws AuthorizationException {
+        authorizationHandler.isAuthorized(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME,
+                Permission.builder()
+                        .principal(serviceName)
+                        .operation(VERIFY_CLIENT_DEVICE_IDENTITY)
+                        .resource("*")
+                        .build());
+    }
+
+    private String getCertificateFromCredential(ClientDeviceCredential credential) {
+        if (credential == null) {
+            throw new InvalidArgumentsError(NO_DEVICE_CREDENTIAL_ERROR);
+        }
+        String certificate = credential.getClientDeviceCertificate();
+        if (Utils.isEmpty(certificate)) {
+            throw new InvalidArgumentsError(NO_DEVICE_CERTIFICATE_ERROR);
+        }
+        return certificate;
+    }
+
+    @Override
+    public void handleStreamEvent(EventStreamJsonMessage eventStreamJsonMessage) {
+
+    }
+
+    @Override
+    protected void onStreamClosed() {
+
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Exposes verifying client device identity over IPC. 

**Why is this change necessary:**
Facilitate any authorized non-plugin component (such as new MQTT 5 broker or BYOB) to verify client device identity over IPC.

**How was this change tested:**
Added integ tests. 

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
