### PR TITLE
Fix session

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/GetClientDeviceAuthTokenTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/GetClientDeviceAuthTokenTest.java
@@ -127,10 +127,11 @@ class GetClientDeviceAuthTokenTest {
             throws Exception {
         kernel.getContext().put(SessionManager.class, sessionManager);
         Map<String, String> mqttCredentialMap = ImmutableMap.of(
-                "certificatePem", "VALID PEM",
                 "clientId", "some-client-id",
                 "username", null,
-                "password", null);
+                "password", null,
+                "certificatePem", "-----BEGIN CERTIFICATE-----\n" +
+                        "PEM=\n" + "-----END CERTIFICATE-----\n");
 
         when(sessionManager
                 .createSession("mqtt", mqttCredentialMap))
@@ -141,7 +142,7 @@ class GetClientDeviceAuthTokenTest {
                 "BrokerWithGetClientDeviceAuthTokenPermission")) {
             GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
             MQTTCredential mqttCredential = new MQTTCredential().withClientId("some-client-id")
-                    .withCertificatePem("VALID PEM");
+                    .withCertificatePem("PEM");
             CredentialDocument cd = new CredentialDocument().withMqttCredential(mqttCredential);
             GetClientDeviceAuthTokenRequest request = new GetClientDeviceAuthTokenRequest().withCredential(cd);
             Pair<CompletableFuture<Void>, Consumer<GetClientDeviceAuthTokenResponse>> cb =
@@ -235,10 +236,11 @@ class GetClientDeviceAuthTokenTest {
         ignoreExceptionOfType(context, AuthenticationException.class);
         startNucleusWithConfig("cda.yaml");
         Map<String, String> mqttCredentialMap = ImmutableMap.of(
-                "certificatePem", "VALID PEM",
                 "clientId", "some-client-id",
                 "username", null,
-                "password", null);
+                "password", null,
+                "certificatePem", "-----BEGIN CERTIFICATE-----\n" +
+                        "PEM=\n" + "-----END CERTIFICATE-----\n");
         when(sessionManager
                 .createSession("mqtt", mqttCredentialMap))
                 .thenThrow(AuthenticationException.class);
@@ -247,7 +249,7 @@ class GetClientDeviceAuthTokenTest {
                 "BrokerWithGetClientDeviceAuthTokenPermission")) {
             GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
             MQTTCredential mqttCredential = new MQTTCredential().withClientId("some-client-id")
-                    .withCertificatePem("VALID PEM");
+                    .withCertificatePem("PEM");
             CredentialDocument cd = new CredentialDocument().withMqttCredential(mqttCredential);
             GetClientDeviceAuthTokenRequest request = new GetClientDeviceAuthTokenRequest().withCredential(cd);
 
@@ -266,10 +268,11 @@ class GetClientDeviceAuthTokenTest {
         ignoreExceptionOfType(context, CloudServiceInteractionException.class);
         startNucleusWithConfig("cda.yaml");
         Map<String, String> mqttCredentialMap = ImmutableMap.of(
-                "certificatePem", "VALID PEM",
                 "clientId", "some-client-id",
                 "username", null,
-                "password", null);
+                "password", null,
+                "certificatePem", "-----BEGIN CERTIFICATE-----\n" +
+                        "PEM=\n" + "-----END CERTIFICATE-----\n");
         when(sessionManager
                 .createSession("mqtt", mqttCredentialMap))
                 .thenThrow(CloudServiceInteractionException.class);
@@ -278,7 +281,7 @@ class GetClientDeviceAuthTokenTest {
                 "BrokerWithGetClientDeviceAuthTokenPermission")) {
             GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
             MQTTCredential mqttCredential = new MQTTCredential().withClientId("some-client-id")
-                    .withCertificatePem("VALID PEM");
+                    .withCertificatePem("PEM");
             CredentialDocument cd = new CredentialDocument().withMqttCredential(mqttCredential);
             GetClientDeviceAuthTokenRequest request = new GetClientDeviceAuthTokenRequest().withCredential(cd);
 

--- a/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
@@ -29,6 +29,7 @@ import com.aws.greengrass.ipc.VerifyClientDeviceIdentityOperationHandler;
 import com.aws.greengrass.lifecyclemanager.PluginService;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
+import com.aws.greengrass.util.ResizableLinkedBlockingQueue;
 import com.aws.greengrass.util.RetryUtils;
 import com.aws.greengrass.util.Utils;
 import com.fasterxml.jackson.databind.MapperFeature;
@@ -46,7 +47,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
@@ -69,6 +71,8 @@ public class ClientDevicesAuthService extends PluginService {
             RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofSeconds(3)).maxAttempt(Integer.MAX_VALUE)
                     .retryableExceptions(Arrays.asList(ThrottlingException.class, InternalServerException.class))
                     .build();
+    public static final String CLOUD_QUEUE_SIZE_TOPIC = "cloudQueueSize";
+    public static final String THREAD_POOL_SIZE_TOPIC = "threadPoolSize";
 
     private final GroupManager groupManager;
 
@@ -83,12 +87,11 @@ public class ClientDevicesAuthService extends PluginService {
     private final SessionManager sessionManager;
     private final DeviceAuthClient deviceAuthClient;
     // Limit the queue size before we start rejecting requests
-    // TODO: User configurable
-    private static final int CLOUD_CALL_QUEUE_SIZE = 100;
-    // Create a threadpool for calling the cloud. Single thread will be used.
-    // TODO: User configurable pool size
-    private final ThreadPoolExecutor cloudCallThreadPool = new ThreadPoolExecutor(1, 1, 60, TimeUnit.SECONDS,
-            new LinkedBlockingQueue<>(CLOUD_CALL_QUEUE_SIZE));
+    private static final int DEFAULT_CLOUD_CALL_QUEUE_SIZE = 100;
+    private static final int DEFAULT_THREAD_POOL_SIZE = 1;
+    // Create a threadpool for calling the cloud. Single thread will be used by default.
+    private final ThreadPoolExecutor cloudCallThreadPool;
+    private int cloudCallQueueSize;
 
     /**
      * Constructor.
@@ -117,6 +120,11 @@ public class ClientDevicesAuthService extends PluginService {
                                     SessionManager sessionManager,
                                     DeviceAuthClient deviceAuthClient) {
         super(topics);
+        cloudCallQueueSize = DEFAULT_CLOUD_CALL_QUEUE_SIZE;
+        cloudCallQueueSize = getValidCloudCallQueueSize(topics);
+        cloudCallThreadPool = new ThreadPoolExecutor(1,
+                DEFAULT_THREAD_POOL_SIZE, 60, TimeUnit.SECONDS,
+                new ResizableLinkedBlockingQueue<>(cloudCallQueueSize));
         cloudCallThreadPool.allowCoreThreadTimeOut(true); // act as a cached threadpool
         this.groupManager = groupManager;
         this.certificateManager = certificateManager;
@@ -129,6 +137,17 @@ public class ClientDevicesAuthService extends PluginService {
         this.deviceAuthClient = deviceAuthClient;
         SessionCreator.registerSessionFactory("mqtt", mqttSessionFactory);
         certificateManager.updateCertificatesConfiguration(new CertificatesConfig(this.getConfig()));
+    }
+
+    private int getValidCloudCallQueueSize(Topics topics) {
+        int newSize = Coerce.toInt(
+                topics.findOrDefault(DEFAULT_CLOUD_CALL_QUEUE_SIZE, CONFIGURATION_CONFIG_KEY, CLOUD_QUEUE_SIZE_TOPIC));
+        if (newSize <= 0) {
+            logger.atWarn().log("{} illegal size, will not change the queue size from {}",
+                    CLOUD_QUEUE_SIZE_TOPIC, cloudCallQueueSize);
+            return cloudCallQueueSize; // existing size
+        }
+        return newSize;
     }
 
     /**
@@ -155,7 +174,26 @@ public class ClientDevicesAuthService extends PluginService {
             Topics deviceGroupTopics = this.config.lookupTopics(CONFIGURATION_CONFIG_KEY, DEVICE_GROUPS_TOPICS);
             Topic caTypeTopic = this.config.lookup(CONFIGURATION_CONFIG_KEY, CA_TYPE_TOPIC);
 
-            if (whatHappened == WhatHappened.initialized) {
+            // Attempt to update the thread pool size as needed
+            try {
+                int threadPoolSize = Coerce.toInt(this.config.findOrDefault(DEFAULT_THREAD_POOL_SIZE,
+                        CONFIGURATION_CONFIG_KEY, THREAD_POOL_SIZE_TOPIC));
+                if (threadPoolSize >= cloudCallThreadPool.getCorePoolSize()) {
+                    cloudCallThreadPool.setMaximumPoolSize(threadPoolSize);
+                }
+            } catch (IllegalArgumentException e) {
+                logger.atWarn().log("Unable to update CDA threadpool size due to {}", e.getMessage());
+            }
+
+            if (whatHappened != WhatHappened.initialized && node != null && node.childOf(CLOUD_QUEUE_SIZE_TOPIC)) {
+                BlockingQueue<Runnable> q = cloudCallThreadPool.getQueue();
+                if (q instanceof ResizableLinkedBlockingQueue) {
+                    cloudCallQueueSize = getValidCloudCallQueueSize(this.config);
+                    ((ResizableLinkedBlockingQueue) q).resize(cloudCallQueueSize);
+                }
+            }
+
+            if (whatHappened == WhatHappened.initialized || node == null) {
                 updateDeviceGroups(whatHappened, deviceGroupTopics);
                 updateCAType(caTypeTopic);
             } else if (node.childOf(DEVICE_GROUPS_TOPICS)) {
@@ -241,6 +279,14 @@ public class ClientDevicesAuthService extends PluginService {
         return Coerce.toString(caPassphrase);
     }
 
+    @Override
+    protected CompletableFuture<Void> close(boolean waitForDependers) {
+        // shutdown the threadpool in close, not in shutdown() because it is created
+        // and injected in the constructor and we won't be able to restart it after it stops.
+        cloudCallThreadPool.shutdown();
+        return super.close(waitForDependers);
+    }
+
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
     private void uploadCoreDeviceCAs(List<String> certificatePemList) {
         String thingName = Coerce.toString(deviceConfiguration.getThingName());
@@ -281,7 +327,8 @@ public class ClientDevicesAuthService extends PluginService {
                 new VerifyClientDeviceIdentityOperationHandler(context, iotAuthClient,
                         authorizationHandler, cloudCallThreadPool));
         greengrassCoreIPCService.setGetClientDeviceAuthTokenHandler(context ->
-                new GetClientDeviceAuthTokenOperationHandler(context, sessionManager, authorizationHandler));
+                new GetClientDeviceAuthTokenOperationHandler(context, sessionManager,
+                        authorizationHandler, cloudCallThreadPool));
         greengrassCoreIPCService.setAuthorizeClientDeviceActionHandler(context ->
                 new AuthorizeClientDeviceActionOperationHandler(context, deviceAuthClient, authorizationHandler));
     }

--- a/src/main/java/com/aws/greengrass/device/session/MqttSessionFactory.java
+++ b/src/main/java/com/aws/greengrass/device/session/MqttSessionFactory.java
@@ -6,11 +6,13 @@
 package com.aws.greengrass.device.session;
 
 import com.aws.greengrass.device.exception.AuthenticationException;
+import com.aws.greengrass.device.exception.CloudServiceInteractionException;
 import com.aws.greengrass.device.iot.Certificate;
 import com.aws.greengrass.device.iot.IotAuthClient;
 import com.aws.greengrass.device.iot.Thing;
 
 import java.util.Map;
+import java.util.Optional;
 import javax.inject.Inject;
 
 public class MqttSessionFactory implements SessionFactory {
@@ -31,14 +33,22 @@ public class MqttSessionFactory implements SessionFactory {
         //   we don't yet have the ability to authorize actions for those clients. So, for now, assume
         //   this is an IoT Thing and components will be specially handled elsewhere.
         Thing thing = new Thing(mqttCredential.clientId);
-        Certificate cert = new Certificate(mqttCredential.certificatePem);
-        if (!iotAuthClient.isThingAttachedToCertificate(thing, cert)) {
-            throw new AuthenticationException("unable to authenticate device");
+        Optional<String> certificateId;
+        try {
+            certificateId = iotAuthClient.getActiveCertificateId(mqttCredential.certificatePem);
+            if (!certificateId.isPresent()) {
+                throw new AuthenticationException("Certificate isn't active");
+            }
+            Certificate cert = new Certificate(certificateId.get());
+            if (!iotAuthClient.isThingAttachedToCertificate(thing, cert)) {
+                throw new AuthenticationException("unable to authenticate device");
+            }
+            Session session = new SessionImpl(cert);
+            session.putAttributeProvider(Thing.NAMESPACE, thing);
+            return session;
+        } catch (CloudServiceInteractionException e) {
+            throw new AuthenticationException("Failed to verify certificate with cloud", e);
         }
-
-        Session session = new SessionImpl(cert);
-        session.putAttributeProvider(Thing.NAMESPACE, thing);
-        return session;
     }
 
     private static class MqttCredential {

--- a/src/main/java/com/aws/greengrass/util/ResizableLinkedBlockingQueue.java
+++ b/src/main/java/com/aws/greengrass/util/ResizableLinkedBlockingQueue.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.util;
+
+import java.util.concurrent.LinkedBlockingQueue;
+
+/**
+ * Wrapper for LinkedBlockingQueue which lets us resize on demand.
+ * When grown, the queue accepts new entries immediately.
+ * When shrunk, all members of the queue remain, but new entries will be rejected until the queue size decreases
+ * under the capacity.
+ */
+public class ResizableLinkedBlockingQueue<T> extends LinkedBlockingQueue<T> {
+    private static final long serialVersionUID = -6903933977591709194L;
+
+    private volatile int capacity;
+
+    public ResizableLinkedBlockingQueue(int capacity) {
+        super();
+        this.capacity = capacity;
+    }
+
+    @Override
+    public boolean offer(T t) {
+        // If the current queue is at or over capacity, then reject new requests.
+        // This means that if we resize to be smaller, we will process all the committed work, but won't accept
+        // new work until the queue size is back under the limit.
+        if (size() >= capacity) {
+            return false;
+        }
+        return super.offer(t);
+    }
+
+    public void resize(int newCapacity) {
+        capacity = newCapacity;
+    }
+
+    @Override
+    public int remainingCapacity() {
+        return capacity - size(); // might be negative!
+    }
+
+    public int capacity() {
+        return capacity;
+    }
+}

--- a/src/test/java/com/aws/greengrass/device/session/MqttSessionFactoryTest.java
+++ b/src/test/java/com/aws/greengrass/device/session/MqttSessionFactoryTest.java
@@ -6,8 +6,10 @@
 package com.aws.greengrass.device.session;
 
 import com.aws.greengrass.device.exception.AuthenticationException;
+import com.aws.greengrass.device.exception.CloudServiceInteractionException;
 import com.aws.greengrass.device.iot.IotAuthClient;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.hamcrest.core.IsNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,8 +19,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.utils.ImmutableMap;
 
 import java.util.Map;
+import java.util.Optional;
 
-import org.hamcrest.core.IsNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -43,6 +45,7 @@ public class MqttSessionFactoryTest {
 
     @Test
     void GIVEN_credentialsWithUnknownClientId_WHEN_createSession_THEN_throwsAuthenticationException() {
+        when(mockIotAuthClient.getActiveCertificateId(any())).thenReturn(Optional.of("id"));
         when(mockIotAuthClient.isThingAttachedToCertificate(any(), any())).thenReturn(false);
 
         Assertions.assertThrows(AuthenticationException.class,
@@ -50,7 +53,24 @@ public class MqttSessionFactoryTest {
     }
 
     @Test
+    void GIVEN_credentialsWithInvalidCertificate_WHEN_createSession_THEN_throwsAuthenticationException() {
+        when(mockIotAuthClient.getActiveCertificateId(any())).thenReturn(Optional.empty());
+        Assertions.assertThrows(AuthenticationException.class,
+                () -> mqttSessionFactory.createSession(credentialMap));
+    }
+
+    @Test
+    void GIVEN_credentialsWithCertificate_WHEN_createSession_AND_cloudError_THEN_throwsAuthenticationException() {
+        when(mockIotAuthClient.getActiveCertificateId(any())).thenReturn(Optional.of("id"));
+        when(mockIotAuthClient.isThingAttachedToCertificate(any(), any()))
+                .thenThrow(CloudServiceInteractionException.class);
+        Assertions.assertThrows(AuthenticationException.class,
+                () -> mqttSessionFactory.createSession(credentialMap));
+    }
+
+    @Test
     void GIVEN_credentialsWithValidClientId_WHEN_createSession_THEN_returnsSession() throws AuthenticationException {
+        when(mockIotAuthClient.getActiveCertificateId(any())).thenReturn(Optional.of("id"));
         when(mockIotAuthClient.isThingAttachedToCertificate(any(), any())).thenReturn(true);
 
         Session session = mqttSessionFactory.createSession(credentialMap);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Re-encode certificate PEM of the `GetClientDeviceAuthTokenRequest` IPC request if it is not encoded already. 

**Why is this change necessary:**
Same as https://github.com/aws-greengrass/aws-greengrass-client-device-auth/pull/81

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
