### PR TITLE
feat: expose authz client device action over IPC

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/AuthorizeClientDeviceActionTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/AuthorizeClientDeviceActionTest.java
@@ -8,7 +8,7 @@ package com.aws.greengrass.integrationtests.ipc;
 import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.device.ClientDevicesAuthService;
 import com.aws.greengrass.device.DeviceAuthClient;
-import com.aws.greengrass.device.exception.AuthorizationException;
+import com.aws.greengrass.device.exception.InvalidSessionException;
 import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
@@ -68,8 +68,8 @@ class AuthorizeClientDeviceActionTest {
     private DeviceAuthClient deviceAuthClient;
 
     private static void authzClientDeviceAction(GreengrassCoreIPCClient ipcClient,
-                                               AuthorizeClientDeviceActionRequest request,
-                                               Consumer<AuthorizeClientDeviceActionResponse> consumer)
+                                                AuthorizeClientDeviceActionRequest request,
+                                                Consumer<AuthorizeClientDeviceActionResponse> consumer)
             throws Exception {
         AuthorizeClientDeviceActionResponseHandler handler =
                 ipcClient.authorizeClientDeviceAction(request, Optional.empty());
@@ -179,7 +179,7 @@ class AuthorizeClientDeviceActionTest {
     void GIVEN_brokerWithInvalidAuthToken_WHEN_AuthorizeClientDeviceAction_THEN_throwInvalidClientDeviceAuthTokenError
             (ExtensionContext context) throws Exception {
         kernel.getContext().put(DeviceAuthClient.class, deviceAuthClient);
-        ignoreExceptionOfType(context, AuthorizationException.class);
+        ignoreExceptionOfType(context, InvalidSessionException.class);
         startNucleusWithConfig("cda.yaml");
         try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
                 "BrokerWithAuthorizeClientDeviceActionPermission")) {
@@ -188,7 +188,7 @@ class AuthorizeClientDeviceActionTest {
                     .withOperation("some-action")
                     .withResource("some-resource")
                     .withClientDeviceAuthToken("some-invalid-token");
-            when(deviceAuthClient.canDevicePerform(any())).thenThrow(AuthorizationException.class);
+            when(deviceAuthClient.canDevicePerform(any())).thenThrow(InvalidSessionException.class);
             Exception err = assertThrows(Exception.class, () -> {
                 authzClientDeviceAction(ipcClient, request, null);
             });

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/AuthorizeClientDeviceActionTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/AuthorizeClientDeviceActionTest.java
@@ -215,12 +215,7 @@ class AuthorizeClientDeviceActionTest {
                     .withOperation("some-action")
                     .withResource("some-resource")
                     .withClientDeviceAuthToken("some-token");
-            AuthorizationRequest authzReq = AuthorizationRequest.builder()
-                    .sessionId(request.getClientDeviceAuthToken())
-                    .operation(request.getOperation())
-                    .resource(request.getResource())
-                    .build();
-            when(deviceAuthClient.canDevicePerform(authzReq)).thenThrow(IllegalArgumentException.class);
+            when(deviceAuthClient.canDevicePerform(any())).thenThrow(IllegalArgumentException.class);
             Exception err = assertThrows(Exception.class, () -> {
                 authzClientDeviceAction(ipcClient, request, null);
             });

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/AuthorizeClientDeviceActionTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/AuthorizeClientDeviceActionTest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.integrationtests.ipc;
+
+import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.device.ClientDevicesAuthService;
+import com.aws.greengrass.device.DeviceAuthClient;
+import com.aws.greengrass.device.exception.AuthorizationException;
+import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
+import com.aws.greengrass.lifecyclemanager.GreengrassService;
+import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.logging.impl.config.LogConfig;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.testcommons.testutilities.UniqueRootPathExtension;
+import com.aws.greengrass.util.GreengrassServiceClientFactory;
+import com.aws.greengrass.util.Pair;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.aws.greengrass.AuthorizeClientDeviceActionResponseHandler;
+import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCClient;
+import software.amazon.awssdk.aws.greengrass.model.AuthorizeClientDeviceActionRequest;
+import software.amazon.awssdk.aws.greengrass.model.AuthorizeClientDeviceActionResponse;
+import software.amazon.awssdk.aws.greengrass.model.InvalidArgumentsError;
+import software.amazon.awssdk.aws.greengrass.model.InvalidClientDeviceAuthTokenError;
+import software.amazon.awssdk.aws.greengrass.model.ServiceError;
+import software.amazon.awssdk.aws.greengrass.model.UnauthorizedError;
+import software.amazon.awssdk.eventstreamrpc.EventStreamRPCConnection;
+import software.amazon.awssdk.services.greengrassv2data.GreengrassV2DataClient;
+
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static com.aws.greengrass.testcommons.testutilities.TestUtils.asyncAssertOnConsumer;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({GGExtension.class, UniqueRootPathExtension.class, MockitoExtension.class})
+class AuthorizeClientDeviceActionTest {
+    private static GlobalStateChangeListener listener;
+    @TempDir
+    Path rootDir;
+    private Kernel kernel;
+    @Mock
+    private GreengrassServiceClientFactory clientFactory;
+    @Mock
+    private GreengrassV2DataClient client;
+    @Mock
+    private DeviceAuthClient deviceAuthClient;
+
+    private static void authzClientDeviceAction(GreengrassCoreIPCClient ipcClient,
+                                               AuthorizeClientDeviceActionRequest request,
+                                               Consumer<AuthorizeClientDeviceActionResponse> consumer)
+            throws Exception {
+        AuthorizeClientDeviceActionResponseHandler handler =
+                ipcClient.authorizeClientDeviceAction(request, Optional.empty());
+        AuthorizeClientDeviceActionResponse response = handler.getResponse().get(10, TimeUnit.SECONDS);
+        consumer.accept(response);
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        // Set this property for kernel to scan its own classpath to find plugins
+        System.setProperty("aws.greengrass.scanSelfClasspath", "true");
+        kernel = new Kernel();
+        kernel.getContext().put(GreengrassServiceClientFactory.class, clientFactory);
+
+        when(clientFactory.getGreengrassV2DataClient()).thenReturn(client);
+
+    }
+
+    private void startNucleusWithConfig(String configFileName) throws InterruptedException {
+        startNucleusWithConfig(configFileName, State.RUNNING);
+    }
+
+    private void startNucleusWithConfig(String configFileName, State expectedServiceState) throws InterruptedException {
+        CountDownLatch authServiceRunning = new CountDownLatch(1);
+        kernel.parseArgs("-r", rootDir.toAbsolutePath().toString(), "-i",
+                getClass().getResource(configFileName).toString());
+        listener = (GreengrassService service, State was, State newState) -> {
+            if (service.getName().equals(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME) &&
+                    service.getState().equals(expectedServiceState)) {
+                authServiceRunning.countDown();
+            }
+        };
+        kernel.getContext().addGlobalStateChangeListener(listener);
+        kernel.launch();
+        assertThat(authServiceRunning.await(30L, TimeUnit.SECONDS), is(true));
+        kernel.getContext().removeGlobalStateChangeListener(listener);
+    }
+
+    @AfterEach
+    void afterEach() {
+        LogConfig.getRootLogConfig().reset();
+        kernel.shutdown();
+    }
+
+    @Test
+    void GIVEN_brokerWithAuthorizedAction_WHEN_AuthorizeClientDeviceAction_THEN_returnTrue() throws Exception {
+        kernel.getContext().put(DeviceAuthClient.class, deviceAuthClient);
+        startNucleusWithConfig("cda.yaml");
+        try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
+                "BrokerWithAuthorizeClientDeviceActionPermission")) {
+            GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
+            AuthorizeClientDeviceActionRequest request = new AuthorizeClientDeviceActionRequest()
+                    .withOperation("some-action")
+                    .withResource("some-resource")
+                    .withClientDeviceAuthToken("some-token");
+            when(deviceAuthClient.canDevicePerform(any())).thenReturn(true);
+            Pair<CompletableFuture<Void>, Consumer<AuthorizeClientDeviceActionResponse>> cb =
+                    asyncAssertOnConsumer((m) -> {
+                        assertTrue(m.isIsAuthorized());
+                    });
+            authzClientDeviceAction(ipcClient, request, cb.getRight());
+            cb.getLeft().get(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void GIVEN_brokerWithUnauthorizedAction_WHEN_AuthorizeClientDeviceAction_THEN_returnFalse() throws Exception {
+        kernel.getContext().put(DeviceAuthClient.class, deviceAuthClient);
+        startNucleusWithConfig("cda.yaml");
+        try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
+                "BrokerWithAuthorizeClientDeviceActionPermission")) {
+            GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
+            AuthorizeClientDeviceActionRequest request = new AuthorizeClientDeviceActionRequest()
+                    .withOperation("some-invalid-action")
+                    .withResource("some-resource")
+                    .withClientDeviceAuthToken("some-token");
+            when(deviceAuthClient.canDevicePerform(any())).thenReturn(false);
+            Pair<CompletableFuture<Void>, Consumer<AuthorizeClientDeviceActionResponse>> cb =
+                    asyncAssertOnConsumer((m) -> {
+                        assertFalse(m.isIsAuthorized());
+                    });
+            authzClientDeviceAction(ipcClient, request, cb.getRight());
+            cb.getLeft().get(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void GIVEN_brokerWithInvalidAuthzRequest_WHEN_AuthorizeClientDeviceAction_THEN_throwInvalidArgumentsError()
+            throws Exception {
+        kernel.getContext().put(DeviceAuthClient.class, deviceAuthClient);
+        startNucleusWithConfig("cda.yaml");
+        try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
+                "BrokerWithAuthorizeClientDeviceActionPermission")) {
+            GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
+            AuthorizeClientDeviceActionRequest request = new AuthorizeClientDeviceActionRequest()
+                    .withOperation("some-action")
+                    .withResource(null)
+                    .withClientDeviceAuthToken("some-token");
+            Exception err = assertThrows(Exception.class, () -> {
+                authzClientDeviceAction(ipcClient, request, null);
+            });
+            assertEquals(err.getCause().getClass(), InvalidArgumentsError.class);
+        }
+    }
+
+    @Test
+    void GIVEN_brokerWithInvalidAuthToken_WHEN_AuthorizeClientDeviceAction_THEN_throwInvalidClientDeviceAuthTokenError
+            (ExtensionContext context) throws Exception {
+        kernel.getContext().put(DeviceAuthClient.class, deviceAuthClient);
+        ignoreExceptionOfType(context, AuthorizationException.class);
+        startNucleusWithConfig("cda.yaml");
+        try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
+                "BrokerWithAuthorizeClientDeviceActionPermission")) {
+            GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
+            AuthorizeClientDeviceActionRequest request = new AuthorizeClientDeviceActionRequest()
+                    .withOperation("some-action")
+                    .withResource("some-resource")
+                    .withClientDeviceAuthToken("some-invalid-token");
+            when(deviceAuthClient.canDevicePerform(any())).thenThrow(AuthorizationException.class);
+            Exception err = assertThrows(Exception.class, () -> {
+                authzClientDeviceAction(ipcClient, request, null);
+            });
+            assertEquals(err.getCause().getClass(), InvalidClientDeviceAuthTokenError.class);
+        }
+    }
+
+    @Test
+    void GIVEN_brokerWithValidAuthzRequest_WHEN_AuthorizeClientDeviceActionFails_THEN_throwServiceError
+            (ExtensionContext context) throws Exception {
+        kernel.getContext().put(DeviceAuthClient.class, deviceAuthClient);
+        ignoreExceptionOfType(context, IllegalArgumentException.class);
+        startNucleusWithConfig("cda.yaml");
+        try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
+                "BrokerWithAuthorizeClientDeviceActionPermission")) {
+            GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
+            AuthorizeClientDeviceActionRequest request = new AuthorizeClientDeviceActionRequest()
+                    .withOperation("some-action")
+                    .withResource("some-resource")
+                    .withClientDeviceAuthToken("some-token");
+            when(deviceAuthClient.canDevicePerform(any())).thenThrow(IllegalArgumentException.class);
+            Exception err = assertThrows(Exception.class, () -> {
+                authzClientDeviceAction(ipcClient, request, null);
+            });
+            assertEquals(err.getCause().getClass(), ServiceError.class);
+        }
+    }
+
+    @Test
+    void GIVEN_brokerWithNoCDAPolicyConfig_WHEN_AuthorizeClientDeviceAction_THEN_throwUnauthorizedError()
+            throws Exception {
+        kernel.getContext().put(DeviceAuthClient.class, deviceAuthClient);
+        startNucleusWithConfig("BrokerNotAuthorized.yaml");
+        try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
+                "BrokerWithNoConfig")) {
+            GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
+            AuthorizeClientDeviceActionRequest request = new AuthorizeClientDeviceActionRequest()
+                    .withOperation("some-action")
+                    .withResource("some-resource")
+                    .withClientDeviceAuthToken("some-token");
+            Exception err = assertThrows(Exception.class, () -> {
+                authzClientDeviceAction(ipcClient, request, null);
+            });
+            assertEquals(err.getCause().getClass(), UnauthorizedError.class);
+        }
+    }
+
+    @Test
+    void GIVEN_brokerWithMissingAuthzClientDeviceActionPermission_WHEN_AuthorizeClientDeviceAction_THEN_throwUnauthorizedError()
+            throws Exception {
+        kernel.getContext().put(DeviceAuthClient.class, deviceAuthClient);
+        startNucleusWithConfig("BrokerNotAuthorized.yaml");
+        try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
+                "BrokerMissingAuthorizeClientDeviceActionPolicy")) {
+            GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
+            AuthorizeClientDeviceActionRequest request = new AuthorizeClientDeviceActionRequest()
+                    .withOperation("some-action")
+                    .withResource("some-resource")
+                    .withClientDeviceAuthToken("some-token");
+            Exception err = assertThrows(Exception.class, () -> {
+                authzClientDeviceAction(ipcClient, request, null);
+            });
+            assertEquals(err.getCause().getClass(), UnauthorizedError.class);
+        }
+    }
+}

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/AuthorizeClientDeviceActionTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/AuthorizeClientDeviceActionTest.java
@@ -52,6 +52,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({GGExtension.class, UniqueRootPathExtension.class, MockitoExtension.class})
@@ -73,7 +74,7 @@ class AuthorizeClientDeviceActionTest {
             throws Exception {
         AuthorizeClientDeviceActionResponseHandler handler =
                 ipcClient.authorizeClientDeviceAction(request, Optional.empty());
-        AuthorizeClientDeviceActionResponse response = handler.getResponse().get(5, TimeUnit.SECONDS);
+        AuthorizeClientDeviceActionResponse response = handler.getResponse().get(1, TimeUnit.SECONDS);
         consumer.accept(response);
     }
 
@@ -136,7 +137,7 @@ class AuthorizeClientDeviceActionTest {
                         assertTrue(m.isIsAuthorized());
                     });
             authzClientDeviceAction(ipcClient, request, cb.getRight());
