### PR TITLE
fix: check thing association with cert id during session creation

### DIFF
--- a/src/main/java/com/aws/greengrass/device/session/MqttSessionFactory.java
+++ b/src/main/java/com/aws/greengrass/device/session/MqttSessionFactory.java
@@ -6,11 +6,13 @@
 package com.aws.greengrass.device.session;
 
 import com.aws.greengrass.device.exception.AuthenticationException;
+import com.aws.greengrass.device.exception.CloudServiceInteractionException;
 import com.aws.greengrass.device.iot.Certificate;
 import com.aws.greengrass.device.iot.IotAuthClient;
 import com.aws.greengrass.device.iot.Thing;
 
 import java.util.Map;
+import java.util.Optional;
 import javax.inject.Inject;
 
 public class MqttSessionFactory implements SessionFactory {
@@ -31,14 +33,22 @@ public class MqttSessionFactory implements SessionFactory {
         //   we don't yet have the ability to authorize actions for those clients. So, for now, assume
         //   this is an IoT Thing and components will be specially handled elsewhere.
         Thing thing = new Thing(mqttCredential.clientId);
-        Certificate cert = new Certificate(mqttCredential.certificatePem);
-        if (!iotAuthClient.isThingAttachedToCertificate(thing, cert)) {
-            throw new AuthenticationException("unable to authenticate device");
+        Optional<String> certificateId;
+        try {
+            certificateId = iotAuthClient.getActiveCertificateId(mqttCredential.certificatePem);
+            if (!certificateId.isPresent()) {
+                throw new AuthenticationException("Certificate isn't active");
+            }
+            Certificate cert = new Certificate(certificateId.get());
+            if (!iotAuthClient.isThingAttachedToCertificate(thing, cert)) {
+                throw new AuthenticationException("unable to authenticate device");
+            }
+            Session session = new SessionImpl(cert);
+            session.putAttributeProvider(Thing.NAMESPACE, thing);
+            return session;
+        } catch (CloudServiceInteractionException e) {
+            throw new AuthenticationException("Failed to verify certificate with cloud", e);
         }
-
-        Session session = new SessionImpl(cert);
-        session.putAttributeProvider(Thing.NAMESPACE, thing);
-        return session;
     }
 
     private static class MqttCredential {

--- a/src/test/java/com/aws/greengrass/device/session/MqttSessionFactoryTest.java
+++ b/src/test/java/com/aws/greengrass/device/session/MqttSessionFactoryTest.java
@@ -6,8 +6,10 @@
 package com.aws.greengrass.device.session;
 
 import com.aws.greengrass.device.exception.AuthenticationException;
+import com.aws.greengrass.device.exception.CloudServiceInteractionException;
 import com.aws.greengrass.device.iot.IotAuthClient;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.hamcrest.core.IsNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,8 +19,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.utils.ImmutableMap;
 
 import java.util.Map;
+import java.util.Optional;
 
-import org.hamcrest.core.IsNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -43,6 +45,7 @@ public class MqttSessionFactoryTest {
 
     @Test
     void GIVEN_credentialsWithUnknownClientId_WHEN_createSession_THEN_throwsAuthenticationException() {
+        when(mockIotAuthClient.getActiveCertificateId(any())).thenReturn(Optional.of("id"));
         when(mockIotAuthClient.isThingAttachedToCertificate(any(), any())).thenReturn(false);
 
         Assertions.assertThrows(AuthenticationException.class,
@@ -50,7 +53,24 @@ public class MqttSessionFactoryTest {
     }
 
     @Test
+    void GIVEN_credentialsWithInvalidCertificate_WHEN_createSession_THEN_throwsAuthenticationException() {
+        when(mockIotAuthClient.getActiveCertificateId(any())).thenReturn(Optional.empty());
+        Assertions.assertThrows(AuthenticationException.class,
+                () -> mqttSessionFactory.createSession(credentialMap));
+    }
+
+    @Test
+    void GIVEN_credentialsWithCertificate_WHEN_createSession_AND_cloudError_THEN_throwsAuthenticationException() {
+        when(mockIotAuthClient.getActiveCertificateId(any())).thenReturn(Optional.of("id"));
+        when(mockIotAuthClient.isThingAttachedToCertificate(any(), any()))
+                .thenThrow(CloudServiceInteractionException.class);
+        Assertions.assertThrows(AuthenticationException.class,
+                () -> mqttSessionFactory.createSession(credentialMap));
+    }
+
+    @Test
     void GIVEN_credentialsWithValidClientId_WHEN_createSession_THEN_returnsSession() throws AuthenticationException {
+        when(mockIotAuthClient.getActiveCertificateId(any())).thenReturn(Optional.of("id"));
         when(mockIotAuthClient.isThingAttachedToCertificate(any(), any())).thenReturn(true);
 
         Session session = mqttSessionFactory.createSession(credentialMap);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
The cloud API `VerifyClientDeviceIoTCertificateAssociationRequest`needs certificate with its ID but not certificate pem to verify thing-cert association. This change fixed the certificate object creation in the session creation code where cert pem is used instead of its ID during `isThingAttachedToCertificate` check. 

**Why is this change necessary:**
Fixed the API request parameters. 
 
**How was this change tested:**
Added two more unit tests and UATs are in place. 

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
