### PR TITLE
fix: add state to update shadow request

### DIFF
--- a/src/main/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitor.java
+++ b/src/main/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitor.java
@@ -261,7 +261,7 @@ public class CISShadowMonitor {
                 lastVersion = newVersion;
             }
         }, executorService).exceptionally(e -> {
-            LOGGER.atError().kv(VERSION, newVersion).cause(e).log("Unable to handle cis shadow delta");
+            LOGGER.atError().kv(VERSION, newVersion).cause(e).log("Unable to handle CIS shadow delta");
             return null;
         });
     }

--- a/src/main/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitor.java
+++ b/src/main/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitor.java
@@ -267,7 +267,7 @@ public class CISShadowMonitor {
     }
 
     private CompletableFuture<Integer> reportVersion(int version) {
-        LOGGER.atInfo().kv(VERSION, version).log("Reporting version");
+        LOGGER.atInfo().kv(VERSION, version).log("Reporting CIS version");
         UpdateShadowRequest updateShadowRequest = new UpdateShadowRequest();
         updateShadowRequest.thingName = shadowName;
         updateShadowRequest.version = version;

--- a/src/main/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitor.java
+++ b/src/main/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitor.java
@@ -234,7 +234,7 @@ public class CISShadowMonitor {
                 RetryUtils.runWithRetry(GET_CONNECTIVITY_RETRY_CONFIG, connectivityInfoProvider::getConnectivityInfo,
                         "get-connectivity", LOGGER);
             } catch (InterruptedException e) {
-                LOGGER.atWarn().kv(VERSION, version).cause(e)
+                LOGGER.atDebug().kv(VERSION, version).cause(e)
                         .log("Retry workflow for getting connectivity info interrupted");
                 Thread.currentThread().interrupt();
                 return;

--- a/src/main/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitor.java
+++ b/src/main/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitor.java
@@ -45,10 +45,11 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.inject.Inject;
 
-@SuppressWarnings({"PMD.ImmutableField", "PMD.AvoidDuplicateLiterals"})
+@SuppressWarnings("PMD.ImmutableField")
 public class CISShadowMonitor {
     private static final Logger LOGGER = LogManager.getLogger(CISShadowMonitor.class);
     private static final String CIS_SHADOW_SUFFIX = "-gci";
+    private static final String VERSION = "version";
     private static final long TIMEOUT_FOR_SUBSCRIBING_TO_TOPICS_SECONDS = Duration.ofMinutes(1).getSeconds();
     private static final long WAIT_TIME_TO_SUBSCRIBE_AGAIN_IN_MS = Duration.ofMinutes(2).toMillis();
     private static final Random JITTER = new Random();
@@ -210,7 +211,7 @@ public class CISShadowMonitor {
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
     private synchronized void handleNewCloudVersion(int newVersion) {
         if (newVersion == lastVersion) {
-            LOGGER.atInfo().kv("version", newVersion).log("Already processed version. Skipping cert re-generation");
+            LOGGER.atInfo().kv(VERSION, newVersion).log("Already processed version. Skipping cert re-generation");
             return;
         }
 
@@ -252,14 +253,14 @@ public class CISShadowMonitor {
                     reportVersion(version);
                 } catch (ExecutionException e) {
                     Throwable cause = e.getCause() == null ? e : e.getCause();
-                    LOGGER.atWarn().kv("version", version).cause(cause).log("Unable to report CIS shadow version");
+                    LOGGER.atWarn().kv(VERSION, version).cause(cause).log("Unable to report CIS shadow version");
                 } catch (TimeoutException e) {
-                    LOGGER.atWarn().kv("version", version).log("Timed out while reporting CIS shadow version");
+                    LOGGER.atWarn().kv(VERSION, version).log("Timed out while reporting CIS shadow version");
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
-                    LOGGER.atWarn().kv("version", version).log("Interrupted while reporting CIS shadow version");
+                    LOGGER.atWarn().kv(VERSION, version).log("Interrupted while reporting CIS shadow version");
                 } catch (Exception e) {
-                    LOGGER.atWarn().kv("version", version).cause(e).log("Unable to report CIS shadow version");
+                    LOGGER.atWarn().kv(VERSION, version).cause(e).log("Unable to report CIS shadow version");
                 } finally {
                     lastVersion = version;
                 }
@@ -270,7 +271,7 @@ public class CISShadowMonitor {
     }
 
     private void reportVersion(int version) throws ExecutionException, InterruptedException, TimeoutException {
-        LOGGER.atInfo().kv("version", version).log("Reporting version");
+        LOGGER.atInfo().kv(VERSION, version).log("Reporting version");
         UpdateShadowRequest updateShadowRequest = new UpdateShadowRequest();
         updateShadowRequest.thingName = shadowName;
         updateShadowRequest.version = version;

--- a/src/main/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitor.java
+++ b/src/main/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitor.java
@@ -256,6 +256,7 @@ public class CISShadowMonitor {
                 } catch (TimeoutException e) {
                     LOGGER.atWarn().kv("version", version).log("Timed out while reporting CIS shadow version");
                 } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
                     LOGGER.atWarn().kv("version", version).log("Interrupted while reporting CIS shadow version");
                 } catch (Exception e) {
                     LOGGER.atWarn().kv("version", version).cause(e).log("Unable to report CIS shadow version");

--- a/src/main/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitor.java
+++ b/src/main/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitor.java
@@ -175,7 +175,8 @@ public class CISShadowMonitor {
                 iotShadowClient.SubscribeToShadowDeltaUpdatedEvents(shadowDeltaUpdatedSubscriptionRequest,
                                 QualityOfService.AT_LEAST_ONCE,
                                 this::processCISShadow,
-                                (e) -> LOGGER.atError().log("Error processing shadowDeltaUpdatedSubscription Response", e))
+                                (e) -> LOGGER.atError()
+                                        .log("Error processing shadowDeltaUpdatedSubscription Response", e))
                         .get(TIMEOUT_FOR_SUBSCRIBING_TO_TOPICS_SECONDS, TimeUnit.SECONDS);
                 LOGGER.info("Subscribed to shadow update delta topic");
 
@@ -184,7 +185,8 @@ public class CISShadowMonitor {
                 iotShadowClient.SubscribeToGetShadowAccepted(getShadowSubscriptionRequest,
                                 QualityOfService.AT_LEAST_ONCE,
                                 this::processCISShadow,
-                                (e) -> LOGGER.atError().log("Error processing getShadowSubscription Response", e))
+                                (e) -> LOGGER.atError()
+                                        .log("Error processing getShadowSubscription Response", e))
                         .get(TIMEOUT_FOR_SUBSCRIBING_TO_TOPICS_SECONDS, TimeUnit.SECONDS);
                 LOGGER.info("Subscribed to shadow get accepted topic");
                 return;

--- a/src/main/java/com/aws/greengrass/cisclient/ConnectivityInfoProvider.java
+++ b/src/main/java/com/aws/greengrass/cisclient/ConnectivityInfoProvider.java
@@ -31,7 +31,7 @@ public class ConnectivityInfoProvider {
     private final DeviceConfiguration deviceConfiguration;
     private final GreengrassServiceClientFactory clientFactory;
 
-    private volatile List<String> cachedHostAddresses = Collections.emptyList();
+    protected volatile List<String> cachedHostAddresses = Collections.emptyList();
 
     /**
      * Constructor.

--- a/src/test/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitorTest.java
+++ b/src/test/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitorTest.java
@@ -143,7 +143,7 @@ public class CISShadowMonitorTest {
 
         assertTrue(shadowUpdated.await(5L, TimeUnit.SECONDS));
 
-        verify(certificateGenerator).generateCertificate(any(), any());
+        verify(certificateGenerator, times(1)).generateCertificate(any(), any());
     }
 
     @Test
@@ -156,7 +156,7 @@ public class CISShadowMonitorTest {
         publishDesiredShadowState(Utils.immutableMap("newState", 1));
 
         assertTrue(shadowDeltaUpdated.await(5L, TimeUnit.SECONDS));
-        verify(certificateGenerator).generateCertificate(any(), any());
+        verify(certificateGenerator, times(1)).generateCertificate(any(), any());
     }
 
     @Test
@@ -188,7 +188,7 @@ public class CISShadowMonitorTest {
         publishDesiredShadowState(Utils.immutableMap("newState", 1));
 
         assertTrue(shadowDeltaUpdated.await(5L, TimeUnit.SECONDS));
-        verify(certificateGenerator).generateCertificate(any(), any());
+        verify(certificateGenerator, times(1)).generateCertificate(any(), any());
     }
 
     @Test
@@ -227,7 +227,7 @@ public class CISShadowMonitorTest {
         publishDesiredShadowState(Utils.immutableMap("newState", 1));
 
         assertTrue(shadowDeltaUpdated.await(5L, TimeUnit.SECONDS));
-        verify(certificateGenerator).generateCertificate(any(), any());
+        verify(certificateGenerator, times(1)).generateCertificate(any(), any());
     }
 
     @Test
@@ -301,7 +301,7 @@ public class CISShadowMonitorTest {
         publishDesiredShadowState(Utils.immutableMap("newState", 2));
 
         assertTrue(shadowDeltaUpdated.await(5L, TimeUnit.SECONDS));
-        verify(certificateGenerator).generateCertificate(any(), any());
+        verify(certificateGenerator, times(1)).generateCertificate(any(), any());
     }
 
     @Test
@@ -338,19 +338,19 @@ public class CISShadowMonitorTest {
 
     private void verifyGetShadowAcceptedSubscription() {
         ArgumentCaptor<GetShadowSubscriptionRequest> request = ArgumentCaptor.forClass(GetShadowSubscriptionRequest.class);
-        shadowClientOrder.verify(shadowClient).SubscribeToGetShadowAccepted(request.capture(), eq(QualityOfService.AT_LEAST_ONCE), any(), any());
+        shadowClientOrder.verify(shadowClient, times(1)).SubscribeToGetShadowAccepted(request.capture(), eq(QualityOfService.AT_LEAST_ONCE), any(), any());
         assertEquals(SHADOW_NAME, request.getValue().thingName);
     }
 
     private void verifyShadowDeltaUpdatedSubscription() {
         ArgumentCaptor<ShadowDeltaUpdatedSubscriptionRequest> request = ArgumentCaptor.forClass(ShadowDeltaUpdatedSubscriptionRequest.class);
-        shadowClientOrder.verify(shadowClient).SubscribeToShadowDeltaUpdatedEvents(request.capture(), eq(QualityOfService.AT_LEAST_ONCE), any(), any());
+        shadowClientOrder.verify(shadowClient, times(1)).SubscribeToShadowDeltaUpdatedEvents(request.capture(), eq(QualityOfService.AT_LEAST_ONCE), any(), any());
         assertEquals(SHADOW_NAME, request.getValue().thingName);
     }
 
     private void verifyPublishGetShadow() {
         ArgumentCaptor<GetShadowRequest> request = ArgumentCaptor.forClass(GetShadowRequest.class);
-        shadowClientOrder.verify(shadowClient).PublishGetShadow(request.capture(), eq(QualityOfService.AT_LEAST_ONCE));
+        shadowClientOrder.verify(shadowClient, times(1)).PublishGetShadow(request.capture(), eq(QualityOfService.AT_LEAST_ONCE));
         assertEquals(SHADOW_NAME, request.getValue().thingName);
     }
 

--- a/src/test/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitorTest.java
+++ b/src/test/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitorTest.java
@@ -530,6 +530,7 @@ public class CISShadowMonitorTest {
             }
         }
 
+        @SuppressWarnings("PMD.AvoidCatchingGenericException")
         private CompletableFuture<Integer> propagateException(Callable<CompletableFuture<Integer>> action) {
             try {
                 return action.call();

--- a/src/test/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitorTest.java
+++ b/src/test/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitorTest.java
@@ -473,12 +473,11 @@ public class CISShadowMonitorTest {
                 }
 
                 Map<String, Object> desired = state.desired;
-                Map<String, Object> reported = state.reported;
-
                 if (desired == null || desired.isEmpty()) {
                     return delta;
                 }
 
+                Map<String, Object> reported = state.reported;
                 if (reported == null || reported.isEmpty()) {
                     delta.putAll(desired);
                     return delta;
@@ -561,6 +560,7 @@ public class CISShadowMonitorTest {
             }
         }
 
+        @SuppressWarnings("PMD.PrematureDeclaration")
         private void handleUpdateShadowRequest(UpdateShadowRequest request) {
             final AtomicBoolean accepted = new AtomicBoolean();
             final AtomicBoolean versionConflict = new AtomicBoolean();
@@ -568,13 +568,12 @@ public class CISShadowMonitorTest {
             // update internal shadow state based on the request.
             // if no shadow exists, create a new one
             Shadow computedShadow = shadowByThingName.compute(request.thingName, (thingName, existingShadow) -> {
-                Shadow shadow = existingShadow;
-                if (shadow == null) {
-                    shadow = Shadow.builder()
-                            .state(request.state)
-                            .version(INITIAL_SHADOW_VERSION)
-                            .build();
-                }
+                Shadow shadow = existingShadow == null ?
+                        Shadow.builder()
+                                .state(request.state)
+                                .version(INITIAL_SHADOW_VERSION)
+                                .build()
+                        : existingShadow;
 
                 // if version is provided, it must match the latest version
                 // https://docs.aws.amazon.com/iot/latest/developerguide/device-shadow-data-flow.html#optimistic-locking

--- a/src/test/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitorTest.java
+++ b/src/test/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitorTest.java
@@ -386,6 +386,8 @@ public class CISShadowMonitorTest {
                         } else if (topic.endsWith("shadow/update")) {
                             readPayload(message, UpdateShadowRequest.class)
                                     .ifPresent(this::handleUpdateShadowRequest);
+                        } else {
+                            throw new UnsupportedOperationException("please add a new handler for " + topic);
                         }
                         return DUMMY_PACKET_ID;
                     })

--- a/src/test/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitorTest.java
+++ b/src/test/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitorTest.java
@@ -8,40 +8,61 @@ package com.aws.greengrass.certificatemanager.certificate;
 import com.aws.greengrass.cisclient.ConnectivityInfoProvider;
 import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.testcommons.testutilities.TestUtils;
+import com.aws.greengrass.util.Utils;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.crt.mqtt.MqttClientConnection;
-import software.amazon.awssdk.crt.mqtt.MqttClientConnectionEvents;
+import software.amazon.awssdk.crt.mqtt.MqttMessage;
 import software.amazon.awssdk.crt.mqtt.QualityOfService;
 import software.amazon.awssdk.iot.iotshadow.IotShadowClient;
+import software.amazon.awssdk.iot.iotshadow.model.ErrorResponse;
 import software.amazon.awssdk.iot.iotshadow.model.GetShadowRequest;
 import software.amazon.awssdk.iot.iotshadow.model.GetShadowResponse;
 import software.amazon.awssdk.iot.iotshadow.model.GetShadowSubscriptionRequest;
 import software.amazon.awssdk.iot.iotshadow.model.ShadowDeltaUpdatedEvent;
 import software.amazon.awssdk.iot.iotshadow.model.ShadowDeltaUpdatedSubscriptionRequest;
+import software.amazon.awssdk.iot.iotshadow.model.ShadowState;
+import software.amazon.awssdk.iot.iotshadow.model.ShadowUpdatedEvent;
 import software.amazon.awssdk.iot.iotshadow.model.UpdateShadowRequest;
+import software.amazon.awssdk.iot.iotshadow.model.UpdateShadowSubscriptionRequest;
 
-import java.security.KeyStoreException;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
-import static com.aws.greengrass.certificatemanager.certificate.CISShadowMonitor.SHADOW_GET_ACCEPTED_TOPIC;
-import static com.aws.greengrass.certificatemanager.certificate.CISShadowMonitor.SHADOW_UPDATE_DELTA_TOPIC;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -49,172 +70,314 @@ import static org.mockito.Mockito.when;
 public class CISShadowMonitorTest {
     private static final String SHADOW_NAME = "testThing-gci";
 
-    @Mock
-    private IotShadowClient mockShadowClient;
+    FakeIotShadowClient shadowClient = spy(new FakeIotShadowClient());
+
+    InOrder shadowClientOrder = Mockito.inOrder(shadowClient);
+
+    ExecutorService executor = TestUtils.synchronousExecutorService();
 
     @Mock
-    private MqttClientConnection mockConnection;
+    MqttClient mqttClient;
 
     @Mock
-    private MqttClient mockMqttClient;
+    ConnectivityInfoProvider mockConnectivityInfoProvider;
 
     @Mock
-    private ExecutorService mockExecutor;
+    CertificateGenerator certificateGenerator;
 
-    @Mock
-    private ConnectivityInfoProvider mockConnectivityInfoProvider;
+    CISShadowMonitor cisShadowMonitor;
 
     @BeforeEach
     void setup() {
-        lenient().doAnswer(invocation -> {
-            ((Runnable)invocation.getArgument(0)).run();
-            return null;
-        }).when(mockExecutor).execute(any(Runnable.class));
-        lenient().doAnswer(invocation -> {
-            ((Runnable)invocation.getArgument(0)).run();
-            return null;
-        }).when(mockExecutor).submit(any(Runnable.class));
+        cisShadowMonitor = new CISShadowMonitor(
+                mqttClient,
+                shadowClient.getConnection(),
+                shadowClient,
+                executor,
+                SHADOW_NAME,
+                mockConnectivityInfoProvider
+        );
+
+        // pre-populate shadow
+        UpdateShadowRequest updateShadowRequest = new UpdateShadowRequest();
+        updateShadowRequest.thingName = SHADOW_NAME;
+        updateShadowRequest.state = new ShadowState();
+        updateShadowRequest.state.desired = new HashMap<>();
+        updateShadowRequest.state.desired.put("test", 1);
+        shadowClient.PublishUpdateShadow(updateShadowRequest, QualityOfService.AT_LEAST_ONCE);
+        reset(shadowClient);
     }
 
-    @Test
-    public void GIVEN_CISShadowMonitor_WHEN_connected_THEN_publish_to_get_topic() {
-        new CISShadowMonitor(mockMqttClient, mockConnection, mockShadowClient, mockExecutor, SHADOW_NAME,
-                mockConnectivityInfoProvider);
-        ArgumentCaptor<MqttClientConnectionEvents> callbackArgumentCaptor = ArgumentCaptor.forClass(
-                MqttClientConnectionEvents.class);
-        verify(mockMqttClient, times(1)).addToCallbackEvents(callbackArgumentCaptor.capture());
-
-        callbackArgumentCaptor.getValue().onConnectionResumed(false);
-        ArgumentCaptor<GetShadowRequest> requestArgumentCaptor = ArgumentCaptor.forClass(GetShadowRequest.class);
-        verify(mockShadowClient, times(1)).PublishGetShadow(requestArgumentCaptor.capture(),
-                eq(QualityOfService.AT_LEAST_ONCE));
-        assertThat(requestArgumentCaptor.getValue().thingName, is(SHADOW_NAME));
-    }
-
-    @Test
-    public void GIVEN_CISShadowMonitor_WHEN_start_monitor_THEN_subscribe_and_publish_to_topics() {
-        CISShadowMonitor cisShadowMonitor = new CISShadowMonitor(mockMqttClient, mockConnection, mockShadowClient,
-                mockExecutor, SHADOW_NAME, mockConnectivityInfoProvider);
-
-        when(mockShadowClient.SubscribeToShadowDeltaUpdatedEvents(any(), any(), any(), any()))
-                .thenReturn(CompletableFuture.completedFuture(0));
-        when(mockShadowClient.SubscribeToGetShadowAccepted(any(), any(), any(), any()))
-                .thenReturn(CompletableFuture.completedFuture(0));
-        cisShadowMonitor.startMonitor();
-
-        ArgumentCaptor<ShadowDeltaUpdatedSubscriptionRequest> updateSubscribeRequest = ArgumentCaptor.forClass(
-                ShadowDeltaUpdatedSubscriptionRequest.class);
-        ArgumentCaptor<GetShadowSubscriptionRequest> getSubscribeRequest = ArgumentCaptor.forClass(
-                GetShadowSubscriptionRequest.class);
-        ArgumentCaptor<GetShadowRequest> publishRequest = ArgumentCaptor.forClass(GetShadowRequest.class);
-
-        verify(mockShadowClient, times(1)).SubscribeToShadowDeltaUpdatedEvents(
-                updateSubscribeRequest.capture(), eq(QualityOfService.AT_LEAST_ONCE), any(),
-                any());
-        assertThat(updateSubscribeRequest.getValue().thingName, is(SHADOW_NAME));
-        verify(mockShadowClient, times(1)).SubscribeToGetShadowAccepted(
-                getSubscribeRequest.capture(), eq(QualityOfService.AT_LEAST_ONCE), any(),
-                any());
-        assertThat(getSubscribeRequest.getValue().thingName, is(SHADOW_NAME));
-
-        verify(mockShadowClient, times(1)).PublishGetShadow(publishRequest.capture(),
-                eq(QualityOfService.AT_LEAST_ONCE));
-        assertThat(publishRequest.getValue().thingName, is(SHADOW_NAME));
-    }
-
-    @Test
-    public void GIVEN_CISShadowMonitor_WHEN_update_delta_version_THEN_cert_generated() throws KeyStoreException {
-        CISShadowMonitor cisShadowMonitor = new CISShadowMonitor(mockMqttClient, mockConnection, mockShadowClient,
-                mockExecutor, SHADOW_NAME, mockConnectivityInfoProvider);
-        when(mockShadowClient.SubscribeToShadowDeltaUpdatedEvents(any(), any(), any(), any()))
-                .thenReturn(CompletableFuture.completedFuture(0));
-        when(mockShadowClient.SubscribeToGetShadowAccepted(any(), any(), any(), any()))
-                .thenReturn(CompletableFuture.completedFuture(0));
-        cisShadowMonitor.startMonitor();
-
-        ArgumentCaptor<Consumer<ShadowDeltaUpdatedEvent>> updateSubscribeHandler = ArgumentCaptor.forClass(
-                Consumer.class);
-        verify(mockShadowClient, times(1)).SubscribeToShadowDeltaUpdatedEvents(any(), any(),
-                updateSubscribeHandler.capture(), any());
-
-        //receive new version
-        CertificateGenerator mockCertGenerator = mock(CertificateGenerator.class);
-        cisShadowMonitor.addToMonitor(mockCertGenerator);
-        ShadowDeltaUpdatedEvent shadowDeltaUpdatedEvent = new ShadowDeltaUpdatedEvent();
-        shadowDeltaUpdatedEvent.version = 1;
-        updateSubscribeHandler.getValue().accept(shadowDeltaUpdatedEvent);
-
-        verify(mockCertGenerator, times(1)).generateCertificate(any());
-        ArgumentCaptor<UpdateShadowRequest> updateShadowRequest = ArgumentCaptor.forClass(UpdateShadowRequest.class);
-        verify(mockShadowClient, times(1)).PublishUpdateShadow(updateShadowRequest.capture(),
-                eq(QualityOfService.AT_LEAST_ONCE));
-        assertThat(updateShadowRequest.getValue().version, is(1));
-
-        //receive same version again
-        reset(mockCertGenerator);
-        reset(mockShadowClient);
-        updateSubscribeHandler.getValue().accept(shadowDeltaUpdatedEvent);
-
-        verify(mockCertGenerator, never()).generateCertificate(any());
-        verify(mockShadowClient, times(1)).PublishUpdateShadow(updateShadowRequest.capture(),
-                eq(QualityOfService.AT_LEAST_ONCE));
-        assertThat(updateShadowRequest.getValue().version, is(1));
-    }
-
-    @Test
-    public void GIVEN_CISShadowMonitor_WHEN_get_accepted_version_THEN_cert_generated() throws KeyStoreException {
-        CISShadowMonitor cisShadowMonitor = new CISShadowMonitor(mockMqttClient, mockConnection, mockShadowClient,
-                mockExecutor, SHADOW_NAME, mockConnectivityInfoProvider);
-        when(mockShadowClient.SubscribeToShadowDeltaUpdatedEvents(any(), any(), any(), any()))
-                .thenReturn(CompletableFuture.completedFuture(0));
-        when(mockShadowClient.SubscribeToGetShadowAccepted(any(), any(), any(), any()))
-                .thenReturn(CompletableFuture.completedFuture(0));
-        cisShadowMonitor.startMonitor();
-
-        ArgumentCaptor<Consumer<GetShadowResponse>> getSubscribeHandler = ArgumentCaptor.forClass(
-                Consumer.class);
-        verify(mockShadowClient, times(1)).SubscribeToGetShadowAccepted(any(), any(),
-                getSubscribeHandler.capture(), any());
-
-        //receive new version
-        CertificateGenerator mockCertGenerator = mock(CertificateGenerator.class);
-        cisShadowMonitor.addToMonitor(mockCertGenerator);
-        GetShadowResponse getShadowResponse = new GetShadowResponse();
-        getShadowResponse.version = 1;
-        getSubscribeHandler.getValue().accept(getShadowResponse);
-
-        verify(mockCertGenerator, times(1)).generateCertificate(any());
-        ArgumentCaptor<UpdateShadowRequest> updateShadowRequest = ArgumentCaptor.forClass(UpdateShadowRequest.class);
-        verify(mockShadowClient, times(1)).PublishUpdateShadow(updateShadowRequest.capture(),
-                eq(QualityOfService.AT_LEAST_ONCE));
-        assertThat(updateShadowRequest.getValue().version, is(1));
-
-        //receive same version again
-        reset(mockCertGenerator);
-        reset(mockShadowClient);
-        getSubscribeHandler.getValue().accept(getShadowResponse);
-
-        verify(mockCertGenerator, never()).generateCertificate(any());
-        verify(mockShadowClient, times(1)).PublishUpdateShadow(updateShadowRequest.capture(),
-                eq(QualityOfService.AT_LEAST_ONCE));
-        assertThat(updateShadowRequest.getValue().version, is(1));
-    }
-
-    @Test
-    public void GIVEN_CISShadowMonitor_WHEN_stop_monitor_THEN_unsubscribe_from_topics() {
-        CISShadowMonitor cisShadowMonitor = new CISShadowMonitor(mockMqttClient, mockConnection, mockShadowClient,
-                mockExecutor, SHADOW_NAME, mockConnectivityInfoProvider);
-        when(mockShadowClient.SubscribeToShadowDeltaUpdatedEvents(any(), any(), any(), any()))
-                .thenReturn(CompletableFuture.completedFuture(0));
-        when(mockShadowClient.SubscribeToGetShadowAccepted(any(), any(), any(), any()))
-                .thenReturn(CompletableFuture.completedFuture(0));
-        cisShadowMonitor.startMonitor();
-
+    @AfterEach
+    void tearDown() {
         cisShadowMonitor.stopMonitor();
-        ArgumentCaptor<String> unsubscribeTopic = ArgumentCaptor.forClass(String.class);
-        verify(mockConnection, times(2)).unsubscribe(unsubscribeTopic.capture());
-        assertThat(unsubscribeTopic.getAllValues(),
-                containsInAnyOrder(String.format(SHADOW_UPDATE_DELTA_TOPIC, SHADOW_NAME),
-                        String.format(SHADOW_GET_ACCEPTED_TOPIC, SHADOW_NAME)));
+    }
+
+    @Test
+    void GIVEN_CISShadowMonitor_WHEN_connection_resumed_THEN_get_shadow() {
+        cisShadowMonitor.getCallbacks().onConnectionResumed(false);
+        verifyPublishGetShadow();
+    }
+
+    @Test
+    void GIVEN_CISShadowMonitor_WHEN_start_monitor_THEN_subscribe_to_shadow_topics_and_get_shadow() {
+        cisShadowMonitor.startMonitor();
+        verifyShadowDeltaUpdatedSubscription();
+        verifyGetShadowAcceptedSubscription();
+        verifyPublishGetShadow();
+    }
+
+    @Test
+    void GIVEN_CISShadowMonitor_WHEN_start_monitor_THEN_new_cert_generated() throws Exception {
+        CountDownLatch shadowUpdated = whenUpdateShadowAccepted();
+
+        cisShadowMonitor.addToMonitor(certificateGenerator);
+        cisShadowMonitor.startMonitor();
+
+        assertTrue(shadowUpdated.await(5L, TimeUnit.SECONDS));
+
+        verify(certificateGenerator).generateCertificate(any());
+    }
+
+    @Test
+    void GIVEN_CISShadowMonitor_WHEN_cis_shadow_changed_THEN_new_cert_generated() throws Exception {
+        CountDownLatch shadowDeltaUpdated = whenShadowDeltaUpdated();
+
+        cisShadowMonitor.startMonitor();
+        cisShadowMonitor.addToMonitor(certificateGenerator);
+
+        publishDesiredShadowState(Utils.immutableMap("newState", 1));
+        assertTrue(shadowDeltaUpdated.await(5L, TimeUnit.SECONDS));
+
+        verify(certificateGenerator).generateCertificate(any());
+    }
+
+    @Test
+    void GIVEN_CISShadowMonitor_WHEN_stop_monitor_THEN_unsubscribe() {
+        cisShadowMonitor.startMonitor();
+        assertTrue(shadowClient.hasSubscriptions());
+        cisShadowMonitor.stopMonitor();
+        assertFalse(shadowClient.hasSubscriptions());
+    }
+
+    // TODO test receiving same version
+    // TODO test if exception when publishing
+
+    private CountDownLatch whenUpdateShadowAccepted() {
+        CountDownLatch shadowUpdated = new CountDownLatch(1);
+        UpdateShadowSubscriptionRequest request = new UpdateShadowSubscriptionRequest();
+        request.thingName = SHADOW_NAME;
+        shadowClient.SubscribeToUpdateShadowAccepted(request, QualityOfService.AT_LEAST_ONCE, resp -> shadowUpdated.countDown());
+        return shadowUpdated;
+    }
+
+    private CountDownLatch whenShadowDeltaUpdated() {
+        CountDownLatch shadowDeltaUpdated = new CountDownLatch(1);
+        ShadowDeltaUpdatedSubscriptionRequest request = new ShadowDeltaUpdatedSubscriptionRequest();
+        request.thingName = SHADOW_NAME;
+        shadowClient.SubscribeToShadowDeltaUpdatedEvents(request, QualityOfService.AT_LEAST_ONCE, resp -> shadowDeltaUpdated.countDown());
+        return shadowDeltaUpdated;
+    }
+
+    private void publishDesiredShadowState(Map<String, Object> desired) {
+        UpdateShadowRequest updateShadowRequest = new UpdateShadowRequest();
+        updateShadowRequest.thingName = SHADOW_NAME;
+        updateShadowRequest.state = new ShadowState();
+        updateShadowRequest.state.desired = new HashMap<>(desired);
+        shadowClient.PublishUpdateShadow(updateShadowRequest, QualityOfService.AT_LEAST_ONCE);
+    }
+
+    private void verifyGetShadowAcceptedSubscription() {
+        ArgumentCaptor<GetShadowSubscriptionRequest> request = ArgumentCaptor.forClass(GetShadowSubscriptionRequest.class);
+        shadowClientOrder.verify(shadowClient).SubscribeToGetShadowAccepted(request.capture(), eq(QualityOfService.AT_LEAST_ONCE), any(), any());
+        assertEquals(SHADOW_NAME, request.getValue().thingName);
+    }
+
+    private void verifyShadowDeltaUpdatedSubscription() {
+        ArgumentCaptor<ShadowDeltaUpdatedSubscriptionRequest> request = ArgumentCaptor.forClass(ShadowDeltaUpdatedSubscriptionRequest.class);
+        shadowClientOrder.verify(shadowClient).SubscribeToShadowDeltaUpdatedEvents(request.capture(), eq(QualityOfService.AT_LEAST_ONCE), any(), any());
+        assertEquals(SHADOW_NAME, request.getValue().thingName);
+    }
+
+    private void verifyPublishGetShadow() {
+        ArgumentCaptor<GetShadowRequest> request = ArgumentCaptor.forClass(GetShadowRequest.class);
+        shadowClientOrder.verify(shadowClient).PublishGetShadow(request.capture(), eq(QualityOfService.AT_LEAST_ONCE));
+        assertEquals(SHADOW_NAME, request.getValue().thingName);
+    }
+
+
+    static class FakeIotShadowClient extends IotShadowClient {
+        private static final CompletableFuture<Integer> DUMMY_PACKET_ID = CompletableFuture.completedFuture(0);
+        private static final int INITIAL_SHADOW_VERSION = 1;
+        private static final ObjectMapper MAPPER = new ObjectMapper();
+
+        private final Map<String, List<Consumer<MqttMessage>>> subscriptionsByTopic = new ConcurrentHashMap<>();
+        private final Map<String, Shadow> shadowByThingName = new ConcurrentHashMap<>();
+
+        @Getter(AccessLevel.PACKAGE)
+        private final MqttClientConnection connection;
+
+        @Data
+        @Builder
+        static class Shadow {
+            int version;
+            ShadowState state;
+        }
+
+        FakeIotShadowClient() {
+            this(mock(MqttClientConnection.class));
+        }
+
+        private FakeIotShadowClient(MqttClientConnection connection) {
+            super(connection);
+            this.connection = connection;
+            // store subscriptions in-memory on subscribe
+            when(this.connection.subscribe(any(), any(), any())).thenAnswer(invocation -> {
+                String topic = invocation.getArgument(0);
+                Consumer<MqttMessage> messageHandler = invocation.getArgument(2);
+                subscriptionsByTopic.computeIfAbsent(topic, t -> new CopyOnWriteArrayList<>())
+                        .add(messageHandler);
+                return DUMMY_PACKET_ID;
+            });
+            // fire messages to subscriptions on publish
+            when(this.connection.publish(any(), any(), anyBoolean())).thenAnswer(invocation -> {
+                MqttMessage message = invocation.getArgument(0);
+                String topic = message.getTopic();
+
+                if (topic.endsWith("shadow/get")) {
+                    readPayload(message, GetShadowRequest.class)
+                            .ifPresent(this::handleGetShadowRequest);
+                } else if (topic.endsWith("shadow/update")) {
+                    readPayload(message, UpdateShadowRequest.class)
+                            .ifPresent(this::handleUpdateShadowRequest);
+                }
+                return DUMMY_PACKET_ID;
+            });
+            // delete subscriptions on unsubscribe
+            when(this.connection.unsubscribe(any())).thenAnswer(invocation -> {
+                String topic = invocation.getArgument(0);
+                subscriptionsByTopic.remove(topic);
+                return DUMMY_PACKET_ID;
+            });
+        }
+
+        private void handleGetShadowRequest(GetShadowRequest request) {
+            Shadow shadow = shadowByThingName.get(request.thingName);
+            if (shadow == null) {
+                String rejected = String.format("$aws/things/%s/shadow/get/rejected", request.thingName);
+                ErrorResponse response = new ErrorResponse();
+                response.message = "no shadow found";
+                publishMessage(rejected, response);
+            } else {
+                String accepted = String.format("$aws/things/%s/shadow/get/accepted", request.thingName);
+                GetShadowResponse response = new GetShadowResponse();
+                response.version = shadow.version;
+                publishMessage(accepted, response);
+            }
+        }
+
+        private void handleUpdateShadowRequest(UpdateShadowRequest request) {
+            // create a new shadow if one doesn't exist already
+            Shadow shadow = shadowByThingName.compute(request.thingName, (k, v) -> {
+                if (v != null) {
+                    return v;
+                }
+                return Shadow.builder()
+                        .state(request.state)
+                        .version(INITIAL_SHADOW_VERSION)
+                        .build();
+            });
+
+            if (shadow.version == INITIAL_SHADOW_VERSION || request.version == null || request.version == shadow.version) {
+                publishShadowAccepted(request.thingName);
+
+                if (request.state.desired == null && request.state.reported == null) {
+                    return;
+                }
+
+                Map<String, Object> desired = request.state.desired == null ? shadow.state.desired : request.state.desired;
+                Map<String, Object> reported = request.state.reported == null ? shadow.state.reported : request.state.reported;
+
+                Map<String, Object> delta = getDelta(desired, reported);
+                if (delta.isEmpty()) {
+                    return;
+                }
+
+                shadow.state.desired = desired == null ? null : new HashMap<>(desired);
+                shadow.state.reported = reported == null ? null : new HashMap<>(reported);
+                shadow.version += 1;
+                publishShadowDelta(delta, request.thingName);
+            }
+        }
+
+        private void publishShadowAccepted(String thingName) {
+            String topic = String.format("$aws/things/%s/shadow/update/accepted", thingName);
+            ShadowUpdatedEvent event = new ShadowUpdatedEvent();
+            publishMessage(topic, event);
+        }
+
+        private void publishShadowDelta(Map<String, Object> delta, String thingName) {
+            String topic = String.format("$aws/things/%s/shadow/update/delta", thingName);
+            ShadowDeltaUpdatedEvent event = new ShadowDeltaUpdatedEvent();
+            event.state = new HashMap<>(delta);
+            event.version = shadowByThingName.get(thingName).version;
+            publishMessage(topic, event);
+        }
+
+        private Map<String, Object> getDelta(Map<String, Object> desired, Map<String, Object> reported) {
+            Map<String, Object> delta = new HashMap<>();
+
+            if (desired == null || desired.isEmpty()) {
+                return delta;
+            }
+
+            if (reported == null || reported.isEmpty()) {
+                delta.putAll(desired);
+                return delta;
+            }
+
+            for (Map.Entry<String, Object> entry : desired.entrySet()) {
+                if (reported.containsKey(entry.getKey())) {
+                    if (!Objects.equals(reported.get(entry.getKey()), entry.getValue())) {
+                        delta.put(entry.getKey(), entry.getValue());
+                    }
+                } else {
+                    delta.put(entry.getKey(), entry.getValue());
+                }
+            }
+            return delta;
+        }
+
+        private static <T> Optional<T> readPayload(MqttMessage message, Class<T> clazz) {
+            try {
+                return Optional.of(MAPPER.readValue(message.getPayload(), clazz));
+            } catch (IOException e) {
+                return Optional.empty();
+            }
+        }
+
+        private <T> Optional<MqttMessage> wrapInMessage(String topic, T payload) {
+            try {
+                return Optional.of(new MqttMessage(
+                        topic,
+                        MAPPER.writeValueAsBytes(payload),
+                        QualityOfService.AT_LEAST_ONCE)
+                );
+            } catch (JsonProcessingException e) {
+                return Optional.empty();
+            }
+        }
+
+        private <T> void publishMessage(String topic, T event) {
+            List<Consumer<MqttMessage>> subscribers = subscriptionsByTopic.get(topic);
+            if (subscribers != null) {
+                subscribers.forEach(subscriber ->
+                        wrapInMessage(topic, event).ifPresent(subscriber));
+            }
+        }
+
+        boolean hasSubscriptions() {
+            return !subscriptionsByTopic.isEmpty();
+        }
     }
 }

--- a/src/test/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitorTest.java
+++ b/src/test/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitorTest.java
@@ -10,12 +10,10 @@ import com.aws.greengrass.mqttclient.MqttClient;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.TestUtils;
 import com.aws.greengrass.util.Utils;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,54 +21,55 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InOrder;
+import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
-import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 import software.amazon.awssdk.crt.mqtt.MqttClientConnection;
 import software.amazon.awssdk.crt.mqtt.MqttMessage;
 import software.amazon.awssdk.crt.mqtt.QualityOfService;
-import software.amazon.awssdk.iot.ShadowStateFactory;
-import software.amazon.awssdk.iot.Timestamp;
 import software.amazon.awssdk.iot.iotshadow.IotShadowClient;
-import software.amazon.awssdk.iot.iotshadow.model.ErrorResponse;
 import software.amazon.awssdk.iot.iotshadow.model.GetShadowRequest;
 import software.amazon.awssdk.iot.iotshadow.model.GetShadowResponse;
-import software.amazon.awssdk.iot.iotshadow.model.GetShadowSubscriptionRequest;
 import software.amazon.awssdk.iot.iotshadow.model.ShadowDeltaUpdatedEvent;
-import software.amazon.awssdk.iot.iotshadow.model.ShadowDeltaUpdatedSubscriptionRequest;
-import software.amazon.awssdk.iot.iotshadow.model.ShadowState;
 import software.amazon.awssdk.iot.iotshadow.model.ShadowStateWithDelta;
-import software.amazon.awssdk.iot.iotshadow.model.ShadowUpdatedEvent;
 import software.amazon.awssdk.iot.iotshadow.model.UpdateShadowRequest;
-import software.amazon.awssdk.iot.iotshadow.model.UpdateShadowSubscriptionRequest;
+import software.amazon.awssdk.services.greengrassv2data.model.ConnectivityInfo;
 
+import javax.annotation.Nonnull;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.security.KeyStoreException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.Callable;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -78,23 +77,23 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 public class CISShadowMonitorTest {
+
     private static final String SHADOW_NAME = "testThing-gci";
-    private static final String SHADOW_FIELD_VERSION = "version";
-    private static final int SHADOW_FIELD_VERSION_INITIAL_VALUE = 0;
-    private static final Map<String, Object> SHADOW_DESIRED_INITIAL_STATE =
-            Utils.immutableMap(SHADOW_FIELD_VERSION, String.valueOf(SHADOW_FIELD_VERSION_INITIAL_VALUE));
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final CompletableFuture<Integer> DUMMY_PACKET_ID = CompletableFuture.completedFuture(0);
+    private static final String SHADOW_ACCEPTED_TOPIC = String.format("$aws/things/%s/shadow/get/accepted", SHADOW_NAME);
+    private static final String SHADOW_DELTA_UPDATED_TOPIC = String.format("$aws/things/%s/shadow/update/delta", SHADOW_NAME);
+    private static final String GET_SHADOW_TOPIC = String.format("$aws/things/%s/shadow/get", SHADOW_NAME);
+    private static final String UPDATE_SHADOW_TOPIC = String.format("$aws/things/%s/shadow/update", SHADOW_NAME);
+
 
     FakeIotShadowClient shadowClient = spy(new FakeIotShadowClient());
-
-    InOrder shadowClientOrder = Mockito.inOrder(shadowClient);
-
+    MqttClientConnection shadowClientConnection = shadowClient.getConnection();
     ExecutorService executor = TestUtils.synchronousExecutorService();
+    FakeConnectivityInfoProvider connectivityInfoProvider = new FakeConnectivityInfoProvider();
 
     @Mock
     MqttClient mqttClient;
-
-    @Mock
-    ConnectivityInfoProvider mockConnectivityInfoProvider;
 
     @Mock
     CertificateGenerator certificateGenerator;
@@ -102,24 +101,15 @@ public class CISShadowMonitorTest {
     CISShadowMonitor cisShadowMonitor;
 
     @BeforeEach
-    void setup() throws Exception {
+    void setup() {
         cisShadowMonitor = new CISShadowMonitor(
                 mqttClient,
-                shadowClient.getConnection(),
+                shadowClientConnection,
                 shadowClient,
                 executor,
                 SHADOW_NAME,
-                mockConnectivityInfoProvider
+                connectivityInfoProvider
         );
-
-        // pre-populate shadow
-        UpdateShadowRequest updateShadowRequest = new UpdateShadowRequest();
-        updateShadowRequest.thingName = SHADOW_NAME;
-        updateShadowRequest.state = new ShadowState();
-        updateShadowRequest.state.desired = new HashMap<>();
-        updateShadowRequest.state.desired.putAll(SHADOW_DESIRED_INITIAL_STATE);
-        shadowClient.PublishUpdateShadow(updateShadowRequest, QualityOfService.AT_LEAST_ONCE).get(5, TimeUnit.SECONDS);
-        reset(shadowClient);
     }
 
     @AfterEach
@@ -128,373 +118,394 @@ public class CISShadowMonitorTest {
     }
 
     @Test
-    void GIVEN_CISShadowMonitor_WHEN_connection_resumed_THEN_get_shadow() {
+    @SuppressWarnings("unchecked")
+    void GIVEN_CISShadowMonitor_WHEN_start_monitor_OR_reconnect_THEN_get_shadow_is_processed() throws Exception {
+
+        int shadowInitialVersion = 1;
+        Map<String, Object> shadowInitialDesiredState = Utils.immutableMap("field", "value");
+        Map<String, Object> shadowInitialReportedState = Collections.emptyMap();
+        Map<String, Object> shadowInitialDelta = Utils.immutableMap("field", "value");
+
+        // capture the subscription callback for get shadow operation.
+        ArgumentCaptor<Consumer<MqttMessage>> getShadowCallback = ArgumentCaptor.forClass(Consumer.class);
+        when(shadowClientConnection.subscribe(eq(SHADOW_ACCEPTED_TOPIC), any(), getShadowCallback.capture())).thenReturn(DUMMY_PACKET_ID);
+
+        // when get shadow request is published, send a response to the subscription callback
+        when(shadowClientConnection.publish(argThat(new GetShadowRequestMatcher()), any(), anyBoolean()))
+                .thenAnswer(invocation -> {
+                    GetShadowResponse response = new GetShadowResponse();
+                    response.version = shadowInitialVersion;
+                    response.state = new ShadowStateWithDelta();
+                    response.state.desired = new HashMap<>(shadowInitialDesiredState);
+                    response.state.reported = new HashMap<>(shadowInitialReportedState);
+                    response.state.delta = new HashMap<>(shadowInitialDelta);
+
+                    wrapInMessage(SHADOW_ACCEPTED_TOPIC, response, false).ifPresent(resp ->
+                            getShadowCallback.getValue().accept(resp));
+
+                    return DUMMY_PACKET_ID;
+                });
+
+        // notify when shadow update is published
+        WhenUpdateIsPublished whenUpdateIsPublished = WhenUpdateIsPublished.builder()
+                .expectedReportedState(shadowInitialDesiredState) // reported state updated to desired state
+                .expectedDesiredState(null) // desired state isn't modified
+                .build();
+        when(shadowClientConnection.publish(argThat(new ShadowUpdateRequestMatcher()), any(), anyBoolean()))
+                .thenAnswer(whenUpdateIsPublished);
+
+        cisShadowMonitor.addToMonitor(certificateGenerator);
+        cisShadowMonitor.startMonitor();
+
+        assertTrue(whenUpdateIsPublished.getLatch().await(5L, TimeUnit.SECONDS));
+
+        // simulate a reconnect
         cisShadowMonitor.getCallbacks().onConnectionResumed(false);
-        verifyPublishGetShadow();
+
+        verifyCertsRotatedWhenConnectivityChanges();
     }
 
     @Test
-    void GIVEN_CISShadowMonitor_WHEN_start_monitor_THEN_subscribe_to_shadow_topics_and_get_shadow() throws InterruptedException {
-        CountDownLatch shadowUpdated = whenUpdateShadowAccepted(1);
+    @SuppressWarnings("unchecked")
+    void GIVEN_CISShadowMonitor_WHEN_cis_shadow_changes_THEN_delta_is_processed() throws Exception {
 
-        cisShadowMonitor.startMonitor();
-        verifyShadowDeltaUpdatedSubscription();
-        verifyGetShadowAcceptedSubscription();
-        verifyPublishGetShadow();
+        // capture the subscription callback for shadow delta update
+        ArgumentCaptor<Consumer<MqttMessage>> shadowDeltaUpdatedCallback = ArgumentCaptor.forClass(Consumer.class);
+        when(shadowClientConnection.subscribe(eq(SHADOW_DELTA_UPDATED_TOPIC), any(), shadowDeltaUpdatedCallback.capture())).thenReturn(DUMMY_PACKET_ID);
 
-        assertTrue(shadowUpdated.await(5L, TimeUnit.SECONDS));
-        assertDesiredAndReportedShadowState(
-                Utils.immutableMap(SHADOW_FIELD_VERSION, "0"),
-                Utils.immutableMap(SHADOW_FIELD_VERSION, "0"));
-    }
+        // generated list of deltas to feed to the shadow monitor
+        List<Map<String, Object>> deltas = IntStream.range(0, 5)
+                .mapToObj(i -> Utils.immutableMap("field", (Object) String.valueOf(i)))
+                .collect(Collectors.toList());
+        Map<String, Object> lastDelta = deltas.get(deltas.size() - 1);
 
-    @Test
-    void GIVEN_CISShadowMonitor_WHEN_start_monitor_THEN_new_cert_generated() throws Exception {
-        CountDownLatch shadowUpdated = whenUpdateShadowAccepted(1);
-
-        cisShadowMonitor.addToMonitor(certificateGenerator);
-        cisShadowMonitor.startMonitor();
-
-        assertTrue(shadowUpdated.await(5L, TimeUnit.SECONDS));
-
-        verify(certificateGenerator, times(1)).generateCertificate(any(), any());
-    }
-
-    @Test
-    void GIVEN_CISShadowMonitor_WHEN_cis_shadow_changed_THEN_new_cert_generated() throws Exception {
-        int numShadowChanges = 1;
-        CountDownLatch shadowDeltaUpdated = whenShadowDeltaUpdated(numShadowChanges);
+        // notify when last shadow update is published
+        WhenUpdateIsPublished whenUpdateIsPublished = WhenUpdateIsPublished.builder()
+                .expectedReportedState(lastDelta) // reported state updated to desired state
+                .expectedDesiredState(null) // desired state isn't modified
+                .build();
+        when(shadowClientConnection.publish(argThat(new ShadowUpdateRequestMatcher()), any(), anyBoolean()))
+                .thenAnswer(whenUpdateIsPublished);
 
         cisShadowMonitor.startMonitor();
         cisShadowMonitor.addToMonitor(certificateGenerator);
 
-        for (int i = 1; i <= numShadowChanges; i++) {
-            Map<String, Object> desiredState = Utils.immutableMap(SHADOW_FIELD_VERSION, String.valueOf(i));
-            publishDesiredShadowState(desiredState);
-        }
-
-        assertTrue(shadowDeltaUpdated.await(5L, TimeUnit.SECONDS));
-        assertDesiredAndReportedShadowState(
-                Utils.immutableMap(SHADOW_FIELD_VERSION, String.valueOf(numShadowChanges)),
-                Utils.immutableMap(SHADOW_FIELD_VERSION, String.valueOf(numShadowChanges)));
-
-        verify(certificateGenerator, times(numShadowChanges)).generateCertificate(any(), any());
-    }
-
-    @Test
-    void GIVEN_CISShadowMonitor_WHEN_cis_shadow_changed_multiple_times_THEN_new_cert_generated_multiple_times() throws Exception {
-        int numShadowChanges = 3;
-        CountDownLatch shadowDeltaUpdated = whenShadowDeltaUpdated(numShadowChanges);
-
-        cisShadowMonitor.startMonitor();
-        cisShadowMonitor.addToMonitor(certificateGenerator);
-
-        for (int i = 1; i <= numShadowChanges; i++) {
-            Map<String, Object> desiredState = Utils.immutableMap(SHADOW_FIELD_VERSION, String.valueOf(i));
-            publishDesiredShadowState(desiredState);
-        }
-
-        assertTrue(shadowDeltaUpdated.await(5L, TimeUnit.SECONDS));
-        assertDesiredAndReportedShadowState(
-                Utils.immutableMap(SHADOW_FIELD_VERSION, String.valueOf(numShadowChanges)),
-                Utils.immutableMap(SHADOW_FIELD_VERSION, String.valueOf(numShadowChanges)));
-
-        verify(certificateGenerator, times(numShadowChanges)).generateCertificate(any(), any());
-    }
-
-    @Test
-    void GIVEN_CISShadowMonitor_WHEN_cis_shadow_changed_duplicate_THEN_only_one_new_cert_generated() throws Exception {
-        int numShadowChanges = 1;
-        CountDownLatch shadowDeltaUpdated = whenShadowDeltaUpdated(numShadowChanges * 2);
-
-        cisShadowMonitor.startMonitor();
-        cisShadowMonitor.addToMonitor(certificateGenerator);
-
-        shadowClient.withDuplicatePublishing(true);
-
-        for (int i = 1; i <= numShadowChanges; i++) {
-            Map<String, Object> desiredState = Utils.immutableMap(SHADOW_FIELD_VERSION, String.valueOf(i));
-            publishDesiredShadowState(desiredState);
-        }
-
-        assertTrue(shadowDeltaUpdated.await(5L, TimeUnit.SECONDS));
-        assertDesiredAndReportedShadowState(
-                Utils.immutableMap(SHADOW_FIELD_VERSION, String.valueOf(numShadowChanges)),
-                Utils.immutableMap(SHADOW_FIELD_VERSION, String.valueOf(numShadowChanges)));
-
-        verify(certificateGenerator, times(numShadowChanges)).generateCertificate(any(), any());
-    }
-
-    @Test
-    void GIVEN_CISShadowMonitor_WHEN_cis_shadow_changed_multiple_times_with_duplicates_THEN_new_cert_generated_multiple_times() throws Exception {
-        int numShadowChanges = 3;
-        CountDownLatch shadowDeltaUpdated = whenShadowDeltaUpdated(numShadowChanges * 2);
-
-        cisShadowMonitor.startMonitor();
-        cisShadowMonitor.addToMonitor(certificateGenerator);
-
-        shadowClient.withDuplicatePublishing(true);
-
-        for (int i = 1; i <= numShadowChanges; i++) {
-            Map<String, Object> desiredState = Utils.immutableMap(SHADOW_FIELD_VERSION, String.valueOf(i));
-            publishDesiredShadowState(desiredState);
-        }
-
-        assertTrue(shadowDeltaUpdated.await(5L, TimeUnit.SECONDS));
-        assertDesiredAndReportedShadowState(
-                Utils.immutableMap(SHADOW_FIELD_VERSION, String.valueOf(numShadowChanges)),
-                Utils.immutableMap(SHADOW_FIELD_VERSION, String.valueOf(numShadowChanges)));
-
-        verify(certificateGenerator, times(numShadowChanges)).generateCertificate(any(), any());
-    }
-
-    @Test
-    void GIVEN_CISShadowMonitor_WHEN_cis_shadow_changed_and_shadow_update_failed_THEN_new_cert_generated(ExtensionContext context) throws Exception {
-        ignoreExceptionOfType(context, FakeIotShadowClient.SIMULATED_PUBLISH_EXCEPTION.getClass());
-
-        int numShadowChanges = 1;
-        CountDownLatch shadowDeltaUpdated = whenShadowDeltaUpdated(numShadowChanges);
-
-        cisShadowMonitor.startMonitor();
-        cisShadowMonitor.addToMonitor(certificateGenerator);
-
-        shadowClient.onPrePublish(topic -> {
-            if (topic.endsWith("shadow/update/delta")) {
-                shadowClient.withPublishException(true);
-            }
+        // trigger update delta subscription callbacks
+        AtomicInteger version = new AtomicInteger(1);
+        deltas.forEach(delta -> {
+            ShadowDeltaUpdatedEvent deltaUpdatedEvent = new ShadowDeltaUpdatedEvent();
+            deltaUpdatedEvent.version = version.getAndIncrement();
+            deltaUpdatedEvent.state = new HashMap<>(delta);
+            wrapInMessage(SHADOW_DELTA_UPDATED_TOPIC, deltaUpdatedEvent, false).ifPresent(resp ->
+                    shadowDeltaUpdatedCallback.getValue().accept(resp));
         });
 
-        for (int i = 1; i <= numShadowChanges; i++) {
-            Map<String, Object> desiredState = Utils.immutableMap(SHADOW_FIELD_VERSION, String.valueOf(i));
-            publishDesiredShadowState(desiredState);
-        }
-
-        assertTrue(shadowDeltaUpdated.await(5L, TimeUnit.SECONDS));
-        assertDesiredAndReportedShadowState(
-                Utils.immutableMap(SHADOW_FIELD_VERSION, String.valueOf(numShadowChanges)),
-                Utils.immutableMap(SHADOW_FIELD_VERSION, String.valueOf(numShadowChanges)));
-
-        verify(certificateGenerator, times(numShadowChanges)).generateCertificate(any(), any());
+        assertTrue(whenUpdateIsPublished.getLatch().await(5L, TimeUnit.SECONDS));
+        verifyCertsRotatedWhenConnectivityChanges();
     }
 
     @Test
-    void GIVEN_CISShadowMonitor_WHEN_cis_shadow_changed_multiple_times_and_shadow_update_failed_THEN_new_cert_generated_multiple_times(ExtensionContext context) throws Exception {
-        ignoreExceptionOfType(context, FakeIotShadowClient.SIMULATED_PUBLISH_EXCEPTION.getClass());
+    @SuppressWarnings("unchecked")
+    void GIVEN_CISShadowMonitor_WHEN_cis_shadow_changes_with_duplicate_delta_messages_THEN_delta_processing_is_deduped() throws Exception {
 
-        int numShadowChanges = 3;
-        CountDownLatch shadowDeltaUpdated = whenShadowDeltaUpdated(numShadowChanges);
+        // capture the subscription callback for shadow delta update
+        ArgumentCaptor<Consumer<MqttMessage>> shadowDeltaUpdatedCallback = ArgumentCaptor.forClass(Consumer.class);
+        when(shadowClientConnection.subscribe(eq(SHADOW_DELTA_UPDATED_TOPIC), any(), shadowDeltaUpdatedCallback.capture())).thenReturn(DUMMY_PACKET_ID);
+
+        // generated list of deltas to feed to the shadow monitor
+        List<Map<String, Object>> deltas = IntStream.range(0, 5)
+                .mapToObj(i -> Utils.immutableMap("field", (Object) String.valueOf(i)))
+                .collect(Collectors.toList());
+        Map<String, Object> lastDelta = deltas.get(deltas.size() - 1);
+
+        // notify when last shadow update is published
+        WhenUpdateIsPublished whenUpdateIsPublished = WhenUpdateIsPublished.builder()
+                .expectedReportedState(lastDelta) // reported state updated to desired state
+                .expectedDesiredState(null) // desired state isn't modified
+                .build();
+        when(shadowClientConnection.publish(argThat(new ShadowUpdateRequestMatcher()), any(), anyBoolean()))
+                .thenAnswer(whenUpdateIsPublished);
 
         cisShadowMonitor.startMonitor();
         cisShadowMonitor.addToMonitor(certificateGenerator);
 
-        shadowClient.onPrePublish(topic -> {
-            if (topic.endsWith("shadow/update/delta")) {
-                // force the update shadow call within cisShadowMonitor to fail
-                shadowClient.withPublishException(true);
-            }
+        // trigger update delta subscription callbacks
+        AtomicInteger version = new AtomicInteger(1);
+        deltas.forEach(delta -> {
+            ShadowDeltaUpdatedEvent deltaUpdatedEvent = new ShadowDeltaUpdatedEvent();
+            deltaUpdatedEvent.version = version.getAndIncrement();
+            deltaUpdatedEvent.state = new HashMap<>(delta);
+
+            // original message
+            wrapInMessage(SHADOW_DELTA_UPDATED_TOPIC, deltaUpdatedEvent, false).ifPresent(resp ->
+                    shadowDeltaUpdatedCallback.getValue().accept(resp));
+            // duplicate message
+            wrapInMessage(SHADOW_DELTA_UPDATED_TOPIC, deltaUpdatedEvent, true).ifPresent(resp ->
+                    shadowDeltaUpdatedCallback.getValue().accept(resp));
         });
 
-        for (int i = 1; i <= numShadowChanges; i++) {
-            shadowClient.withPublishException(false);
-            Map<String, Object> desiredState = Utils.immutableMap(SHADOW_FIELD_VERSION, String.valueOf(i));
-            publishDesiredShadowState(desiredState);
-        }
-
-        assertTrue(shadowDeltaUpdated.await(5L, TimeUnit.SECONDS));
-        assertDesiredAndReportedShadowState(
-                Utils.immutableMap(SHADOW_FIELD_VERSION, String.valueOf(numShadowChanges)),
-                Utils.immutableMap(SHADOW_FIELD_VERSION, String.valueOf(numShadowChanges)));
-
-        verify(certificateGenerator, times(numShadowChanges)).generateCertificate(any(), any());
+        assertTrue(whenUpdateIsPublished.getLatch().await(5L, TimeUnit.SECONDS));
+        verifyCertsRotatedWhenConnectivityChanges();
     }
 
     @Test
-    void GIVEN_CISShadowMonitor_WHEN_cis_shadow_changed_multiple_times_with_duplicates_and_shadow_update_failed_THEN_new_cert_generated_multiple_times(ExtensionContext context) throws Exception {
-        ignoreExceptionOfType(context, FakeIotShadowClient.SIMULATED_PUBLISH_EXCEPTION.getClass());
+    @SuppressWarnings({"unchecked", "PMD.AvoidCatchingGenericException"})
+    void GIVEN_CISShadowMonitor_WHEN_cis_shadow_changes_AND_shadow_update_request_fails_THEN_delta_processing_is_unaffected(ExtensionContext context) throws Exception {
+        ignoreExceptionOfType(context, RuntimeException.class);
+        ignoreExceptionOfType(context, CompletionException.class);
 
-        int numShadowChanges = 3;
-        CountDownLatch shadowDeltaUpdated = whenShadowDeltaUpdated(numShadowChanges * 2);
+        // capture the subscription callback for shadow delta update
+        ArgumentCaptor<Consumer<MqttMessage>> shadowDeltaUpdatedCallback = ArgumentCaptor.forClass(Consumer.class);
+        when(shadowClientConnection.subscribe(eq(SHADOW_DELTA_UPDATED_TOPIC), any(), shadowDeltaUpdatedCallback.capture())).thenReturn(DUMMY_PACKET_ID);
+
+        // generated list of deltas to feed to the shadow monitor
+        List<Map<String, Object>> deltas = IntStream.range(0, 5)
+                .mapToObj(i -> Utils.immutableMap("field", (Object) String.valueOf(i)))
+                .collect(Collectors.toList());
+        Map<String, Object> lastDelta = deltas.get(deltas.size() - 1);
+
+        // notify when last shadow update is published
+        WhenUpdateIsPublished whenUpdateIsPublished = WhenUpdateIsPublished.builder()
+                .expectedReportedState(lastDelta) // reported state updated to desired state
+                .expectedDesiredState(null) // desired state isn't modified
+                .build();
+        when(shadowClientConnection.publish(argThat(new ShadowUpdateRequestMatcher()), any(), anyBoolean()))
+                // first time, fail with direct exception
+                .thenThrow(RuntimeException.class)
+                // second time, fail with exception nested in the future
+                .thenAnswer(invocation -> {
+                    CompletableFuture<Integer> error = new CompletableFuture<>();
+                    error.completeExceptionally(new RuntimeException());
+                    return error;
+                })
+                // rest of the time, complete normally
+                .thenAnswer(whenUpdateIsPublished);
 
         cisShadowMonitor.startMonitor();
         cisShadowMonitor.addToMonitor(certificateGenerator);
 
-        shadowClient.withDuplicatePublishing(true);
-        shadowClient.onPrePublish(topic -> {
-            if (topic.endsWith("shadow/update/delta")) {
-                // force the update shadow call within cisShadowMonitor to fail
-                shadowClient.withPublishException(true);
-            }
-        });
+        // trigger update delta subscription callbacks
+        int version = 1;
+        for (Map<String, Object> delta : deltas) {
+            ShadowDeltaUpdatedEvent deltaUpdatedEvent = new ShadowDeltaUpdatedEvent();
+            deltaUpdatedEvent.version = version++;
+            deltaUpdatedEvent.state = new HashMap<>(delta);
 
-        for (int i = 1; i <= numShadowChanges; i++) {
-            shadowClient.withPublishException(false);
-            Map<String, Object> desiredState = Utils.immutableMap(SHADOW_FIELD_VERSION, String.valueOf(i));
-            publishDesiredShadowState(desiredState);
+            try {
+                wrapInMessage(SHADOW_DELTA_UPDATED_TOPIC, deltaUpdatedEvent, false).ifPresent(resp ->
+                        shadowDeltaUpdatedCallback.getValue().accept(resp));
+            } catch (RuntimeException e) {
+                if (version == 1) {
+                    // expected exception on first publish
+                    continue;
+                }
+                throw e;
+            }
         }
 
-        assertTrue(shadowDeltaUpdated.await(5L, TimeUnit.SECONDS));
-        assertDesiredAndReportedShadowState(
-                Utils.immutableMap(SHADOW_FIELD_VERSION, String.valueOf(numShadowChanges)),
-                Utils.immutableMap(SHADOW_FIELD_VERSION, String.valueOf(numShadowChanges)));
-
-        verify(certificateGenerator, times(numShadowChanges)).generateCertificate(any(), any());
+        assertTrue(whenUpdateIsPublished.getLatch().await(5L, TimeUnit.SECONDS));
+        verifyCertsRotatedWhenConnectivityChanges();
     }
 
     @Test
-    void GIVEN_CISShadowMonitor_WHEN_cis_shadow_changed_twice_and_connectivity_call_fails_once_THEN_one_cert_generated(ExtensionContext context) throws Exception {
+    @SuppressWarnings("unchecked")
+    void GIVEN_CISShadowMonitor_WHEN_cis_shadow_changes_AND_connectivity_call_fails_THEN_delta_not_processed_on_failure(ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, RuntimeException.class);
 
-        CountDownLatch shadowDeltaUpdated = whenShadowDeltaUpdated(2);
+        // make connectivity call fail the first time
+        connectivityInfoProvider.setMode(FakeConnectivityInfoProvider.Mode.FAIL_ONCE);
+
+        // capture the subscription callback for shadow delta update
+        ArgumentCaptor<Consumer<MqttMessage>> shadowDeltaUpdatedCallback = ArgumentCaptor.forClass(Consumer.class);
+        when(shadowClientConnection.subscribe(eq(SHADOW_DELTA_UPDATED_TOPIC), any(), shadowDeltaUpdatedCallback.capture())).thenReturn(DUMMY_PACKET_ID);
+
+        // generated list of deltas to feed to the shadow monitor
+        List<Map<String, Object>> deltas = IntStream.range(0, 5)
+                .mapToObj(i -> Utils.immutableMap("field", (Object) String.valueOf(i)))
+                .collect(Collectors.toList());
+        Map<String, Object> lastDelta = deltas.get(deltas.size() - 1);
+
+        // notify when last shadow update is published
+        WhenUpdateIsPublished whenUpdateIsPublished = WhenUpdateIsPublished.builder()
+                .expectedReportedState(lastDelta) // reported state updated to desired state
+                .expectedDesiredState(null) // desired state isn't modified
+                .build();
+        when(shadowClientConnection.publish(argThat(new ShadowUpdateRequestMatcher()), any(), anyBoolean()))
+                .thenAnswer(whenUpdateIsPublished);
 
         cisShadowMonitor.startMonitor();
         cisShadowMonitor.addToMonitor(certificateGenerator);
 
-        // for first delta, simulate CIS failure
-        when(mockConnectivityInfoProvider.getConnectivityInfo()).thenThrow(RuntimeException.class);
-        publishDesiredShadowState(Utils.immutableMap(SHADOW_FIELD_VERSION, "1"));
+        // trigger update delta subscription callbacks
+        AtomicInteger version = new AtomicInteger(1);
+        deltas.forEach(delta -> {
+            ShadowDeltaUpdatedEvent deltaUpdatedEvent = new ShadowDeltaUpdatedEvent();
+            deltaUpdatedEvent.version = version.getAndIncrement();
+            deltaUpdatedEvent.state = new HashMap<>(delta);
 
-        // for second delta, everything works smoothly
-        reset(mockConnectivityInfoProvider);
-        publishDesiredShadowState(Utils.immutableMap(SHADOW_FIELD_VERSION, "2"));
+            // original message
+            wrapInMessage(SHADOW_DELTA_UPDATED_TOPIC, deltaUpdatedEvent, false).ifPresent(resp ->
+                    shadowDeltaUpdatedCallback.getValue().accept(resp));
 
-        assertTrue(shadowDeltaUpdated.await(5L, TimeUnit.SECONDS));
-        assertDesiredAndReportedShadowState(
-                Utils.immutableMap(SHADOW_FIELD_VERSION, "2"),
-                Utils.immutableMap(SHADOW_FIELD_VERSION, "2"));
+            // duplicate message
+            // opted to throw this scenario in rather than split it out into its own test.
+            // we already have a specific test for duplicate messages, so no need for extra clutter.
+            wrapInMessage(SHADOW_DELTA_UPDATED_TOPIC, deltaUpdatedEvent, true).ifPresent(resp ->
+                    shadowDeltaUpdatedCallback.getValue().accept(resp));
+        });
 
-        verify(certificateGenerator, times(1)).generateCertificate(any(), any());
+        assertTrue(whenUpdateIsPublished.getLatch().await(5L, TimeUnit.SECONDS));
+        verifyCertsRotatedWhenConnectivityChanges();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void GIVEN_CISShadowMonitor_WHEN_cis_shadow_delta_duplicate_received_THEN_delta_processing_is_deduped(ExtensionContext context) throws Exception {
+        // make connectivity call yield the same response each time,
+        // to match scenario where we receive same shadow delta version multiple times.
+        connectivityInfoProvider.setMode(FakeConnectivityInfoProvider.Mode.CONSTANT);
+
+        // capture the subscription callback for shadow delta update
+        ArgumentCaptor<Consumer<MqttMessage>> shadowDeltaUpdatedCallback = ArgumentCaptor.forClass(Consumer.class);
+        when(shadowClientConnection.subscribe(eq(SHADOW_DELTA_UPDATED_TOPIC), any(), shadowDeltaUpdatedCallback.capture())).thenReturn(DUMMY_PACKET_ID);
+
+        Map<String, Object> delta = Utils.immutableMap("field", "1");
+
+        // notify when last shadow update is published
+        WhenUpdateIsPublished whenUpdateIsPublished = WhenUpdateIsPublished.builder()
+                .expectedReportedState(delta) // reported state updated to desired state
+                .expectedDesiredState(null) // desired state isn't modified
+                .build();
+        when(shadowClientConnection.publish(argThat(new ShadowUpdateRequestMatcher()), any(), anyBoolean()))
+                .thenAnswer(whenUpdateIsPublished);
+
+        cisShadowMonitor.startMonitor();
+        cisShadowMonitor.addToMonitor(certificateGenerator);
+
+        // trigger update delta subscription callbacks
+        AtomicInteger version = new AtomicInteger(1);
+
+        ShadowDeltaUpdatedEvent deltaUpdatedEvent = new ShadowDeltaUpdatedEvent();
+        deltaUpdatedEvent.version = version.getAndIncrement();
+        deltaUpdatedEvent.state = new HashMap<>(delta);
+
+
+        // send the same message multiple times
+        for (int i = 0; i < 2; i++) {
+            wrapInMessage(SHADOW_DELTA_UPDATED_TOPIC, deltaUpdatedEvent, i > 0).ifPresent(resp ->
+                    shadowDeltaUpdatedCallback.getValue().accept(resp));
+        }
+
+        assertTrue(whenUpdateIsPublished.getLatch().await(5L, TimeUnit.SECONDS));
+        verifyCertsRotatedWhenConnectivityChanges();
     }
 
     @Test
     void GIVEN_CISShadowMonitor_WHEN_stop_monitor_THEN_unsubscribe() {
+        AtomicInteger numSubscriptions = new AtomicInteger();
+        when(shadowClientConnection.subscribe(any(), any(), any())).thenAnswer(invocation -> {
+            numSubscriptions.incrementAndGet();
+            return DUMMY_PACKET_ID;
+        });
+        when(shadowClientConnection.unsubscribe(any())).thenAnswer(invocation -> {
+            numSubscriptions.decrementAndGet();
+            return DUMMY_PACKET_ID;
+        });
+
+
         cisShadowMonitor.startMonitor();
-        assertTrue(shadowClient.hasSubscriptions());
+        assertTrue(numSubscriptions.get() > 0);
+
         cisShadowMonitor.stopMonitor();
-        assertFalse(shadowClient.hasSubscriptions());
+        assertEquals(0, numSubscriptions.get());
     }
 
-    private CountDownLatch whenUpdateShadowAccepted(int times) {
-        CountDownLatch shadowUpdated = new CountDownLatch(times);
-        UpdateShadowSubscriptionRequest request = new UpdateShadowSubscriptionRequest();
-        request.thingName = SHADOW_NAME;
-        shadowClient.SubscribeToUpdateShadowAccepted(request, QualityOfService.AT_LEAST_ONCE, resp -> shadowUpdated.countDown());
-        return shadowUpdated;
+    /**
+     * Verify that certificates are rotated only when connectivity info changes.
+     *
+     * @throws KeyStoreException n/a
+     */
+    private void verifyCertsRotatedWhenConnectivityChanges() throws KeyStoreException {
+        verify(certificateGenerator, times(connectivityInfoProvider.getNumUniqueConnectivityInfoResponses())).generateCertificate(any(), any());
     }
 
-    private CountDownLatch whenShadowDeltaUpdated(int times) {
-        CountDownLatch shadowDeltaUpdated = new CountDownLatch(times);
-        ShadowDeltaUpdatedSubscriptionRequest request = new ShadowDeltaUpdatedSubscriptionRequest();
-        request.thingName = SHADOW_NAME;
-        shadowClient.SubscribeToShadowDeltaUpdatedEvents(request, QualityOfService.AT_LEAST_ONCE, resp -> shadowDeltaUpdated.countDown());
-        return shadowDeltaUpdated;
+    @Nonnull
+    private static <T> T readValue(MqttMessage message, Class<T> clazz) {
+        try {
+            return MAPPER.readValue(message.getPayload(), clazz);
+        } catch (IOException e) {
+            fail(String.format("unable to read payload of type %s", clazz.getSimpleName()), e);
+            return null;
+        }
     }
 
-    private void publishDesiredShadowState(Map<String, Object> desired) {
-        UpdateShadowRequest updateShadowRequest = new UpdateShadowRequest();
-        updateShadowRequest.thingName = SHADOW_NAME;
-        updateShadowRequest.state = new ShadowState();
-        updateShadowRequest.state.desired = new HashMap<>(desired);
-        shadowClient.PublishUpdateShadow(updateShadowRequest, QualityOfService.AT_LEAST_ONCE);
+    private static <T> Optional<MqttMessage> wrapInMessage(String topic, T payload, boolean dup) {
+        try {
+            return Optional.of(new MqttMessage(
+                    topic,
+                    MAPPER.writeValueAsString(payload).getBytes(StandardCharsets.UTF_8),
+                    QualityOfService.AT_LEAST_ONCE,
+                    false,
+                    dup)
+            );
+        } catch (JsonProcessingException e) {
+            return Optional.empty();
+        }
     }
 
-    private void verifyGetShadowAcceptedSubscription() {
-        ArgumentCaptor<GetShadowSubscriptionRequest> request = ArgumentCaptor.forClass(GetShadowSubscriptionRequest.class);
-        shadowClientOrder.verify(shadowClient, times(1)).SubscribeToGetShadowAccepted(request.capture(), eq(QualityOfService.AT_LEAST_ONCE), any(), any());
-        assertEquals(SHADOW_NAME, request.getValue().thingName);
+    static class GetShadowRequestMatcher implements ArgumentMatcher<MqttMessage> {
+        @Override
+        public boolean matches(MqttMessage message) {
+            if (message == null) {
+                return false;
+            }
+            GetShadowRequest request = readValue(message, GetShadowRequest.class);
+            return Objects.equals(message.getTopic(), GET_SHADOW_TOPIC) &&
+                    Objects.equals(SHADOW_NAME, request.thingName);
+        }
     }
 
-    private void verifyShadowDeltaUpdatedSubscription() {
-        ArgumentCaptor<ShadowDeltaUpdatedSubscriptionRequest> request = ArgumentCaptor.forClass(ShadowDeltaUpdatedSubscriptionRequest.class);
-        shadowClientOrder.verify(shadowClient, times(1)).SubscribeToShadowDeltaUpdatedEvents(request.capture(), eq(QualityOfService.AT_LEAST_ONCE), any(), any());
-        assertEquals(SHADOW_NAME, request.getValue().thingName);
+    @Builder
+    static class ShadowUpdateRequestMatcher implements ArgumentMatcher<MqttMessage> {
+        @Override
+        public boolean matches(MqttMessage message) {
+            if (message == null) {
+                return false;
+            }
+            UpdateShadowRequest request = readValue(message, UpdateShadowRequest.class);
+            return Objects.equals(message.getTopic(), UPDATE_SHADOW_TOPIC) &&
+                    Objects.equals(SHADOW_NAME, request.thingName);
+        }
     }
 
-    private void verifyPublishGetShadow() {
-        ArgumentCaptor<GetShadowRequest> request = ArgumentCaptor.forClass(GetShadowRequest.class);
-        shadowClientOrder.verify(shadowClient, times(1)).PublishGetShadow(request.capture(), eq(QualityOfService.AT_LEAST_ONCE));
-        assertEquals(SHADOW_NAME, request.getValue().thingName);
-    }
+    @Builder
+    static class WhenUpdateIsPublished implements Answer<CompletableFuture<Integer>> {
 
-    private void assertDesiredAndReportedShadowState(Map<String, Object> desired, Map<String, Object> reported) {
-        ShadowState state = shadowClient.getShadow(SHADOW_NAME).state;
-        assertEquals(desired, state.desired, "unexpected desired state");
-        assertEquals(reported, state.reported, "unexpected reported state");
-    }
+        @Getter(AccessLevel.PACKAGE)
+        private final CountDownLatch latch = new CountDownLatch(1);
+        private final Map<String, Object> expectedReportedState;
+        private final Map<String, Object> expectedDesiredState;
 
+        @Override
+        public CompletableFuture<Integer> answer(InvocationOnMock invocation) {
+            MqttMessage message = invocation.getArgument(0);
+            if (message == null || !message.getTopic().equals(UPDATE_SHADOW_TOPIC)) {
+                return DUMMY_PACKET_ID;
+            }
+
+            UpdateShadowRequest request = readValue(message, UpdateShadowRequest.class);
+            if (Objects.equals(request.state.reported, expectedReportedState) &&
+                    Objects.equals(request.state.desired, expectedDesiredState)) {
+                latch.countDown();
+            }
+            return DUMMY_PACKET_ID;
+        }
+    }
 
     static class FakeIotShadowClient extends IotShadowClient {
 
-        static final RuntimeException SIMULATED_PUBLISH_EXCEPTION = new RuntimeException("simulated publish error");
-        private static final CompletableFuture<Integer> DUMMY_PACKET_ID = CompletableFuture.completedFuture(0);
-        private static final int INITIAL_SHADOW_VERSION = 1;
-        private static final Gson MAPPER = new GsonBuilder()
-                .disableHtmlEscaping()
-                .registerTypeAdapter(Timestamp.class, new Timestamp.Serializer())
-                .registerTypeAdapter(Timestamp.class, new Timestamp.Deserializer())
-                .registerTypeAdapterFactory(new ShadowStateFactory())
-                .create();
-
-        private final Map<String, List<Consumer<MqttMessage>>> subscriptionsByTopic = new ConcurrentHashMap<>();
-        private final Map<String, Shadow> shadowByThingName = new ConcurrentHashMap<>();
-        private final AtomicReference<Consumer<String>> onPrePublish = new AtomicReference<>();
-        private final AtomicBoolean withDuplicatePublishing = new AtomicBoolean();
-        private final AtomicBoolean withPublishException = new AtomicBoolean();
-
         @Getter(AccessLevel.PACKAGE)
         private final MqttClientConnection connection;
-
-        @Data
-        @Builder
-        static class Shadow {
-            final int version;
-            final ShadowState state;
-
-            static Shadow copy(Shadow other) {
-                ShadowBuilder builder = Shadow.builder();
-                if (other.state != null) {
-                    builder.state = new ShadowState();
-                    if (other.state.desired != null) {
-                        builder.state.desired = new HashMap<>(other.state.desired);
-                    }
-                    if (other.state.reported != null) {
-                        builder.state.reported = new HashMap<>(other.state.reported);
-                    }
-                }
-                return builder
-                        .version(other.version)
-                        .build();
-            }
-
-            public Map<String, Object> calculateDelta() {
-                Map<String, Object> delta = new HashMap<>();
-
-                if (state == null) {
-                    return delta;
-                }
-
-                Map<String, Object> desired = state.desired;
-                if (desired == null || desired.isEmpty()) {
-                    return delta;
-                }
-
-                Map<String, Object> reported = state.reported;
-                if (reported == null || reported.isEmpty()) {
-                    delta.putAll(desired);
-                    return delta;
-                }
-
-                for (Map.Entry<String, Object> entry : desired.entrySet()) {
-                    if (reported.containsKey(entry.getKey())) {
-                        if (!Objects.equals(reported.get(entry.getKey()), entry.getValue())) {
-                            delta.put(entry.getKey(), entry.getValue());
-                        }
-                    } else {
-                        delta.put(entry.getKey(), entry.getValue());
-                    }
-                }
-                return delta;
-            }
-        }
 
         FakeIotShadowClient() {
             this(mock(MqttClientConnection.class));
@@ -503,222 +514,80 @@ public class CISShadowMonitorTest {
         private FakeIotShadowClient(MqttClientConnection connection) {
             super(connection);
             this.connection = connection;
-            // store subscriptions in-memory on subscribe
-            when(this.connection.subscribe(any(), any(), any())).thenAnswer(invocation ->
-                    propagateException(() -> {
-                        String topic = invocation.getArgument(0);
-                        Consumer<MqttMessage> messageHandler = invocation.getArgument(2);
-                        subscriptionsByTopic.computeIfAbsent(topic, t -> new CopyOnWriteArrayList<>())
-                                .add(messageHandler);
-                        return DUMMY_PACKET_ID;
-                    })
-            );
-            // fire messages to subscriptions on publish
-            when(this.connection.publish(any(), any(), anyBoolean())).thenAnswer(invocation ->
-                    propagateException(() -> {
-                        MqttMessage message = invocation.getArgument(0);
-                        String topic = message.getTopic();
+            when(this.connection.subscribe(any(), any(), any())).thenReturn(DUMMY_PACKET_ID);
+            when(this.connection.publish(any(), any(), anyBoolean())).thenReturn(DUMMY_PACKET_ID);
+            when(this.connection.unsubscribe(any())).thenReturn(DUMMY_PACKET_ID);
+        }
+    }
 
-                        if (topic.endsWith("shadow/get")) {
-                            readPayload(message, GetShadowRequest.class)
-                                    .ifPresent(this::handleGetShadowRequest);
-                        } else if (topic.endsWith("shadow/update")) {
-                            readPayload(message, UpdateShadowRequest.class)
-                                    .ifPresent(this::handleUpdateShadowRequest);
-                        } else {
-                            throw new UnsupportedOperationException("please add a new handler for " + topic);
-                        }
-                        return DUMMY_PACKET_ID;
-                    })
-            );
-            // delete subscriptions on unsubscribe
-            when(this.connection.unsubscribe(any())).thenAnswer(invocation ->
-                    propagateException(() -> {
-                        String topic = invocation.getArgument(0);
-                        subscriptionsByTopic.remove(topic);
-                        return DUMMY_PACKET_ID;
-                    })
-            );
+    static class FakeConnectivityInfoProvider extends ConnectivityInfoProvider {
+
+        private final AtomicReference<List<ConnectivityInfo>> CONNECTIVITY_INFO_SAMPLE = new AtomicReference<>(Collections.singletonList(connectivityInfoWithRandomHost()));
+        private final Set<Integer> responseHashes = new CopyOnWriteArraySet<>();
+        private final AtomicReference<Mode> mode = new AtomicReference<>(Mode.RANDOM);
+        private final AtomicBoolean failed = new AtomicBoolean();
+
+        enum Mode {
+            /**
+             * Each call to getConnectivityInfo returns a unique, random response.
+             */
+            RANDOM,
+            /**
+             * Each call to getConnectivityInfo yields the same response.
+             */
+            CONSTANT,
+            /**
+             * Throw a runtime exception only the FIRST time getConnectivityInfo is called.
+             * Subsequent calls follow {@link Mode#RANDOM} behavior.
+             */
+            FAIL_ONCE
         }
 
-        private void handleGetShadowRequest(GetShadowRequest request) {
-            Shadow shadow = getShadow(request.thingName);
-            if (shadow == null) {
-                String rejected = String.format("$aws/things/%s/shadow/get/rejected", request.thingName);
-                ErrorResponse response = new ErrorResponse();
-                response.message = "no shadow found";
-                publishMessage(rejected, response);
-            } else {
-                String accepted = String.format("$aws/things/%s/shadow/get/accepted", request.thingName);
-                GetShadowResponse response = new GetShadowResponse();
-                response.version = shadow.version;
-                response.state = new ShadowStateWithDelta();
-                response.state.desired = shadow.state.desired;
-                response.state.reported = shadow.state.reported;
-                response.state.delta = new HashMap<>(shadow.calculateDelta());
-                publishMessage(accepted, response);
-            }
+        FakeConnectivityInfoProvider() {
+            super(null, null);
         }
 
-        @SuppressWarnings("PMD.PrematureDeclaration")
-        private void handleUpdateShadowRequest(UpdateShadowRequest request) {
-            final AtomicBoolean accepted = new AtomicBoolean();
-            final AtomicBoolean versionConflict = new AtomicBoolean();
+        void setMode(Mode mode) {
+            this.mode.set(mode);
+        }
 
-            // update internal shadow state based on the request.
-            // if no shadow exists, create a new one
-            Shadow computedShadow = shadowByThingName.compute(request.thingName, (thingName, existingShadow) -> {
-                Shadow shadow = existingShadow == null ?
-                        Shadow.builder()
-                                .state(request.state)
-                                .version(INITIAL_SHADOW_VERSION)
-                                .build()
-                        : existingShadow;
+        /**
+         * Get the number of unique responses to getConnectivityInfo provided by this fake.
+         *
+         * @return number of unique connectivity info responses generated by this fake
+         */
+        int getNumUniqueConnectivityInfoResponses() {
+            return responseHashes.size();
+        }
 
-                // if version is provided, it must match the latest version
-                // https://docs.aws.amazon.com/iot/latest/developerguide/device-shadow-data-flow.html#optimistic-locking
-                if (request.version != null && request.version != shadow.version) {
-                    versionConflict.set(true);
-                    return existingShadow;
-                }
+        @Override
+        public List<ConnectivityInfo> getConnectivityInfo() {
+            List<ConnectivityInfo> connectivityInfo = doGetConnectivityInfo();
+            cachedHostAddresses = connectivityInfo.stream().map(ConnectivityInfo::hostAddress).distinct().collect(Collectors.toList());
+            responseHashes.add(cachedHostAddresses.hashCode());
+            return connectivityInfo;
+        }
 
-                accepted.set(true);
-
-                return applyRequestToShadow(shadow, request);
-            });
-
-            if (versionConflict.get()) {
-                publishVersionConflictError(request.thingName);
-                return;
-            }
-
-            if (accepted.get()) {
-                publishShadowAccepted(request.thingName);
-            }
-
-            Map<String, Object> delta = computedShadow.calculateDelta();
-            if (!delta.isEmpty()) {
-                publishShadowDelta(delta, computedShadow.version, request.thingName);
+        private List<ConnectivityInfo> doGetConnectivityInfo() {
+            switch (mode.get()) {
+                case FAIL_ONCE:
+                    if (!failed.getAndSet(true)) {
+                        throw new RuntimeException("simulated getConnectivityInfo failure");
+                    }
+                    // fall-through to random behavior
+                case RANDOM:
+                    return Collections.singletonList(connectivityInfoWithRandomHost());
+                case CONSTANT:
+                    return CONNECTIVITY_INFO_SAMPLE.get();
+                default:
+                    return Collections.emptyList();
             }
         }
 
-        private Shadow applyRequestToShadow(Shadow shadow, UpdateShadowRequest request) {
-            if (request.state.desired == null && request.state.reported == null) {
-                return Shadow.copy(shadow);
-            }
-
-            Map<String, Object> desired = request.state.desired == null ? shadow.state.desired : request.state.desired;
-            Map<String, Object> reported = request.state.reported == null ? shadow.state.reported : request.state.reported;
-
-            ShadowState shadowState = new ShadowState();
-            shadowState.reported = reported == null ? null : new HashMap<>(reported);
-            shadowState.desired = desired == null ? null : new HashMap<>(desired);
-
-            return Shadow.builder()
-                    .state(shadowState)
-                    .version(shadow.version + 1)
+        private static ConnectivityInfo connectivityInfoWithRandomHost() {
+            return ConnectivityInfo.builder()
+                    .hostAddress(Utils.generateRandomString(20))
                     .build();
-        }
-
-        private void publishVersionConflictError(String thingName) {
-            publishShadowUpdateRejected(thingName, 409, "Version Conflict");
-        }
-
-        private void publishShadowAccepted(String thingName) {
-            String topic = String.format("$aws/things/%s/shadow/update/accepted", thingName);
-            ShadowUpdatedEvent event = new ShadowUpdatedEvent();
-            publishMessage(topic, event);
-        }
-
-        private void publishShadowUpdateRejected(String thingName, Integer code, String message) {
-            String topic = String.format("$aws/things/%s/shadow/update/rejected", thingName);
-            ErrorResponse resp = new ErrorResponse();
-            resp.code = code;
-            resp.message = message;
-            publishMessage(topic, resp);
-        }
-
-        private void publishShadowDelta(Map<String, Object> delta, int version, String thingName) {
-            String topic = String.format("$aws/things/%s/shadow/update/delta", thingName);
-            ShadowDeltaUpdatedEvent event = new ShadowDeltaUpdatedEvent();
-            event.state = new HashMap<>(delta);
-            event.version = version;
-            publishMessage(topic, event);
-        }
-
-        private static <T> Optional<T> readPayload(MqttMessage message, Class<T> clazz) {
-            try {
-                String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
-                return Optional.of(MAPPER.fromJson(payload, clazz));
-            } catch (JsonParseException e) {
-                return Optional.empty();
-            }
-        }
-
-        private <T> Optional<MqttMessage> wrapInMessage(String topic, T payload, boolean dup) {
-            try {
-                return Optional.of(new MqttMessage(
-                        topic,
-                        MAPPER.toJson(payload).getBytes(StandardCharsets.UTF_8),
-                        QualityOfService.AT_LEAST_ONCE,
-                        false,
-                        dup)
-                );
-            } catch (JsonParseException e) {
-                return Optional.empty();
-            }
-        }
-
-        private <T> void publishMessage(String topic, T event) {
-            if (withPublishException.get()) {
-                throw SIMULATED_PUBLISH_EXCEPTION;
-            }
-
-            Consumer<String> onPrePublish = this.onPrePublish.get();
-            if (onPrePublish != null) {
-                onPrePublish.accept(topic);
-            }
-
-            List<Consumer<MqttMessage>> subscribers = subscriptionsByTopic.get(topic);
-            if (subscribers != null) {
-                subscribers.forEach(subscriber ->
-                        wrapInMessage(topic, event, false).ifPresent(subscriber));
-                if (withDuplicatePublishing.get()) {
-                    subscribers.forEach(subscriber ->
-                            wrapInMessage(topic, event, true).ifPresent(subscriber));
-                }
-            }
-        }
-
-        @SuppressWarnings("PMD.AvoidCatchingGenericException")
-        private CompletableFuture<Integer> propagateException(Callable<CompletableFuture<Integer>> action) {
-            try {
-                return action.call();
-            } catch (Exception e) {
-                CompletableFuture<Integer> cf = new CompletableFuture<>();
-                cf.completeExceptionally(e);
-                return cf;
-            }
-        }
-
-        void onPrePublish(Consumer<String> action) {
-            onPrePublish.set(action);
-        }
-
-        void withPublishException(boolean publishException) {
-            withPublishException.set(publishException);
-        }
-
-        void withDuplicatePublishing(boolean duplicatePublishing) {
-            withDuplicatePublishing.set(duplicatePublishing);
-        }
-
-        boolean hasSubscriptions() {
-            return !subscriptionsByTopic.isEmpty();
-        }
-
-        Shadow getShadow(String thingName) {
-            return Shadow.copy(shadowByThingName.get(thingName));
         }
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

This change fixes the handling of CIS shadow delta updates within `CISShadowMonitor` and adds more exception logging:

* `UpdateShadowRequest#state` field is now populated. Previously, this was causing a `NullPointerException` when the request was processed by `IotShadowClient`.
* `lastVersion` is **always** set after certs have been rotated, to prevent unnecessary cert rotations if the same shadow delta version is processed twice.
* All exceptions are now logged via `CompletableFuture#exceptionally`, when previously some were silently ignored.
* `CISShadowMonitorTest` is completely refactored and uses a fake implementation of `IotShadowClient`.  This allows the test to hit the `NullPointerException` code path mentioned above.

**Why is this change necessary:**

* To prevent unnecessary certificate rotations
* To guarantee logs are provided in error cases when handling CIS shadow delta updates

**How was this change tested:**

Unit tests

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
