### PR TITLE
chore: use new fetchGreengrassV2DataClient API

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/AuthorizeClientDeviceActionTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/AuthorizeClientDeviceActionTest.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.integrationtests.ipc;
 
 import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.device.AuthorizationRequest;
 import com.aws.greengrass.device.ClientDevicesAuthService;
 import com.aws.greengrass.device.DeviceAuthClient;
@@ -79,13 +80,13 @@ class AuthorizeClientDeviceActionTest {
     }
 
     @BeforeEach
-    void beforeEach() {
+    void beforeEach() throws DeviceConfigurationException {
         // Set this property for kernel to scan its own classpath to find plugins
         System.setProperty("aws.greengrass.scanSelfClasspath", "true");
         kernel = new Kernel();
         kernel.getContext().put(GreengrassServiceClientFactory.class, clientFactory);
 
-        when(clientFactory.getGreengrassV2DataClient()).thenReturn(v2DataClient);
+        when(clientFactory.fetchGreengrassV2DataClient()).thenReturn(v2DataClient);
 
     }
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/GetClientDeviceAuthTokenTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/GetClientDeviceAuthTokenTest.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.integrationtests.ipc;
 
 import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.device.ClientDevicesAuthService;
 import com.aws.greengrass.device.exception.AuthenticationException;
 import com.aws.greengrass.device.exception.CloudServiceInteractionException;
@@ -79,13 +80,13 @@ class GetClientDeviceAuthTokenTest {
     }
 
     @BeforeEach
-    void beforeEach() {
+    void beforeEach() throws DeviceConfigurationException {
         // Set this property for kernel to scan its own classpath to find plugins
         System.setProperty("aws.greengrass.scanSelfClasspath", "true");
         kernel = new Kernel();
         kernel.getContext().put(GreengrassServiceClientFactory.class, clientFactory);
 
-        when(clientFactory.getGreengrassV2DataClient()).thenReturn(client);
+        when(clientFactory.fetchGreengrassV2DataClient()).thenReturn(client);
 
     }
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/SubscribeToCertificateUpdatesTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/SubscribeToCertificateUpdatesTest.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.integrationtests.ipc;
 
 import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.device.ClientDevicesAuthService;
 import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
@@ -96,12 +97,12 @@ class SubscribeToCertificateUpdatesTest {
     }
 
     @BeforeEach
-    void beforeEach() {
+    void beforeEach() throws DeviceConfigurationException {
         // Set this property for kernel to scan its own classpath to find plugins
         System.setProperty("aws.greengrass.scanSelfClasspath", "true");
         kernel = new Kernel();
         kernel.getContext().put(GreengrassServiceClientFactory.class, clientFactory);
-        lenient().when(clientFactory.getGreengrassV2DataClient()).thenReturn(client);
+        lenient().when(clientFactory.fetchGreengrassV2DataClient()).thenReturn(client);
     }
 
     private void startNucleusWithConfig(String configFileName) throws InterruptedException {

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/VerifyClientDeviceIdentityTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/VerifyClientDeviceIdentityTest.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.integrationtests.ipc;
 
 import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.device.ClientDevicesAuthService;
 import com.aws.greengrass.device.exception.CloudServiceInteractionException;
 import com.aws.greengrass.device.iot.IotAuthClient;
@@ -78,13 +79,13 @@ class VerifyClientDeviceIdentityTest {
     }
 
     @BeforeEach
-    void beforeEach() {
+    void beforeEach() throws DeviceConfigurationException {
         // Set this property for kernel to scan its own classpath to find plugins
         System.setProperty("aws.greengrass.scanSelfClasspath", "true");
         kernel = new Kernel();
         kernel.getContext().put(GreengrassServiceClientFactory.class, clientFactory);
 
-        when(clientFactory.getGreengrassV2DataClient()).thenReturn(client);
+        when(clientFactory.fetchGreengrassV2DataClient()).thenReturn(client);
 
     }
 
@@ -192,7 +193,7 @@ class VerifyClientDeviceIdentityTest {
         software.amazon.awssdk.services.greengrassv2data.model.VerifyClientDeviceIdentityRequest re =
                 software.amazon.awssdk.services.greengrassv2data.model.VerifyClientDeviceIdentityRequest.builder()
                         .clientDeviceCertificate("ValidationException PEM").build();
-        when(clientFactory.getGreengrassV2DataClient().verifyClientDeviceIdentity(re))
+        when(clientFactory.fetchGreengrassV2DataClient().verifyClientDeviceIdentity(re))
                 .thenThrow(ValidationException.class);
         ignoreExceptionOfType(context, ValidationException.class);
         try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,

--- a/src/main/java/com/aws/greengrass/cisclient/ConnectivityInfoProvider.java
+++ b/src/main/java/com/aws/greengrass/cisclient/ConnectivityInfoProvider.java
@@ -6,17 +6,22 @@
 package com.aws.greengrass.cisclient;
 
 import com.aws.greengrass.deployment.DeviceConfiguration;
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
+import com.aws.greengrass.util.RetryUtils;
+import software.amazon.awssdk.services.greengrassv2data.GreengrassV2DataClient;
 import software.amazon.awssdk.services.greengrassv2data.model.ConnectivityInfo;
 import software.amazon.awssdk.services.greengrassv2data.model.GetConnectivityInfoRequest;
 import software.amazon.awssdk.services.greengrassv2data.model.GetConnectivityInfoResponse;
 import software.amazon.awssdk.services.greengrassv2data.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.greengrassv2data.model.ValidationException;
 
+import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -32,6 +37,12 @@ public class ConnectivityInfoProvider {
     private final GreengrassServiceClientFactory clientFactory;
 
     private volatile List<String> cachedHostAddresses = Collections.emptyList();
+
+    public static final int CLIENT_RETRY_COUNT = 3;
+    private static final RetryUtils.RetryConfig CLIENT_EXCEPTION_RETRY_CONFIG =
+            RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofSeconds(30))
+                    .maxRetryInterval(Duration.ofSeconds(30)).maxAttempt(CLIENT_RETRY_COUNT)
+                    .retryableExceptions(Arrays.asList(DeviceConfigurationException.class)).build();
 
     /**
      * Constructor.
@@ -59,14 +70,19 @@ public class ConnectivityInfoProvider {
      * Get connectivity info.
      *
      * @return list of connectivity info items
+     * @throws Exception when not able to retrieve greengrasV2DataClient
      */
-    public List<ConnectivityInfo> getConnectivityInfo() {
+    @SuppressWarnings("PMD.SignatureDeclareThrowsException")
+    public List<ConnectivityInfo> getConnectivityInfo() throws Exception {
         GetConnectivityInfoRequest getConnectivityInfoRequest = GetConnectivityInfoRequest.builder()
                 .thingName(Coerce.toString(deviceConfiguration.getThingName())).build();
         List<ConnectivityInfo> connectivityInfoList = Collections.emptyList();
 
-        try {
-            GetConnectivityInfoResponse getConnectivityInfoResponse = clientFactory.getGreengrassV2DataClient()
+        try (GreengrassV2DataClient client = RetryUtils.runWithRetry(CLIENT_EXCEPTION_RETRY_CONFIG, () -> {
+            return clientFactory.fetchGreengrassV2DataClient();
+        }, "get-greengrass-v2-data-client", LOGGER)) {
+
+            GetConnectivityInfoResponse getConnectivityInfoResponse = client
                     .getConnectivityInfo(getConnectivityInfoRequest);
             if (getConnectivityInfoResponse.hasConnectivityInfo()) {
                 // Filter out port and metadata since it is not needed

--- a/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
@@ -15,6 +15,7 @@ import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.config.WhatHappened;
 import com.aws.greengrass.dependency.ImplementsService;
 import com.aws.greengrass.deployment.DeviceConfiguration;
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.device.configuration.GroupConfiguration;
 import com.aws.greengrass.device.configuration.GroupManager;
 import com.aws.greengrass.device.exception.CloudServiceInteractionException;
@@ -67,7 +68,8 @@ public class ClientDevicesAuthService extends PluginService {
             .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS, MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES);
     private static final RetryUtils.RetryConfig SERVICE_EXCEPTION_RETRY_CONFIG =
             RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofSeconds(3)).maxAttempt(Integer.MAX_VALUE)
-                    .retryableExceptions(Arrays.asList(ThrottlingException.class, InternalServerException.class))
+                    .retryableExceptions(Arrays.asList(ThrottlingException.class, InternalServerException.class,
+                            DeviceConfigurationException.class))
                     .build();
 
     private final GroupManager groupManager;
@@ -249,7 +251,7 @@ public class ClientDevicesAuthService extends PluginService {
                         .coreDeviceCertificates(certificatePemList).build();
         try {
             RetryUtils.runWithRetry(SERVICE_EXCEPTION_RETRY_CONFIG,
-                    () -> clientFactory.getGreengrassV2DataClient().putCertificateAuthorities(request),
+                    () -> clientFactory.fetchGreengrassV2DataClient().putCertificateAuthorities(request),
                     "put-core-ca-certificate", logger);
         } catch (InterruptedException e) {
             logger.atError().cause(e).log("Put core CA certificates got interrupted");

--- a/src/test/java/com/aws/greengrass/device/ClientDevicesAuthServiceTest.java
+++ b/src/test/java/com/aws/greengrass/device/ClientDevicesAuthServiceTest.java
@@ -10,6 +10,7 @@ import com.aws.greengrass.certificatemanager.certificate.CertificateHelper;
 import com.aws.greengrass.componentmanager.KernelConfigResolver;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.device.configuration.ConfigurationFormatVersion;
 import com.aws.greengrass.device.configuration.GroupConfiguration;
 import com.aws.greengrass.device.configuration.GroupManager;
@@ -103,7 +104,7 @@ class ClientDevicesAuthServiceTest {
 
 
     @BeforeEach
-    void setup() {
+    void setup() throws DeviceConfigurationException {
         // Set this property for kernel to scan its own classpath to find plugins
         System.setProperty("aws.greengrass.scanSelfClasspath", "true");
         kernel = new Kernel();
@@ -111,7 +112,7 @@ class ClientDevicesAuthServiceTest {
         kernel.getContext().put(CertificateExpiryMonitor.class, certExpiryMonitor);
         kernel.getContext().put(GreengrassServiceClientFactory.class, clientFactory);
 
-        lenient().when(clientFactory.getGreengrassV2DataClient()).thenReturn(client);
+        lenient().when(clientFactory.fetchGreengrassV2DataClient()).thenReturn(client);
     }
 
     @AfterEach

--- a/src/test/java/com/aws/greengrass/device/iot/IotAuthClientTest.java
+++ b/src/test/java/com/aws/greengrass/device/iot/IotAuthClientTest.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.device.iot;
 
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.device.exception.CloudServiceInteractionException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
@@ -65,8 +66,8 @@ public class IotAuthClientTest {
     private ArgumentCaptor<VerifyClientDeviceIoTCertificateAssociationRequest> associationRequestCaptor;
 
     @BeforeEach
-    void beforeEach() {
-        lenient().when(clientFactory.getGreengrassV2DataClient()).thenReturn(client);
+    void beforeEach() throws DeviceConfigurationException {
+        lenient().when(clientFactory.fetchGreengrassV2DataClient()).thenReturn(client);
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Updating code to use new fetchGreengrassV2DataClient API. 

**Why is this change necessary:**
This API throws DeviceConfigurationException instead of returning null when the client is not available due to a config error. This avoids an NPE.

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
