### PR TITLE
refactor: modify credentials from map to object

### DIFF
--- a/src/main/java/com/aws/greengrass/device/session/MqttSessionFactory.java
+++ b/src/main/java/com/aws/greengrass/device/session/MqttSessionFactory.java
@@ -9,8 +9,9 @@ import com.aws.greengrass.device.exception.AuthenticationException;
 import com.aws.greengrass.device.iot.Certificate;
 import com.aws.greengrass.device.iot.IotAuthClient;
 import com.aws.greengrass.device.iot.Thing;
+import com.aws.greengrass.device.session.credentials.Credential;
+import com.aws.greengrass.device.session.credentials.MqttCredential;
 
-import java.util.Map;
 import javax.inject.Inject;
 
 public class MqttSessionFactory implements SessionFactory {
@@ -22,16 +23,18 @@ public class MqttSessionFactory implements SessionFactory {
     }
 
     @Override
-    public Session createSession(Map<String, String> credentialMap) throws AuthenticationException {
-        // TODO: replace with jackson object mapper
-        MqttCredential mqttCredential = new MqttCredential(credentialMap);
+    public Session createSession(Credential credential) throws AuthenticationException {
+        if (!credential.getClass().equals(MqttCredential.class)) {
+            throw new IllegalArgumentException("Unable to parse MQTT credentials");
+        }
+        MqttCredential mqttCredential = (MqttCredential) credential;
 
         // TODO: support internal client certificates.
         //   Internally issued certificates need to be handled by the entity creating sessions since
         //   we don't yet have the ability to authorize actions for those clients. So, for now, assume
         //   this is an IoT Thing and components will be specially handled elsewhere.
-        Thing thing = new Thing(mqttCredential.clientId);
-        Certificate cert = new Certificate(mqttCredential.certificatePem);
+        Thing thing = new Thing(mqttCredential.getClientId());
+        Certificate cert = new Certificate(mqttCredential.getCertificatePem());
         if (!iotAuthClient.isThingAttachedToCertificate(thing, cert)) {
             throw new AuthenticationException("unable to authenticate device");
         }
@@ -39,19 +42,5 @@ public class MqttSessionFactory implements SessionFactory {
         Session session = new SessionImpl(cert);
         session.putAttributeProvider(Thing.NAMESPACE, thing);
         return session;
-    }
-
-    private static class MqttCredential {
-        private final String clientId;
-        private final String certificatePem;
-        private final String username;
-        private final String password;
-
-        public MqttCredential(Map<String, String> credentialMap) {
-            this.clientId = credentialMap.get("clientId");
-            this.certificatePem = credentialMap.get("certificatePem");
-            this.username = credentialMap.get("username");
-            this.password = credentialMap.get("password");
-        }
     }
 }

--- a/src/main/java/com/aws/greengrass/device/session/SessionCreator.java
+++ b/src/main/java/com/aws/greengrass/device/session/SessionCreator.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.device.session;
 
 import com.aws.greengrass.device.exception.AuthenticationException;
+import com.aws.greengrass.device.session.credentials.Credential;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 
@@ -22,28 +23,23 @@ public class SessionCreator {
         factoryMap = new ConcurrentHashMap<>();
     }
 
-    private static class SessionFactorySingleton {
-        @SuppressWarnings("PMD.AccessorClassGeneration")
-        private static final SessionCreator INSTANCE = new SessionCreator();
-    }
-
     /**
      * Create a client device session.
      *
      * @param credentialType type of credentials provided
-     * @param credentialMap  map of client credentials
+     * @param credential     client credentials
      * @return new session if the client can be authenticated
      * @throws AuthenticationException if the client fails to be authenticated
      */
-    public static Session createSession(String credentialType, Map<String, String> credentialMap)
+    public static Session createSession(String credentialType, Credential credential)
             throws AuthenticationException {
         SessionFactory sessionFactory = SessionFactorySingleton.INSTANCE.factoryMap.get(credentialType);
         if (sessionFactory == null) {
             logger.atWarn().kv("credentialType", credentialType)
-                .log("no registered handler to process device credentials");
+                    .log("no registered handler to process device credentials");
             throw new IllegalArgumentException("unknown credential type");
         }
-        return sessionFactory.createSession(credentialMap);
+        return sessionFactory.createSession(credential);
     }
 
     public static void registerSessionFactory(String credentialType, SessionFactory sessionFactory) {
@@ -52,5 +48,10 @@ public class SessionCreator {
 
     public static void unregisterSessionFactory(String credentialType) {
         SessionFactorySingleton.INSTANCE.factoryMap.remove(credentialType);
+    }
+
+    private static class SessionFactorySingleton {
+        @SuppressWarnings("PMD.AccessorClassGeneration")
+        private static final SessionCreator INSTANCE = new SessionCreator();
     }
 }

--- a/src/main/java/com/aws/greengrass/device/session/SessionFactory.java
+++ b/src/main/java/com/aws/greengrass/device/session/SessionFactory.java
@@ -6,9 +6,8 @@
 package com.aws.greengrass.device.session;
 
 import com.aws.greengrass.device.exception.AuthenticationException;
-
-import java.util.Map;
+import com.aws.greengrass.device.session.credentials.Credential;
 
 public interface SessionFactory {
-    Session createSession(Map<String, String> credentialMap) throws AuthenticationException;
+    Session createSession(Credential credential) throws AuthenticationException;
 }

--- a/src/main/java/com/aws/greengrass/device/session/SessionManager.java
+++ b/src/main/java/com/aws/greengrass/device/session/SessionManager.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.device.session;
 
 import com.aws.greengrass.device.exception.AuthenticationException;
 import com.aws.greengrass.device.iot.Certificate;
+import com.aws.greengrass.device.session.credentials.Credential;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import lombok.AccessLevel;
@@ -44,11 +45,12 @@ public class SessionManager {
     /**
      * Creates session with certificate.
      *
-     * @deprecated Sessions should be created using device credentials instead of certificates
      * @param certificate Client device certificate
      * @return session id
+     * @deprecated Sessions should be created using device credentials instead of certificates
      */
-    @Deprecated public String createSession(Certificate certificate) {
+    @Deprecated
+    public String createSession(Certificate certificate) {
         Session session = new SessionImpl(certificate);
         return addSessionInternal(session);
     }
@@ -57,13 +59,13 @@ public class SessionManager {
      * Creates a session with device credentials.
      *
      * @param credentialType Device credential type
-     * @param credentialMap  Device credential map
+     * @param credential     Device credential map
      * @return session id
      * @throws AuthenticationException if device credentials were not able to be validated
      */
-    public String createSession(String credentialType, Map<String, String> credentialMap)
+    public String createSession(String credentialType, Credential credential)
             throws AuthenticationException {
-        Session session = SessionCreator.createSession(credentialType, credentialMap);
+        Session session = SessionCreator.createSession(credentialType, credential);
         return addSessionInternal(session);
     }
 

--- a/src/main/java/com/aws/greengrass/device/session/credentials/Credential.java
+++ b/src/main/java/com/aws/greengrass/device/session/credentials/Credential.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.device.session.credentials;
+
+public interface Credential {
+}

--- a/src/main/java/com/aws/greengrass/device/session/credentials/MqttCredential.java
+++ b/src/main/java/com/aws/greengrass/device/session/credentials/MqttCredential.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.device.session.credentials;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MqttCredential implements Credential {
+    String clientId;
+    String certificatePem;
+    String username;
+    String password;
+}

--- a/src/test/java/com/aws/greengrass/device/session/MqttSessionFactoryTest.java
+++ b/src/test/java/com/aws/greengrass/device/session/MqttSessionFactoryTest.java
@@ -7,18 +7,16 @@ package com.aws.greengrass.device.session;
 
 import com.aws.greengrass.device.exception.AuthenticationException;
 import com.aws.greengrass.device.iot.IotAuthClient;
+import com.aws.greengrass.device.session.credentials.MqttCredential;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.hamcrest.core.IsNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.utils.ImmutableMap;
 
-import java.util.Map;
-
-import org.hamcrest.core.IsNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -29,12 +27,7 @@ public class MqttSessionFactoryTest {
     @Mock
     private IotAuthClient mockIotAuthClient;
     private MqttSessionFactory mqttSessionFactory;
-    private final Map<String, String> credentialMap = ImmutableMap.of(
-            "certificatePem", "PEM",
-            "clientId", "clientId",
-            "username", "",
-            "password", ""
-    );
+    MqttCredential credentialMap = MqttCredential.builder().certificatePem("PEM").clientId("clientId").build();
 
     @BeforeEach
     void beforeEach() {

--- a/src/test/java/com/aws/greengrass/device/session/SessionCreatorTest.java
+++ b/src/test/java/com/aws/greengrass/device/session/SessionCreatorTest.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.device.session;
 
 import com.aws.greengrass.device.exception.AuthenticationException;
+import com.aws.greengrass.device.session.credentials.MqttCredential;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -13,8 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.HashMap;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -38,7 +37,7 @@ public class SessionCreatorTest {
     @Test
     void GIVEN_noRegisteredFactories_WHEN_createSession_THEN_throwsException() {
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> SessionCreator.createSession(mqttCredentialType, new HashMap<>()));
+                () -> SessionCreator.createSession(mqttCredentialType, new MqttCredential()));
     }
 
     @Test
@@ -48,13 +47,13 @@ public class SessionCreatorTest {
         when(mqttSessionFactory.createSession(any())).thenReturn(mockSession);
 
         SessionCreator.registerSessionFactory(mqttCredentialType, mqttSessionFactory);
-        assertThat(SessionCreator.createSession(mqttCredentialType, new HashMap<>()), is(mockSession));
+        assertThat(SessionCreator.createSession(mqttCredentialType, new MqttCredential()), is(mockSession));
     }
 
     @Test
     void GIVEN_registeredMqttSessionFactory_WHEN_createSession_WithNonMqttCredentials_THEN_throwsException() {
         SessionCreator.registerSessionFactory(mqttCredentialType, mqttSessionFactory);
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> SessionCreator.createSession(unknownCredentialType, new HashMap<>()));
+                () -> SessionCreator.createSession(unknownCredentialType, new MqttCredential()));
     }
 }

--- a/src/test/java/com/aws/greengrass/device/session/SessionManagerTest.java
+++ b/src/test/java/com/aws/greengrass/device/session/SessionManagerTest.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.device.session;
 
 
 import com.aws.greengrass.device.exception.AuthenticationException;
+import com.aws.greengrass.device.session.credentials.MqttCredential;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,9 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.utils.ImmutableMap;
-
-import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
@@ -36,24 +34,9 @@ class SessionManagerTest {
     private Session mockSession;
     @Mock
     private Session mockSession2;
-    private final Map<String, String> credentialMap = ImmutableMap.of(
-            "certificatePem", "PEM",
-            "clientId", "clientId",
-            "username", "",
-            "password", ""
-    );
-    private final Map<String, String> credentialMap2 = ImmutableMap.of(
-            "certificatePem", "PEM2",
-            "clientId", "clientId2",
-            "username", "",
-            "password", ""
-    );
-    private final Map<String, String> invalidCredentialMap = ImmutableMap.of(
-            "certificatePem", "BAD_PEM",
-            "clientId", "clientId2",
-            "username", "",
-            "password", ""
-    );
+    MqttCredential credentialMap = MqttCredential.builder().certificatePem("PEM").clientId("clientId").build();
+    MqttCredential credentialMap2 = MqttCredential.builder().certificatePem("PEM2").clientId("clientId2").build();
+    MqttCredential invalidCredentialMap = MqttCredential.builder().certificatePem("BAD_PEM").clientId("clientId2").build();
 
     @BeforeEach
     void beforeEach() throws AuthenticationException {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Use Credential and MqttCredential object instead of Map. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
