### PR TITLE
feat: log exceptions for cis get shadow

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/AuthorizeClientDeviceActionTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/AuthorizeClientDeviceActionTest.java
@@ -14,6 +14,7 @@ import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.logging.impl.config.LogConfig;
+import com.aws.greengrass.mqttclient.spool.SpoolerStoreException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.UniqueRootPathExtension;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
@@ -79,7 +80,9 @@ class AuthorizeClientDeviceActionTest {
     }
 
     @BeforeEach
-    void beforeEach() {
+    void beforeEach(ExtensionContext context) {
+        ignoreExceptionOfType(context, SpoolerStoreException.class);
+
         // Set this property for kernel to scan its own classpath to find plugins
         System.setProperty("aws.greengrass.scanSelfClasspath", "true");
         kernel = new Kernel();

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/GetClientDeviceAuthTokenTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/GetClientDeviceAuthTokenTest.java
@@ -14,6 +14,7 @@ import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.logging.impl.config.LogConfig;
+import com.aws.greengrass.mqttclient.spool.SpoolerStoreException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.UniqueRootPathExtension;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
@@ -79,7 +80,9 @@ class GetClientDeviceAuthTokenTest {
     }
 
     @BeforeEach
-    void beforeEach() {
+    void beforeEach(ExtensionContext context) {
+        ignoreExceptionOfType(context, SpoolerStoreException.class);
+
         // Set this property for kernel to scan its own classpath to find plugins
         System.setProperty("aws.greengrass.scanSelfClasspath", "true");
         kernel = new Kernel();

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/SubscribeToCertificateUpdatesTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/SubscribeToCertificateUpdatesTest.java
@@ -11,6 +11,7 @@ import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.logging.impl.config.LogConfig;
+import com.aws.greengrass.mqttclient.spool.SpoolerStoreException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.UniqueRootPathExtension;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -45,6 +47,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static com.aws.greengrass.testcommons.testutilities.TestUtils.asyncAssertOnConsumer;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -96,7 +99,9 @@ class SubscribeToCertificateUpdatesTest {
     }
 
     @BeforeEach
-    void beforeEach() {
+    void beforeEach(ExtensionContext context) {
+        ignoreExceptionOfType(context, SpoolerStoreException.class);
+
         // Set this property for kernel to scan its own classpath to find plugins
         System.setProperty("aws.greengrass.scanSelfClasspath", "true");
         kernel = new Kernel();

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/VerifyClientDeviceIdentityTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/VerifyClientDeviceIdentityTest.java
@@ -13,6 +13,7 @@ import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.logging.impl.config.LogConfig;
+import com.aws.greengrass.mqttclient.spool.SpoolerStoreException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.UniqueRootPathExtension;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
@@ -78,7 +79,9 @@ class VerifyClientDeviceIdentityTest {
     }
 
     @BeforeEach
-    void beforeEach() {
+    void beforeEach(ExtensionContext context) {
+        ignoreExceptionOfType(context, SpoolerStoreException.class);
+
         // Set this property for kernel to scan its own classpath to find plugins
         System.setProperty("aws.greengrass.scanSelfClasspath", "true");
         kernel = new Kernel();

--- a/src/main/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitor.java
+++ b/src/main/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitor.java
@@ -264,7 +264,11 @@ public class CISShadowMonitor {
         LOGGER.info("Publishing to get shadow topic");
         GetShadowRequest getShadowRequest = new GetShadowRequest();
         getShadowRequest.thingName = shadowName;
-        iotShadowClient.PublishGetShadow(getShadowRequest, QualityOfService.AT_LEAST_ONCE);
+        iotShadowClient.PublishGetShadow(getShadowRequest, QualityOfService.AT_LEAST_ONCE)
+                .exceptionally(e -> {
+                    LOGGER.atWarn().cause(e).log("Unable to retrieve CIS shadow");
+                    return null;
+                });
     }
 
     private void unsubscribeFromShadowTopics() {

--- a/src/test/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitorTest.java
+++ b/src/test/java/com/aws/greengrass/certificatemanager/certificate/CISShadowMonitorTest.java
@@ -74,6 +74,8 @@ public class CISShadowMonitorTest {
             ((Runnable)invocation.getArgument(0)).run();
             return null;
         }).when(mockExecutor).submit(any(Runnable.class));
+
+        when(mockShadowClient.PublishGetShadow(any(), any())).thenReturn(CompletableFuture.completedFuture(0));
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/device/ClientDevicesAuthServiceTest.java
+++ b/src/test/java/com/aws/greengrass/device/ClientDevicesAuthServiceTest.java
@@ -17,6 +17,7 @@ import com.aws.greengrass.device.configuration.Permission;
 import com.aws.greengrass.device.exception.AuthorizationException;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
+import com.aws.greengrass.mqttclient.spool.SpoolerStoreException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
@@ -103,7 +104,9 @@ class ClientDevicesAuthServiceTest {
 
 
     @BeforeEach
-    void setup() {
+    void setup(ExtensionContext context) {
+        ignoreExceptionOfType(context, SpoolerStoreException.class);
+
         // Set this property for kernel to scan its own classpath to find plugins
         System.setProperty("aws.greengrass.scanSelfClasspath", "true");
         kernel = new Kernel();


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Add exception logging for `PublishGetShadow` call in `CISShadowMonitor`. 

**Why is this change necessary:**

To help debug if get shadow call fails

**How was this change tested:**

N/A

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
