### PR TITLE
fix: re-encode cert of the GetClientDeviceAuthTokenRequest

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/GetClientDeviceAuthTokenTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/GetClientDeviceAuthTokenTest.java
@@ -130,8 +130,8 @@ class GetClientDeviceAuthTokenTest {
                 "clientId", "some-client-id",
                 "username", null,
                 "password", null,
-                "certificatePem", "-----BEGIN CERTIFICATE-----\n" +
-                        "PEM=\n" + "-----END CERTIFICATE-----\n");
+                "certificatePem", "-----BEGIN CERTIFICATE-----" + System.lineSeparator() + "PEM="
+                        + System.lineSeparator() + "-----END CERTIFICATE-----" + System.lineSeparator());
 
         when(sessionManager
                 .createSession("mqtt", mqttCredentialMap))
@@ -239,8 +239,8 @@ class GetClientDeviceAuthTokenTest {
                 "clientId", "some-client-id",
                 "username", null,
                 "password", null,
-                "certificatePem", "-----BEGIN CERTIFICATE-----\n" +
-                        "PEM=\n" + "-----END CERTIFICATE-----\n");
+                "certificatePem", "-----BEGIN CERTIFICATE-----" + System.lineSeparator() + "PEM="
+                        + System.lineSeparator() + "-----END CERTIFICATE-----" + System.lineSeparator());
         when(sessionManager
                 .createSession("mqtt", mqttCredentialMap))
                 .thenThrow(AuthenticationException.class);
@@ -271,8 +271,8 @@ class GetClientDeviceAuthTokenTest {
                 "clientId", "some-client-id",
                 "username", null,
                 "password", null,
-                "certificatePem", "-----BEGIN CERTIFICATE-----\n" +
-                        "PEM=\n" + "-----END CERTIFICATE-----\n");
+                "certificatePem", "-----BEGIN CERTIFICATE-----" + System.lineSeparator() + "PEM="
+                        + System.lineSeparator() + "-----END CERTIFICATE-----" + System.lineSeparator());
         when(sessionManager
                 .createSession("mqtt", mqttCredentialMap))
                 .thenThrow(CloudServiceInteractionException.class);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/GetClientDeviceAuthTokenTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/GetClientDeviceAuthTokenTest.java
@@ -127,10 +127,11 @@ class GetClientDeviceAuthTokenTest {
             throws Exception {
         kernel.getContext().put(SessionManager.class, sessionManager);
         Map<String, String> mqttCredentialMap = ImmutableMap.of(
-                "certificatePem", "VALID PEM",
                 "clientId", "some-client-id",
                 "username", null,
-                "password", null);
+                "password", null,
+                "certificatePem", "-----BEGIN CERTIFICATE-----\n" +
+                        "PEM=\n" + "-----END CERTIFICATE-----\n");
 
         when(sessionManager
                 .createSession("mqtt", mqttCredentialMap))
@@ -141,7 +142,7 @@ class GetClientDeviceAuthTokenTest {
                 "BrokerWithGetClientDeviceAuthTokenPermission")) {
             GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
             MQTTCredential mqttCredential = new MQTTCredential().withClientId("some-client-id")
-                    .withCertificatePem("VALID PEM");
+                    .withCertificatePem("PEM");
             CredentialDocument cd = new CredentialDocument().withMqttCredential(mqttCredential);
             GetClientDeviceAuthTokenRequest request = new GetClientDeviceAuthTokenRequest().withCredential(cd);
             Pair<CompletableFuture<Void>, Consumer<GetClientDeviceAuthTokenResponse>> cb =
@@ -235,10 +236,11 @@ class GetClientDeviceAuthTokenTest {
         ignoreExceptionOfType(context, AuthenticationException.class);
         startNucleusWithConfig("cda.yaml");
         Map<String, String> mqttCredentialMap = ImmutableMap.of(
-                "certificatePem", "VALID PEM",
                 "clientId", "some-client-id",
                 "username", null,
-                "password", null);
+                "password", null,
+                "certificatePem", "-----BEGIN CERTIFICATE-----\n" +
+                        "PEM=\n" + "-----END CERTIFICATE-----\n");
         when(sessionManager
                 .createSession("mqtt", mqttCredentialMap))
                 .thenThrow(AuthenticationException.class);
@@ -247,7 +249,7 @@ class GetClientDeviceAuthTokenTest {
                 "BrokerWithGetClientDeviceAuthTokenPermission")) {
             GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
             MQTTCredential mqttCredential = new MQTTCredential().withClientId("some-client-id")
-                    .withCertificatePem("VALID PEM");
+                    .withCertificatePem("PEM");
             CredentialDocument cd = new CredentialDocument().withMqttCredential(mqttCredential);
             GetClientDeviceAuthTokenRequest request = new GetClientDeviceAuthTokenRequest().withCredential(cd);
 
@@ -266,10 +268,11 @@ class GetClientDeviceAuthTokenTest {
         ignoreExceptionOfType(context, CloudServiceInteractionException.class);
         startNucleusWithConfig("cda.yaml");
         Map<String, String> mqttCredentialMap = ImmutableMap.of(
-                "certificatePem", "VALID PEM",
                 "clientId", "some-client-id",
                 "username", null,
-                "password", null);
+                "password", null,
+                "certificatePem", "-----BEGIN CERTIFICATE-----\n" +
+                        "PEM=\n" + "-----END CERTIFICATE-----\n");
         when(sessionManager
                 .createSession("mqtt", mqttCredentialMap))
                 .thenThrow(CloudServiceInteractionException.class);
@@ -278,7 +281,7 @@ class GetClientDeviceAuthTokenTest {
                 "BrokerWithGetClientDeviceAuthTokenPermission")) {
             GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
             MQTTCredential mqttCredential = new MQTTCredential().withClientId("some-client-id")
-                    .withCertificatePem("VALID PEM");
+                    .withCertificatePem("PEM");
             CredentialDocument cd = new CredentialDocument().withMqttCredential(mqttCredential);
             GetClientDeviceAuthTokenRequest request = new GetClientDeviceAuthTokenRequest().withCredential(cd);
 

--- a/src/main/java/com/aws/greengrass/ipc/GetClientDeviceAuthTokenOperationHandler.java
+++ b/src/main/java/com/aws/greengrass/ipc/GetClientDeviceAuthTokenOperationHandler.java
@@ -14,7 +14,6 @@ import com.aws.greengrass.device.exception.AuthenticationException;
 import com.aws.greengrass.device.session.SessionManager;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
-import com.aws.greengrass.util.EncryptionUtils;
 import software.amazon.awssdk.aws.greengrass.GeneratedAbstractGetClientDeviceAuthTokenOperationHandler;
 import software.amazon.awssdk.aws.greengrass.model.CredentialDocument;
 import software.amazon.awssdk.aws.greengrass.model.GetClientDeviceAuthTokenRequest;
@@ -27,8 +26,6 @@ import software.amazon.awssdk.aws.greengrass.model.UnauthorizedError;
 import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
 import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
 
-import java.io.IOException;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -36,7 +33,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 
 import static com.aws.greengrass.ipc.common.ExceptionUtil.translateExceptions;
-import static com.aws.greengrass.util.EncryptionUtils.CERTIFICATE_PEM_HEADER;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.GET_CLIENT_DEVICE_AUTH_TOKEN;
 
 public class GetClientDeviceAuthTokenOperationHandler
@@ -132,17 +128,7 @@ public class GetClientDeviceAuthTokenOperationHandler
         String certificatePem = mqttCredential.getCertificatePem();
         // If the certificate PEM is only the encoded data without headers, re-encode it into
         // the format that IoT Core needs.
-        if (!certificatePem.startsWith(CERTIFICATE_PEM_HEADER)) {
-            try {
-                certificatePem = EncryptionUtils.encodeToPem("CERTIFICATE",
-                        // Use MIME decoder as it is more forgiving of formatting
-                        Base64.getMimeDecoder().decode(certificatePem));
-            } catch (IllegalArgumentException | IOException e) {
-                logger.atWarn().log("Unable to convert certificate PEM", e);
-                throw new InvalidArgumentsError("Unable to convert certificate PEM");
-            }
-        }
-        credentialMap.put("certificatePem", certificatePem);
+        credentialMap.put("certificatePem", IPCUtils.reEncodeCertToPem(certificatePem));
         return credentialMap;
     }
 

