### PR TITLE
fix: begin VerifyClientDeviceIdentity conversion to async

### DIFF
--- a/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
@@ -49,9 +49,6 @@ import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;

--- a/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
@@ -46,6 +46,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
@@ -79,6 +85,13 @@ public class ClientDevicesAuthService extends PluginService {
     private final IotAuthClient iotAuthClient;
     private final SessionManager sessionManager;
     private final DeviceAuthClient deviceAuthClient;
+    // Limit the queue size before we start rejecting requests
+    // TODO: User configurable
+    private static final int CLOUD_CALL_QUEUE_SIZE = 100;
+    // Create a threadpool for calling the cloud. Single thread will be used.
+    // TODO: User configurable pool size
+    private final ThreadPoolExecutor cloudCallThreadPool = new ThreadPoolExecutor(1, 1, 60, TimeUnit.SECONDS,
+            new LinkedBlockingQueue<>(CLOUD_CALL_QUEUE_SIZE));
 
     /**
      * Constructor.
@@ -107,6 +120,7 @@ public class ClientDevicesAuthService extends PluginService {
                                     SessionManager sessionManager,
                                     DeviceAuthClient deviceAuthClient) {
         super(topics);
+        cloudCallThreadPool.allowCoreThreadTimeOut(true); // act as a cached threadpool
         this.groupManager = groupManager;
         this.certificateManager = certificateManager;
         this.clientFactory = clientFactory;
@@ -268,7 +282,7 @@ public class ClientDevicesAuthService extends PluginService {
                 new SubscribeToCertificateUpdatesOperationHandler(context, certificateManager, authorizationHandler));
         greengrassCoreIPCService.setVerifyClientDeviceIdentityHandler(context ->
                 new VerifyClientDeviceIdentityOperationHandler(context, iotAuthClient,
-                        authorizationHandler));
+                        authorizationHandler, cloudCallThreadPool));
         greengrassCoreIPCService.setGetClientDeviceAuthTokenHandler(context ->
                 new GetClientDeviceAuthTokenOperationHandler(context, sessionManager, authorizationHandler));
         greengrassCoreIPCService.setAuthorizeClientDeviceActionHandler(context ->


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Depends on https://github.com/aws-greengrass/aws-greengrass-nucleus/pull/1213

This PR requires an additional change to the OperationContinuationHandler in Nucleus in order to test fully successfully.
This change is the first step in changing VerifyClientDeviceIdentity to be asynchronous. It uses its own threadpool which has a limited thread count and queue size (1 and 100 respectively right now). It is only the first step because we will need to make the threadpool more configurable in addition to some cleanup logic and potentially caching.

**Why is this change necessary:**

**How was this change tested:**
All tests ran and passed on my mac with the required Nucleus change.

```
[INFO] Results:
[INFO]
[INFO] Tests run: 160, Failures: 0, Errors: 0, Skipped: 0
[INFO]
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
