### PR TITLE
fix: re-encode certificate for lookup as needed

### DIFF
--- a/src/main/java/com/aws/greengrass/ipc/VerifyClientDeviceIdentityOperationHandler.java
+++ b/src/main/java/com/aws/greengrass/ipc/VerifyClientDeviceIdentityOperationHandler.java
@@ -98,8 +98,9 @@ public class VerifyClientDeviceIdentityOperationHandler
             if (!certificate.startsWith(CERTIFICATE_PEM_HEADER)) {
                 try {
                     certificate = EncryptionUtils.encodeToPem("CERTIFICATE",
-                            Base64.getDecoder().decode(certificate));
-                } catch (IOException e) {
+                            // Use MIME decoder as it is more forgiving of formatting
+                            Base64.getMimeDecoder().decode(certificate));
+                } catch (IllegalArgumentException | IOException e) {
                     logger.atWarn().log("Unable to convert certificate PEM", e);
                     throw new InvalidArgumentsError("Unable to convert certificate PEM");
                 }

--- a/src/main/java/com/aws/greengrass/ipc/VerifyClientDeviceIdentityOperationHandler.java
+++ b/src/main/java/com/aws/greengrass/ipc/VerifyClientDeviceIdentityOperationHandler.java
@@ -13,6 +13,7 @@ import com.aws.greengrass.device.ClientDevicesAuthService;
 import com.aws.greengrass.device.iot.IotAuthClient;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.util.EncryptionUtils;
 import com.aws.greengrass.util.Utils;
 import software.amazon.awssdk.aws.greengrass.GeneratedAbstractVerifyClientDeviceIdentityOperationHandler;
 import software.amazon.awssdk.aws.greengrass.model.ClientDeviceCredential;
@@ -24,12 +25,15 @@ import software.amazon.awssdk.aws.greengrass.model.VerifyClientDeviceIdentityRes
 import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
 import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
 
+import java.io.IOException;
+import java.util.Base64;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 
 import static com.aws.greengrass.ipc.common.ExceptionUtil.translateExceptions;
+import static com.aws.greengrass.util.EncryptionUtils.CERTIFICATE_PEM_HEADER;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.VERIFY_CLIENT_DEVICE_IDENTITY;
 
 public class VerifyClientDeviceIdentityOperationHandler
@@ -88,6 +92,18 @@ public class VerifyClientDeviceIdentityOperationHandler
                 throw new UnauthorizedError(e.getMessage());
             }
             String certificate = getCertificateFromCredential(request.getCredential());
+
+            // If the certificate PEM is only the encoded data without headers, re-encode it into
+            // the format that IoT Core needs.
+            if (!certificate.startsWith(CERTIFICATE_PEM_HEADER)) {
+                try {
+                    certificate = EncryptionUtils.encodeToPem("CERTIFICATE",
+                            Base64.getDecoder().decode(certificate));
+                } catch (IOException e) {
+                    logger.atWarn().log("Unable to convert certificate PEM", e);
+                    throw new InvalidArgumentsError("Unable to convert certificate PEM");
+                }
+            }
             try {
                 Optional<String> certificateId = iotAuthClient.getActiveCertificateId(certificate);
                 VerifyClientDeviceIdentityResponse response = new VerifyClientDeviceIdentityResponse();


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
EMQ X gives us the PEM as just the base64 bytes, without any certificate header or line wrapping. This change will check for that case and re-encode the certificate in the required format.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