-            cb.getLeft().get(5, TimeUnit.SECONDS);
+            cb.getLeft().get(1, TimeUnit.SECONDS);
         }
     }
 
@@ -151,18 +152,13 @@ class AuthorizeClientDeviceActionTest {
                     .withOperation("some-invalid-action")
                     .withResource("some-resource")
                     .withClientDeviceAuthToken("some-token");
-            AuthorizationRequest authzReq = AuthorizationRequest.builder()
-                    .sessionId(request.getClientDeviceAuthToken())
-                    .operation(request.getOperation())
-                    .resource(request.getResource())
-                    .build();
-            when(deviceAuthClient.canDevicePerform(authzReq)).thenReturn(false);
+            when(deviceAuthClient.canDevicePerform(any())).thenReturn(false);
             Pair<CompletableFuture<Void>, Consumer<AuthorizeClientDeviceActionResponse>> cb =
                     asyncAssertOnConsumer((m) -> {
                         assertFalse(m.isIsAuthorized());
                     });
             authzClientDeviceAction(ipcClient, request, cb.getRight());
-            cb.getLeft().get(5, TimeUnit.SECONDS);
+            cb.getLeft().get(1, TimeUnit.SECONDS);
         }
     }
 
@@ -198,12 +194,7 @@ class AuthorizeClientDeviceActionTest {
                     .withOperation("some-action")
                     .withResource("some-resource")
                     .withClientDeviceAuthToken("some-invalid-token");
-            AuthorizationRequest authzReq = AuthorizationRequest.builder()
-                    .sessionId(request.getClientDeviceAuthToken())
-                    .operation(request.getOperation())
-                    .resource(request.getResource())
-                    .build();
-            when(deviceAuthClient.canDevicePerform(authzReq)).thenThrow(InvalidSessionException.class);
+            when(deviceAuthClient.canDevicePerform(any())).thenThrow(InvalidSessionException.class);
             Exception err = assertThrows(Exception.class, () -> {
                 authzClientDeviceAction(ipcClient, request, null);
             });

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/ipc/BrokerNotAuthorized.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/ipc/BrokerNotAuthorized.yaml
@@ -36,6 +36,7 @@ services:
     dependencies:
       - BrokerWithNoConfig
       - BrokerMissingGetClientDeviceAuthTokenPolicy
+      - BrokerMissingAuthorizeClientDeviceActionPolicy
   BrokerWithNoConfig:
     dependencies:
       - aws.greengrass.clientdevices.Auth
@@ -68,6 +69,25 @@ services:
       accessControl:
         aws.greengrass.clientdevices.Auth:
           policyId1:BrokerMissingGetClientDeviceAuthTokenPolicy:
+            policyDescription: access to certificate updates
+            operations:
+              - 'aws.greengrass#VerifyClientDeviceIdentity'
+            resources:
+              - '*'
+
+  BrokerMissingAuthorizeClientDeviceActionPolicy:
+    dependencies:
+      - aws.greengrass.clientdevices.Auth
+    lifecycle:
+      run:
+        windows:
+          powershell -command sleep 1
+        posix:
+          sleep 1
+    configuration:
+      accessControl:
+        aws.greengrass.clientdevices.Auth:
+          policyId1:BrokerMissingAuthorizeClientDeviceActionPolicy:
             policyDescription: access to certificate updates
             operations:
               - 'aws.greengrass#VerifyClientDeviceIdentity'

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/ipc/cda.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/ipc/cda.yaml
@@ -37,6 +37,7 @@ services:
       - BrokerSubscribingToCertUpdates
       - Broker2SubscribingToCertUpdates
       - BrokerWithGetClientDeviceAuthTokenPermission
+      - BrokerWithAuthorizeClientDeviceActionPermission
   BrokerSubscribingToCertUpdates:
     dependencies:
       - aws.greengrass.clientdevices.Auth
@@ -104,5 +105,23 @@ services:
             policyDescription: access to certificate updates
             operations:
               - 'aws.greengrass#GetClientDeviceAuthToken'
+            resources:
+              - '*'
+  BrokerWithAuthorizeClientDeviceActionPermission:
+    dependencies:
+      - aws.greengrass.clientdevices.Auth
+    lifecycle:
+      run:
+        windows:
+          powershell -command sleep 1
+        posix:
+          sleep 1
+    configuration:
+      accessControl:
+        aws.greengrass.clientdevices.Auth:
+          BrokerWithAuthorizeClientDeviceActionPermission:
+            policyDescription: access to certificate updates
+            operations:
+              - 'aws.greengrass#AuthorizeClientDeviceAction'
             resources:
               - '*'

--- a/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
@@ -22,6 +22,7 @@ import com.aws.greengrass.device.iot.IotAuthClient;
 import com.aws.greengrass.device.session.MqttSessionFactory;
 import com.aws.greengrass.device.session.SessionCreator;
 import com.aws.greengrass.device.session.SessionManager;
+import com.aws.greengrass.ipc.AuthorizeClientDeviceActionOperationHandler;
 import com.aws.greengrass.ipc.GetClientDeviceAuthTokenOperationHandler;
 import com.aws.greengrass.ipc.SubscribeToCertificateUpdatesOperationHandler;
 import com.aws.greengrass.ipc.VerifyClientDeviceIdentityOperationHandler;
@@ -77,6 +78,7 @@ public class ClientDevicesAuthService extends PluginService {
     private final GreengrassCoreIPCService greengrassCoreIPCService;
     private final IotAuthClient iotAuthClient;
     private final SessionManager sessionManager;
+    private final DeviceAuthClient deviceAuthClient;
 
     /**
      * Constructor.
@@ -90,7 +92,8 @@ public class ClientDevicesAuthService extends PluginService {
      * @param greengrassCoreIPCService core IPC service
      * @param mqttSessionFactory       session factory to handling mqtt credentials
      * @param iotAuthClient            iot auth client
-     * @param sessionManager session manager
+     * @param sessionManager           session manager
+     * @param deviceAuthClient         device auth client
      */
     @SuppressWarnings("PMD.ExcessiveParameterList")
     @Inject
@@ -101,7 +104,8 @@ public class ClientDevicesAuthService extends PluginService {
                                     GreengrassCoreIPCService greengrassCoreIPCService,
                                     MqttSessionFactory mqttSessionFactory,
                                     IotAuthClient iotAuthClient,
-                                    SessionManager sessionManager) {
+                                    SessionManager sessionManager,
+                                    DeviceAuthClient deviceAuthClient) {
         super(topics);
         this.groupManager = groupManager;
         this.certificateManager = certificateManager;
@@ -111,6 +115,7 @@ public class ClientDevicesAuthService extends PluginService {
         this.greengrassCoreIPCService = greengrassCoreIPCService;
         this.iotAuthClient = iotAuthClient;
         this.sessionManager = sessionManager;
+        this.deviceAuthClient = deviceAuthClient;
         SessionCreator.registerSessionFactory("mqtt", mqttSessionFactory);
         certificateManager.updateCertificatesConfiguration(new CertificatesConfig(this.getConfig()));
     }
@@ -266,5 +271,7 @@ public class ClientDevicesAuthService extends PluginService {
                         authorizationHandler));
         greengrassCoreIPCService.setGetClientDeviceAuthTokenHandler(context ->
                 new GetClientDeviceAuthTokenOperationHandler(context, sessionManager, authorizationHandler));
+        greengrassCoreIPCService.setAuthorizeClientDeviceActionHandler(context ->
+                new AuthorizeClientDeviceActionOperationHandler(context, deviceAuthClient, authorizationHandler));
     }
 }

