### PR TITLE
fix: handle null response from getGreengrassV2DataClient

### DIFF
--- a/src/main/java/com/aws/greengrass/cisclient/ConnectivityInfoProvider.java
+++ b/src/main/java/com/aws/greengrass/cisclient/ConnectivityInfoProvider.java
@@ -6,8 +6,10 @@
 package com.aws.greengrass.cisclient;
 
 import com.aws.greengrass.deployment.DeviceConfiguration;
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.util.ClientUtil;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import software.amazon.awssdk.services.greengrassv2data.model.ConnectivityInfo;
@@ -59,14 +61,16 @@ public class ConnectivityInfoProvider {
      * Get connectivity info.
      *
      * @return list of connectivity info items
+     * @throws DeviceConfigurationException when fails to get GreengrassV2DataClient.
      */
-    public List<ConnectivityInfo> getConnectivityInfo() {
+    public List<ConnectivityInfo> getConnectivityInfo() throws DeviceConfigurationException {
         GetConnectivityInfoRequest getConnectivityInfoRequest = GetConnectivityInfoRequest.builder()
                 .thingName(Coerce.toString(deviceConfiguration.getThingName())).build();
         List<ConnectivityInfo> connectivityInfoList = Collections.emptyList();
 
         try {
-            GetConnectivityInfoResponse getConnectivityInfoResponse = clientFactory.getGreengrassV2DataClient()
+            GetConnectivityInfoResponse getConnectivityInfoResponse =
+                    ClientUtil.fetchGreengrassV2DataClient(clientFactory)
                     .getConnectivityInfo(getConnectivityInfoRequest);
             if (getConnectivityInfoResponse.hasConnectivityInfo()) {
                 // Filter out port and metadata since it is not needed

--- a/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
@@ -17,6 +17,7 @@ import com.aws.greengrass.device.configuration.GroupConfiguration;
 import com.aws.greengrass.device.configuration.GroupManager;
 import com.aws.greengrass.device.exception.CloudServiceInteractionException;
 import com.aws.greengrass.lifecyclemanager.PluginService;
+import com.aws.greengrass.util.ClientUtil;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import com.aws.greengrass.util.RetryUtils;
@@ -184,7 +185,7 @@ public class ClientDevicesAuthService extends PluginService {
                         .coreDeviceCertificates(certificatePemList).build();
         try {
             RetryUtils.runWithRetry(SERVICE_EXCEPTION_RETRY_CONFIG,
-                    () -> clientFactory.getGreengrassV2DataClient().putCertificateAuthorities(request),
+                    () -> ClientUtil.fetchGreengrassV2DataClient(clientFactory).putCertificateAuthorities(request),
                     "put-core-ca-certificate", logger);
         } catch (InterruptedException e) {
             logger.atError().cause(e).log("Put core CA certificates got interrupted");

--- a/src/main/java/com/aws/greengrass/device/iot/IotAuthClient.java
+++ b/src/main/java/com/aws/greengrass/device/iot/IotAuthClient.java
@@ -9,6 +9,7 @@ package com.aws.greengrass.device.iot;
 import com.aws.greengrass.device.exception.CloudServiceInteractionException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.util.ClientUtil;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import com.aws.greengrass.util.RetryUtils;
 import com.aws.greengrass.util.Utils;
@@ -98,7 +99,7 @@ public interface IotAuthClient {
                             .clientDeviceCertificateId(certificate.getIotCertificateId()).build();
             try {
                 RetryUtils.runWithRetry(SERVICE_EXCEPTION_RETRY_CONFIG,
-                        () -> clientFactory.getGreengrassV2DataClient()
+                        () -> ClientUtil.fetchGreengrassV2DataClient(clientFactory)
                                 .verifyClientDeviceIoTCertificateAssociation(request),
                         "verify-certificate-thing-association", logger);
                 logger.atDebug().kv("thingName", thing.getThingName())

--- a/src/main/java/com/aws/greengrass/util/ClientUtil.java
+++ b/src/main/java/com/aws/greengrass/util/ClientUtil.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.util;
+
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
+import software.amazon.awssdk.services.greengrassv2data.GreengrassV2DataClient;
+
+public final class ClientUtil {
+
+    private ClientUtil() {
+    }
+
+    /**
+     * Initializes and returns GreengrassV2DataClient.
+     * @param factory GreengrassServiceClientFactory
+     * @throws DeviceConfigurationException when fails to get GreengrassV2DataClient.
+     */
+    public static GreengrassV2DataClient fetchGreengrassV2DataClient(GreengrassServiceClientFactory factory)
+            throws DeviceConfigurationException {
+        GreengrassV2DataClient client = factory.getGreengrassV2DataClient();
+        if (client == null) {
+            String errorMessage =
+                    factory.getConfigValidationError() == null
+                            ? "Could not get GreengrassV2DataClient." : factory.getConfigValidationError();
+            throw new DeviceConfigurationException(errorMessage);
+        }
+        return client;
+    }
+}

--- a/src/test/java/com/aws/greengrass/cisclient/ConnectivityInfoProviderTest.java
+++ b/src/test/java/com/aws/greengrass/cisclient/ConnectivityInfoProviderTest.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.cisclient;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.deployment.DeviceConfiguration;
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,7 +66,8 @@ public class ConnectivityInfoProviderTest {
 
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
     @Test
-    void GIVEN_connectivity_info_WHEN_get_connectivity_info_THEN_connectivity_info_returned() {
+    void GIVEN_connectivity_info_WHEN_get_connectivity_info_THEN_connectivity_info_returned()
+            throws DeviceConfigurationException {
         ConnectivityInfo connectivityInfo = ConnectivityInfo.builder().hostAddress("172.8.8.10")
                 .metadata("").id("172.8.8.10").portNumber(8883).build();
         ConnectivityInfo connectivityInfo1 = ConnectivityInfo.builder().hostAddress("localhost")
@@ -82,7 +84,8 @@ public class ConnectivityInfoProviderTest {
     }
 
     @Test
-    void GIVEN_no_connectivity_info_WHEN_get_connectivity_info_THEN_no_connectivity_info_returned() {
+    void GIVEN_no_connectivity_info_WHEN_get_connectivity_info_THEN_no_connectivity_info_returned()
+            throws DeviceConfigurationException {
         GetConnectivityInfoResponse getConnectivityInfoResponse = GetConnectivityInfoResponse.builder().build();
         doReturn(getConnectivityInfoResponse).when(greengrassV2DataClient)
                 .getConnectivityInfo(any(GetConnectivityInfoRequest.class));
@@ -95,7 +98,7 @@ public class ConnectivityInfoProviderTest {
 
     @Test
     void GIVEN_cloudThrowValidationException_WHEN_get_connectivity_info_THEN_no_connectivity_info_returned(
-            ExtensionContext context) {
+            ExtensionContext context) throws DeviceConfigurationException {
         ignoreExceptionOfType(context, ValidationException.class);
         when(greengrassV2DataClient.getConnectivityInfo(any(GetConnectivityInfoRequest.class)))
                 .thenThrow(ValidationException.class);
@@ -105,7 +108,8 @@ public class ConnectivityInfoProviderTest {
 
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
     @Test
-    void GIVEN_cached_connectivity_info_WHEN_get_cached_connectivity_info_THEN_connectivity_info_returned() {
+    void GIVEN_cached_connectivity_info_WHEN_get_cached_connectivity_info_THEN_connectivity_info_returned()
+            throws DeviceConfigurationException {
         ConnectivityInfo connectivityInfo = ConnectivityInfo.builder().hostAddress("172.8.8.10")
                 .metadata("").id("172.8.8.10").portNumber(8883).build();
         ConnectivityInfo connectivityInfo1 = ConnectivityInfo.builder().hostAddress("localhost")


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Handle null response from getGreengrassV2DataClient

**Why is this change necessary:**
Needed to avoid NPE when getGreengrassV2DataClient returns null

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
