### PR TITLE
feat: implement async IPC for GetClientDeviceAuthToken, make settings configurable

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/GetClientDeviceAuthTokenTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/GetClientDeviceAuthTokenTest.java
@@ -186,13 +186,17 @@ class GetClientDeviceAuthTokenTest {
                 return "uuid";
             });
             // Request 1 (immediately runs)
-            ipcClient.getClientDeviceAuthToken(request, Optional.empty());
+            CompletableFuture<GetClientDeviceAuthTokenResponse> fut1 =
+                    ipcClient.getClientDeviceAuthToken(request, Optional.empty()).getResponse();
             // Request 2 (queued so that queue size is 1)
-            ipcClient.getClientDeviceAuthToken(request, Optional.empty());
+            CompletableFuture<GetClientDeviceAuthTokenResponse> fut2 =
+                    ipcClient.getClientDeviceAuthToken(request, Optional.empty()).getResponse();
             // Request 3 (expect rejection)
             Exception err = assertThrows(Exception.class, () -> clientDeviceAuthToken(ipcClient, request, (r) -> {}));
             assertThat(err.getCause().getMessage(), containsString("Unable to queue request"));
             assertEquals(ServiceError.class, err.getCause().getClass());
+            fut1.get(2, TimeUnit.SECONDS);
+            fut2.get(2, TimeUnit.SECONDS);
         }
     }
 

--- a/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
@@ -120,6 +120,7 @@ public class ClientDevicesAuthService extends PluginService {
                                     SessionManager sessionManager,
                                     DeviceAuthClient deviceAuthClient) {
         super(topics);
+        cloudCallQueueSize = DEFAULT_CLOUD_CALL_QUEUE_SIZE;
         cloudCallQueueSize = getValidCloudCallQueueSize(topics);
         cloudCallThreadPool = new ThreadPoolExecutor(1,
                 DEFAULT_THREAD_POOL_SIZE, 60, TimeUnit.SECONDS,

--- a/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
@@ -182,7 +182,7 @@ public class ClientDevicesAuthService extends PluginService {
                 }
             }
 
-            if (whatHappened == WhatHappened.initialized) {
+            if (whatHappened == WhatHappened.initialized || node == null) {
                 updateDeviceGroups(whatHappened, deviceGroupTopics);
                 updateCAType(caTypeTopic);
             } else if (node.childOf(DEVICE_GROUPS_TOPICS)) {

--- a/src/main/java/com/aws/greengrass/util/ResizableLinkedBlockingQueue.java
+++ b/src/main/java/com/aws/greengrass/util/ResizableLinkedBlockingQueue.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.util;
+
+import java.util.concurrent.LinkedBlockingQueue;
+
+/**
+ * Wrapper for LinkedBlockingQueue which lets us resize on demand.
+ * When grown, the queue accepts new entries immediately.
+ * When shrunk, all members of the queue remain, but new entries will be rejected until the queue size decreases
+ * under the capacity.
+ */
+public class ResizableLinkedBlockingQueue<T> extends LinkedBlockingQueue<T> {
+    private static final long serialVersionUID = -6903933977591709194L;
+
+    private volatile int capacity;
+
+    public ResizableLinkedBlockingQueue(int capacity) {
+        super();
+        this.capacity = capacity;
+    }
+
+    @Override
+    public boolean offer(T t) {
+        // If the current queue is at or over capacity, then reject new requests.
+        // This means that if we resize to be smaller, we will process all the committed work, but won't accept
+        // new work until the queue size is back under the limit.
+        if (size() >= capacity) {
+            return false;
+        }
+        return super.offer(t);
+    }
+
+    public void resize(int newCapacity) {
+        capacity = newCapacity;
+    }
+
+    @Override
+    public int remainingCapacity() {
+        return capacity - size(); // might be negative!
+    }
+
+    public int capacity() {
+        return capacity;
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- make GetClientDeviceAuthToken IPC API asynchronous
- make the async threadpool configurable by users in terms of the number of threads and the queue size

**Why is this change necessary:**

**How was this change tested:**
Existing tests passing, added test case for when the queue is full that the request is rejected appropriately.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