--- a/src/main/java/com/aws/greengrass/device/DeviceAuthClient.java
+++ b/src/main/java/com/aws/greengrass/device/DeviceAuthClient.java
@@ -8,8 +8,8 @@ package com.aws.greengrass.device;
 import com.aws.greengrass.certificatemanager.certificate.CertificateStore;
 import com.aws.greengrass.device.configuration.GroupManager;
 import com.aws.greengrass.device.exception.AuthenticationException;
-import com.aws.greengrass.device.exception.AuthorizationException;
 import com.aws.greengrass.device.exception.CloudServiceInteractionException;
+import com.aws.greengrass.device.exception.InvalidSessionException;
 import com.aws.greengrass.device.iot.Certificate;
 import com.aws.greengrass.device.iot.IotAuthClient;
 import com.aws.greengrass.device.iot.Thing;
@@ -51,9 +51,9 @@ public class DeviceAuthClient {
     /**
      * Constructor.
      *
-     * @param sessionManager Session manager
-     * @param groupManager   Group manager
-     * @param iotAuthClient  Iot auth client
+     * @param sessionManager   Session manager
+     * @param groupManager     Group manager
+     * @param iotAuthClient    Iot auth client
      * @param certificateStore Certificate store
      */
     @Inject
@@ -196,9 +196,9 @@ public class DeviceAuthClient {
      *
      * @param request authorization request including operation, resource, sessionId, clientId
      * @return if device is authorized
-     * @throws AuthorizationException if session is invalid
+     * @throws InvalidSessionException if session is invalid
      */
-    public boolean canDevicePerform(AuthorizationRequest request) throws AuthorizationException {
+    public boolean canDevicePerform(AuthorizationRequest request) throws InvalidSessionException {
         logger.atDebug()
                 .kv("sessionId", request.getSessionId())
                 .kv("action", request.getOperation())
@@ -212,7 +212,7 @@ public class DeviceAuthClient {
 
         Session session = sessionManager.findSession(request.getSessionId());
         if (session == null) {
-            throw new AuthorizationException(
+            throw new InvalidSessionException(
                     String.format("Invalid session ID (%s)", request.getSessionId()));
         }
 

--- a/src/main/java/com/aws/greengrass/device/DeviceAuthClient.java
+++ b/src/main/java/com/aws/greengrass/device/DeviceAuthClient.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.device;
 import com.aws.greengrass.certificatemanager.certificate.CertificateStore;
 import com.aws.greengrass.device.configuration.GroupManager;
 import com.aws.greengrass.device.exception.AuthenticationException;
+import com.aws.greengrass.device.exception.AuthorizationException;
 import com.aws.greengrass.device.exception.CloudServiceInteractionException;
 import com.aws.greengrass.device.exception.InvalidSessionException;
 import com.aws.greengrass.device.iot.Certificate;
@@ -196,9 +197,9 @@ public class DeviceAuthClient {
      *
      * @param request authorization request including operation, resource, sessionId, clientId
      * @return if device is authorized
-     * @throws InvalidSessionException if session is invalid
+     * @throws AuthorizationException if session is invalid
      */
-    public boolean canDevicePerform(AuthorizationRequest request) throws InvalidSessionException {
+    public boolean canDevicePerform(AuthorizationRequest request) throws AuthorizationException {
         logger.atDebug()
                 .kv("sessionId", request.getSessionId())
                 .kv("action", request.getOperation())

--- a/src/main/java/com/aws/greengrass/device/exception/AuthenticationException.java
+++ b/src/main/java/com/aws/greengrass/device/exception/AuthenticationException.java
@@ -7,7 +7,7 @@ package com.aws.greengrass.device.exception;
 
 public class AuthenticationException extends Exception {
 
-    static final long serialVersionUID = -1L;
+    private static final long serialVersionUID = -1L;
 
     public AuthenticationException(String message) {
         super(message);

--- a/src/main/java/com/aws/greengrass/device/exception/AuthorizationException.java
+++ b/src/main/java/com/aws/greengrass/device/exception/AuthorizationException.java
@@ -7,7 +7,7 @@ package com.aws.greengrass.device.exception;
 
 public class AuthorizationException extends Exception {
 
-    static final long serialVersionUID = -1L;
+    private static final long serialVersionUID = -1L;
 
     public AuthorizationException(String message) {
         super(message);

--- a/src/main/java/com/aws/greengrass/device/exception/CloudServiceInteractionException.java
+++ b/src/main/java/com/aws/greengrass/device/exception/CloudServiceInteractionException.java
@@ -7,7 +7,7 @@ package com.aws.greengrass.device.exception;
 
 public class CloudServiceInteractionException extends RuntimeException {
 
-    static final long serialVersionUID = -1L;
+    private static final long serialVersionUID = -1L;
 
     public CloudServiceInteractionException(String message) {
         super(message);

--- a/src/main/java/com/aws/greengrass/device/exception/InvalidSessionException.java
+++ b/src/main/java/com/aws/greengrass/device/exception/InvalidSessionException.java
@@ -5,7 +5,7 @@
 
 package com.aws.greengrass.device.exception;
 
-public class InvalidSessionException extends Exception {
+public class InvalidSessionException extends AuthorizationException {
     static final long serialVersionUID = -1L;
 
     public InvalidSessionException(String message) {

--- a/src/main/java/com/aws/greengrass/device/exception/InvalidSessionException.java
+++ b/src/main/java/com/aws/greengrass/device/exception/InvalidSessionException.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.device.exception;
 
 public class InvalidSessionException extends Exception {

--- a/src/main/java/com/aws/greengrass/device/exception/InvalidSessionException.java
+++ b/src/main/java/com/aws/greengrass/device/exception/InvalidSessionException.java
@@ -6,7 +6,7 @@
 package com.aws.greengrass.device.exception;
 
 public class InvalidSessionException extends AuthorizationException {
-    static final long serialVersionUID = -1L;
+    private static final long serialVersionUID = -1L;
 
     public InvalidSessionException(String message) {
         super(message);

--- a/src/main/java/com/aws/greengrass/device/exception/InvalidSessionException.java
+++ b/src/main/java/com/aws/greengrass/device/exception/InvalidSessionException.java
@@ -1,0 +1,17 @@
+package com.aws.greengrass.device.exception;
+
+public class InvalidSessionException extends Exception {
+    static final long serialVersionUID = -1L;
+
+    public InvalidSessionException(String message) {
+        super(message);
+    }
+
+    public InvalidSessionException(Throwable e) {
+        super(e);
+    }
+
+    public InvalidSessionException(String message, Throwable e) {
+        super(message, e);
+    }
+}

--- a/src/main/java/com/aws/greengrass/ipc/AuthorizeClientDeviceActionOperationHandler.java
+++ b/src/main/java/com/aws/greengrass/ipc/AuthorizeClientDeviceActionOperationHandler.java
@@ -12,6 +12,7 @@ import com.aws.greengrass.authorization.exceptions.AuthorizationException;
 import com.aws.greengrass.device.AuthorizationRequest;
 import com.aws.greengrass.device.ClientDevicesAuthService;
 import com.aws.greengrass.device.DeviceAuthClient;
+import com.aws.greengrass.device.exception.InvalidSessionException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.util.Utils;
@@ -44,7 +45,7 @@ public class AuthorizeClientDeviceActionOperationHandler
      * Constructor.
      *
      * @param context              operation continuation handler
-     * @param deviceAuthClient device auth client
+     * @param deviceAuthClient     device auth client
      * @param authorizationHandler authorization handler
      */
     public AuthorizeClientDeviceActionOperationHandler(
@@ -75,7 +76,7 @@ public class AuthorizeClientDeviceActionOperationHandler
                 boolean isAuthorized = deviceAuthClient.canDevicePerform(authorizationRequest);
                 AuthorizeClientDeviceActionResponse response = new AuthorizeClientDeviceActionResponse();
                 return response.withIsAuthorized(isAuthorized);
-            }  catch (com.aws.greengrass.device.exception.AuthorizationException e) {
+            } catch (InvalidSessionException e) {
                 logger.atError().cause(e).log("Unable to find a valid session with the given auth token");
                 throw new InvalidClientDeviceAuthTokenError(
                         "Unable to find a valid session with the given auth token. Check Greengrass log for details.");

--- a/src/main/java/com/aws/greengrass/ipc/AuthorizeClientDeviceActionOperationHandler.java
+++ b/src/main/java/com/aws/greengrass/ipc/AuthorizeClientDeviceActionOperationHandler.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.ipc;
+
+
+import com.aws.greengrass.authorization.AuthorizationHandler;
+import com.aws.greengrass.authorization.Permission;
+import com.aws.greengrass.authorization.exceptions.AuthorizationException;
+import com.aws.greengrass.device.AuthorizationRequest;
+import com.aws.greengrass.device.ClientDevicesAuthService;
+import com.aws.greengrass.device.DeviceAuthClient;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.util.Utils;
+import software.amazon.awssdk.aws.greengrass.GeneratedAbstractAuthorizeClientDeviceActionOperationHandler;
+import software.amazon.awssdk.aws.greengrass.model.AuthorizeClientDeviceActionRequest;
+import software.amazon.awssdk.aws.greengrass.model.AuthorizeClientDeviceActionResponse;
+import software.amazon.awssdk.aws.greengrass.model.InvalidArgumentsError;
+import software.amazon.awssdk.aws.greengrass.model.InvalidClientDeviceAuthTokenError;
+import software.amazon.awssdk.aws.greengrass.model.ServiceError;
+import software.amazon.awssdk.aws.greengrass.model.UnauthorizedError;
+import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
+import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
+
+import static com.aws.greengrass.ipc.common.ExceptionUtil.translateExceptions;
+import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.AUTHORIZE_CLIENT_DEVICE_ACTION;
+
+public class AuthorizeClientDeviceActionOperationHandler
+        extends GeneratedAbstractAuthorizeClientDeviceActionOperationHandler {
+    private static final Logger logger = LogManager.getLogger(AuthorizeClientDeviceActionOperationHandler.class);
+    private static final String COMPONENT_NAME = "componentName";
+    private static final String UNAUTHORIZED_ERROR = "Not Authorized";
+    private static final String NO_AUTH_TOKEN_ERROR = "Auth token is required";
+    private static final String NO_OPERATION_ERROR = "Mqtt operation is required";
+    private static final String NO_RESOURCE_ERROR = "Mqtt resource is required";
+    private final String serviceName;
+    private final AuthorizationHandler authorizationHandler;
+    private final DeviceAuthClient deviceAuthClient;
+
+    /**
+     * Constructor.
+     *
+     * @param context              operation continuation handler
+     * @param deviceAuthClient device auth client
+     * @param authorizationHandler authorization handler
+     */
+    public AuthorizeClientDeviceActionOperationHandler(
+            OperationContinuationHandlerContext context,
+            DeviceAuthClient deviceAuthClient,
+            AuthorizationHandler authorizationHandler
+
+    ) {
+
+        super(context);
+        serviceName = context.getAuthenticationData().getIdentityLabel();
+        this.authorizationHandler = authorizationHandler;
+        this.deviceAuthClient = deviceAuthClient;
+    }
+
+    @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.PreserveStackTrace"})
+    @Override
+    public AuthorizeClientDeviceActionResponse handleRequest(AuthorizeClientDeviceActionRequest request) {
+        return translateExceptions(() -> {
+            try {
+                doAuthorizationForClientDevAction();
+            } catch (AuthorizationException e) {
+                logger.atWarn().kv("error", e.getMessage()).kv(COMPONENT_NAME, serviceName).log(UNAUTHORIZED_ERROR);
+                throw new UnauthorizedError(e.getMessage());
+            }
+            AuthorizationRequest authorizationRequest = getAuthzRequest(request);
+            try {
+                boolean isAuthorized = deviceAuthClient.canDevicePerform(authorizationRequest);
+                AuthorizeClientDeviceActionResponse response = new AuthorizeClientDeviceActionResponse();
+                return response.withIsAuthorized(isAuthorized);
+            }  catch (com.aws.greengrass.device.exception.AuthorizationException e) {
+                logger.atError().cause(e).log("Unable to find a valid session with the given auth token");
+                throw new InvalidClientDeviceAuthTokenError(
+                        "Unable to find a valid session with the given auth token. Check Greengrass log for details.");
+            } catch (Exception e) {
+                logger.atError().cause(e).log("Unable to authorize the client device action");
+                throw new ServiceError(
+                        "Authorizing client device action failed. Check Greengrass log for details.");
+            }
+        });
+    }
+
+    private void doAuthorizationForClientDevAction() throws AuthorizationException {
+        authorizationHandler.isAuthorized(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME,
+                Permission.builder()
+                        .principal(serviceName)
+                        .operation(AUTHORIZE_CLIENT_DEVICE_ACTION)
+                        .resource("*")
+                        .build());
+    }
+
+
+    private AuthorizationRequest getAuthzRequest(AuthorizeClientDeviceActionRequest request) {
+        validateRequest(request);
+        return AuthorizationRequest.builder()
+                .sessionId(request.getClientDeviceAuthToken())
+                .operation(request.getOperation())
+                .resource(request.getResource())
+                .build();
+    }
+
+    private void validateRequest(AuthorizeClientDeviceActionRequest request) {
+        if (Utils.isEmpty(request.getClientDeviceAuthToken())) {
+            throw new InvalidArgumentsError(NO_AUTH_TOKEN_ERROR);
+        }
+        if (Utils.isEmpty(request.getOperation())) {
+            throw new InvalidArgumentsError(NO_OPERATION_ERROR);
+        }
+        if (Utils.isEmpty(request.getResource())) {
+            throw new InvalidArgumentsError(NO_RESOURCE_ERROR);
+        }
+    }
+
+    @Override
+    public void handleStreamEvent(EventStreamJsonMessage eventStreamJsonMessage) {
+
+    }
+
+    @Override
+    protected void onStreamClosed() {
+
+    }
+
+}

--- a/src/main/java/com/aws/greengrass/ipc/AuthorizeClientDeviceActionOperationHandler.java
+++ b/src/main/java/com/aws/greengrass/ipc/AuthorizeClientDeviceActionOperationHandler.java
@@ -77,7 +77,7 @@ public class AuthorizeClientDeviceActionOperationHandler
                 AuthorizeClientDeviceActionResponse response = new AuthorizeClientDeviceActionResponse();
                 return response.withIsAuthorized(isAuthorized);
             } catch (InvalidSessionException e) {
-                logger.atError().cause(e).log("Unable to find a valid session with the given auth token");
+                logger.atError().log("Unable to find a valid session with the given auth token");
                 throw new InvalidClientDeviceAuthTokenError(
                         "Unable to find a valid session with the given auth token. Check Greengrass log for details.");
             } catch (Exception e) {

--- a/src/main/java/com/aws/greengrass/ipc/AuthorizeClientDeviceActionOperationHandler.java
+++ b/src/main/java/com/aws/greengrass/ipc/AuthorizeClientDeviceActionOperationHandler.java
@@ -36,7 +36,7 @@ public class AuthorizeClientDeviceActionOperationHandler
     private static final String UNAUTHORIZED_ERROR = "Not Authorized";
     private static final String NO_AUTH_TOKEN_ERROR = "Auth token is required";
     private static final String NO_OPERATION_ERROR = "Operation is required";
-    private static final String NO_RESOURCE_ERROR = "Mqtt resource is required";
+    private static final String NO_RESOURCE_ERROR = "Resource is required";
     private final String serviceName;
     private final AuthorizationHandler authorizationHandler;
     private final DeviceAuthClient deviceAuthClient;

--- a/src/main/java/com/aws/greengrass/ipc/AuthorizeClientDeviceActionOperationHandler.java
+++ b/src/main/java/com/aws/greengrass/ipc/AuthorizeClientDeviceActionOperationHandler.java
@@ -35,7 +35,7 @@ public class AuthorizeClientDeviceActionOperationHandler
     private static final String COMPONENT_NAME = "componentName";
     private static final String UNAUTHORIZED_ERROR = "Not Authorized";
     private static final String NO_AUTH_TOKEN_ERROR = "Auth token is required";
-    private static final String NO_OPERATION_ERROR = "Mqtt operation is required";
+    private static final String NO_OPERATION_ERROR = "Operation is required";
     private static final String NO_RESOURCE_ERROR = "Mqtt resource is required";
     private final String serviceName;
     private final AuthorizationHandler authorizationHandler;
@@ -77,11 +77,11 @@ public class AuthorizeClientDeviceActionOperationHandler
                 AuthorizeClientDeviceActionResponse response = new AuthorizeClientDeviceActionResponse();
                 return response.withIsAuthorized(isAuthorized);
             } catch (InvalidSessionException e) {
-                logger.atError().log("Unable to find a valid session with the given auth token");
+                logger.atWarn().log("Unable to find a valid session with the given auth token");
                 throw new InvalidClientDeviceAuthTokenError(
                         "Unable to find a valid session with the given auth token. Check Greengrass log for details.");
             } catch (Exception e) {
-                logger.atError().cause(e).log("Unable to authorize the client device action");
+                logger.atError().cause(e).log("Unhandled exception while authorizing client device action");
                 throw new ServiceError(
                         "Authorizing client device action failed. Check Greengrass log for details.");
             }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This change exposes authorizing client device action over IPC. Returns either True or False if a valid session exists and is able to authorize certain operation on a resource. 
If a valid session is not found, then `InvalidClientDeviceAuthTokenError` is thrown. 
For all other exceptions, `ServiceError` is thrown.

**Why is this change necessary:**
Needed for mqtt5/byob  integration. 

**How was this change tested:**
Added integrations tests. 

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