--- a/src/main/java/com/aws/greengrass/ipc/IPCUtils.java
+++ b/src/main/java/com/aws/greengrass/ipc/IPCUtils.java
@@ -1,0 +1,29 @@
+package com.aws.greengrass.ipc;
+
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.util.EncryptionUtils;
+import software.amazon.awssdk.aws.greengrass.model.InvalidArgumentsError;
+
+import java.io.IOException;
+import java.util.Base64;
+
+import static com.aws.greengrass.util.EncryptionUtils.CERTIFICATE_PEM_HEADER;
+
+public class IPCUtils {
+    private static final Logger logger = LogManager.getLogger(IPCUtils.class);
+
+    public static String reEncodeCertToPem(String certificatePem) {
+        if (!certificatePem.startsWith(CERTIFICATE_PEM_HEADER)) {
+            try {
+                certificatePem = EncryptionUtils.encodeToPem("CERTIFICATE",
+                        // Use MIME decoder as it is more forgiving of formatting
+                        Base64.getMimeDecoder().decode(certificatePem));
+            } catch (IllegalArgumentException | IOException e) {
+                logger.atWarn().log("Unable to convert certificate PEM", e);
+                throw new InvalidArgumentsError("Unable to convert certificate PEM");
+            }
+        }
+        return certificatePem;
+    }
+}

--- a/src/main/java/com/aws/greengrass/ipc/IPCUtils.java
+++ b/src/main/java/com/aws/greengrass/ipc/IPCUtils.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.ipc;
 
 import com.aws.greengrass.logging.api.Logger;

--- a/src/main/java/com/aws/greengrass/ipc/IPCUtils.java
+++ b/src/main/java/com/aws/greengrass/ipc/IPCUtils.java
@@ -15,9 +15,22 @@ import java.util.Base64;
 
 import static com.aws.greengrass.util.EncryptionUtils.CERTIFICATE_PEM_HEADER;
 
-public class IPCUtils {
+public final class IPCUtils {
     private static final Logger logger = LogManager.getLogger(IPCUtils.class);
 
+    private IPCUtils() {
+
+    }
+
+
+    /**
+     * utility method of encoding certificate to PEM format.
+     *
+     * @param certificatePem certificate pem string to encode
+     * @return encoded pem with headers
+     * @throws InvalidArgumentsError if unable to encode the certificate
+     */
+    @SuppressWarnings("PMD.PreserveStackTrace")
     public static String reEncodeCertToPem(String certificatePem) {
         if (!certificatePem.startsWith(CERTIFICATE_PEM_HEADER)) {
             try {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Re-encode certificate PEM of the `GetClientDeviceAuthTokenRequest` IPC request if it is not encoded already. 

**Why is this change necessary:**
Same as https://github.com/aws-greengrass/aws-greengrass-client-device-auth/pull/81

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.