### PR TITLE
fix: create session for internal components via new SessionManager

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/VerifyClientDeviceIdentityTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/VerifyClientDeviceIdentityTest.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.integrationtests.ipc;
 
 import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.device.ClientDevicesAuthService;
+import com.aws.greengrass.device.DeviceAuthClient;
 import com.aws.greengrass.device.exception.CloudServiceInteractionException;
 import com.aws.greengrass.device.iot.IotAuthClient;
 import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
@@ -57,6 +58,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({GGExtension.class, UniqueRootPathExtension.class, MockitoExtension.class})
@@ -71,6 +73,8 @@ class VerifyClientDeviceIdentityTest {
     private GreengrassV2DataClient client;
     @Mock
     private IotAuthClient iotAuthClient;
+    @Mock
+    private DeviceAuthClient deviceAuthClient;
 
     private static void verifyClientIdentity(GreengrassCoreIPCClient ipcClient,
                                              VerifyClientDeviceIdentityRequest request,
@@ -89,6 +93,8 @@ class VerifyClientDeviceIdentityTest {
         System.setProperty("aws.greengrass.scanSelfClasspath", "true");
         kernel = new Kernel();
         kernel.getContext().put(GreengrassServiceClientFactory.class, clientFactory);
+        kernel.getContext().put(DeviceAuthClient.class, deviceAuthClient);
+        lenient().when(deviceAuthClient.isGreengrassComponent(anyString())).thenReturn(false);
 
         when(clientFactory.getGreengrassV2DataClient()).thenReturn(client);
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/VerifyClientDeviceIdentityTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/VerifyClientDeviceIdentityTest.java
@@ -7,7 +7,6 @@ package com.aws.greengrass.integrationtests.ipc;
 
 import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.device.ClientDevicesAuthService;
-import com.aws.greengrass.device.DeviceAuthClient;
 import com.aws.greengrass.device.exception.CloudServiceInteractionException;
 import com.aws.greengrass.device.iot.IotAuthClient;
 import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
@@ -58,7 +57,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({GGExtension.class, UniqueRootPathExtension.class, MockitoExtension.class})
@@ -73,8 +71,6 @@ class VerifyClientDeviceIdentityTest {
     private GreengrassV2DataClient client;
     @Mock
     private IotAuthClient iotAuthClient;
-    @Mock
-    private DeviceAuthClient deviceAuthClient;
 
     private static void verifyClientIdentity(GreengrassCoreIPCClient ipcClient,
                                              VerifyClientDeviceIdentityRequest request,
@@ -93,8 +89,6 @@ class VerifyClientDeviceIdentityTest {
         System.setProperty("aws.greengrass.scanSelfClasspath", "true");
         kernel = new Kernel();
         kernel.getContext().put(GreengrassServiceClientFactory.class, clientFactory);
-        kernel.getContext().put(DeviceAuthClient.class, deviceAuthClient);
-        lenient().when(deviceAuthClient.isGreengrassComponent(anyString())).thenReturn(false);
 
         when(clientFactory.getGreengrassV2DataClient()).thenReturn(client);
 

--- a/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
@@ -325,7 +325,7 @@ public class ClientDevicesAuthService extends PluginService {
                 new SubscribeToCertificateUpdatesOperationHandler(context, certificateManager, authorizationHandler));
         greengrassCoreIPCService.setVerifyClientDeviceIdentityHandler(context ->
                 new VerifyClientDeviceIdentityOperationHandler(context, iotAuthClient,
-                        authorizationHandler, cloudCallThreadPool));
+                        deviceAuthClient, authorizationHandler, cloudCallThreadPool));
         greengrassCoreIPCService.setGetClientDeviceAuthTokenHandler(context ->
                 new GetClientDeviceAuthTokenOperationHandler(context, sessionManager,
                         authorizationHandler, cloudCallThreadPool));

--- a/src/main/java/com/aws/greengrass/device/DeviceAuthClient.java
+++ b/src/main/java/com/aws/greengrass/device/DeviceAuthClient.java
@@ -118,7 +118,7 @@ public class DeviceAuthClient {
     private boolean isGreengrassComponent(CertPath certPath) {
         try {
             X509Certificate caCertificate = certificateStore.getCACertificate();
-            if (caCertificate == null) {
+            if (certPath.getCertificates() == null || certPath.getCertificates().isEmpty() || caCertificate == null) {
                 return false;
             }
             CertPathValidator cpv = CertPathValidator.getInstance("PKIX");

--- a/src/main/java/com/aws/greengrass/device/DeviceAuthClient.java
+++ b/src/main/java/com/aws/greengrass/device/DeviceAuthClient.java
@@ -224,6 +224,7 @@ public class DeviceAuthClient {
                     String.format("Invalid session ID (%s)", request.getSessionId()));
         }
         // Allow all operations from internal components
+        // Keep the workaround above (ALLOW_ALL_SESSION) for Moquette since it is using the older session management
         if (session.getSessionAttribute(Component.NAMESPACE, "component") != null) {
             return true;
         }

--- a/src/main/java/com/aws/greengrass/device/iot/Component.java
+++ b/src/main/java/com/aws/greengrass/device/iot/Component.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.device.iot;
+
+import com.aws.greengrass.device.attribute.AttributeProvider;
+import com.aws.greengrass.device.attribute.DeviceAttribute;
+import lombok.Value;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Value
+public class Component implements AttributeProvider {
+    public static final String NAMESPACE = "Component";
+    private static final Map<String, DeviceAttribute> ATTRIBUTES = Collections.singletonMap("component", expr -> true);
+
+    @Override
+    public String getNamespace() {
+        return NAMESPACE;
+    }
+
+    @Override
+    public Map<String, DeviceAttribute> getDeviceAttributes() {
+        return ATTRIBUTES;
+    }
+}

--- a/src/main/java/com/aws/greengrass/device/session/MqttSessionFactory.java
+++ b/src/main/java/com/aws/greengrass/device/session/MqttSessionFactory.java
@@ -32,23 +32,22 @@ public class MqttSessionFactory implements SessionFactory {
         // TODO: replace with jackson object mapper
         MqttCredential mqttCredential = new MqttCredential(credentialMap);
 
-        Thing thing = new Thing(mqttCredential.clientId);
-
         boolean isGreengrassComponent = deviceAuthClient.isGreengrassComponent(mqttCredential.certificatePem);
         if (isGreengrassComponent) {
             return createGreengrassComponentSession(mqttCredential);
         }
 
-        return createIotThingSession(mqttCredential, thing);
+        return createIotThingSession(mqttCredential);
     }
 
-    private Session createIotThingSession(MqttCredential mqttCredential, Thing thing) throws AuthenticationException {
+    private Session createIotThingSession(MqttCredential mqttCredential) throws AuthenticationException {
         Optional<String> certificateId;
         try {
             certificateId = iotAuthClient.getActiveCertificateId(mqttCredential.certificatePem);
             if (!certificateId.isPresent()) {
                 throw new AuthenticationException("Certificate isn't active");
             }
+            Thing thing = new Thing(mqttCredential.clientId);
             Certificate cert = new Certificate(certificateId.get());
             if (!iotAuthClient.isThingAttachedToCertificate(thing, cert)) {
                 throw new AuthenticationException("unable to authenticate device");

--- a/src/main/java/com/aws/greengrass/device/session/MqttSessionFactory.java
+++ b/src/main/java/com/aws/greengrass/device/session/MqttSessionFactory.java
@@ -5,9 +5,11 @@
 
 package com.aws.greengrass.device.session;
 
+import com.aws.greengrass.device.DeviceAuthClient;
 import com.aws.greengrass.device.exception.AuthenticationException;
 import com.aws.greengrass.device.exception.CloudServiceInteractionException;
 import com.aws.greengrass.device.iot.Certificate;
+import com.aws.greengrass.device.iot.Component;
 import com.aws.greengrass.device.iot.IotAuthClient;
 import com.aws.greengrass.device.iot.Thing;
 
@@ -17,10 +19,12 @@ import javax.inject.Inject;
 
 public class MqttSessionFactory implements SessionFactory {
     private final IotAuthClient iotAuthClient;
+    private final DeviceAuthClient deviceAuthClient;
 
     @Inject
-    public MqttSessionFactory(IotAuthClient iotAuthClient) {
+    public MqttSessionFactory(IotAuthClient iotAuthClient, DeviceAuthClient deviceAuthClient) {
         this.iotAuthClient = iotAuthClient;
+        this.deviceAuthClient = deviceAuthClient;
     }
 
     @Override
@@ -28,26 +32,31 @@ public class MqttSessionFactory implements SessionFactory {
         // TODO: replace with jackson object mapper
         MqttCredential mqttCredential = new MqttCredential(credentialMap);
 
-        // TODO: support internal client certificates.
-        //   Internally issued certificates need to be handled by the entity creating sessions since
-        //   we don't yet have the ability to authorize actions for those clients. So, for now, assume
-        //   this is an IoT Thing and components will be specially handled elsewhere.
         Thing thing = new Thing(mqttCredential.clientId);
-        Optional<String> certificateId;
-        try {
-            certificateId = iotAuthClient.getActiveCertificateId(mqttCredential.certificatePem);
-            if (!certificateId.isPresent()) {
-                throw new AuthenticationException("Certificate isn't active");
-            }
-            Certificate cert = new Certificate(certificateId.get());
-            if (!iotAuthClient.isThingAttachedToCertificate(thing, cert)) {
-                throw new AuthenticationException("unable to authenticate device");
-            }
+
+        boolean isGreengrassComponent = deviceAuthClient.isGreengrassComponent(mqttCredential.certificatePem);
+        if (isGreengrassComponent) {
+            Certificate cert = new Certificate(mqttCredential.clientId);
             Session session = new SessionImpl(cert);
-            session.putAttributeProvider(Thing.NAMESPACE, thing);
+            session.putAttributeProvider(Component.NAMESPACE, new Component());
             return session;
-        } catch (CloudServiceInteractionException e) {
-            throw new AuthenticationException("Failed to verify certificate with cloud", e);
+        } else {
+            Optional<String> certificateId;
+            try {
+                certificateId = iotAuthClient.getActiveCertificateId(mqttCredential.certificatePem);
+                if (!certificateId.isPresent()) {
+                    throw new AuthenticationException("Certificate isn't active");
+                }
+                Certificate cert = new Certificate(certificateId.get());
+                if (!iotAuthClient.isThingAttachedToCertificate(thing, cert)) {
+                    throw new AuthenticationException("unable to authenticate device");
+                }
+                Session session = new SessionImpl(cert);
+                session.putAttributeProvider(Thing.NAMESPACE, thing);
+                return session;
+            } catch (CloudServiceInteractionException e) {
+                throw new AuthenticationException("Failed to verify certificate with cloud", e);
+            }
         }
     }
 

--- a/src/main/java/com/aws/greengrass/ipc/VerifyClientDeviceIdentityOperationHandler.java
+++ b/src/main/java/com/aws/greengrass/ipc/VerifyClientDeviceIdentityOperationHandler.java
@@ -10,6 +10,7 @@ import com.aws.greengrass.authorization.AuthorizationHandler;
 import com.aws.greengrass.authorization.Permission;
 import com.aws.greengrass.authorization.exceptions.AuthorizationException;
 import com.aws.greengrass.device.ClientDevicesAuthService;
+import com.aws.greengrass.device.DeviceAuthClient;
 import com.aws.greengrass.device.iot.IotAuthClient;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
@@ -40,6 +41,7 @@ public class VerifyClientDeviceIdentityOperationHandler
     private static final String NO_DEVICE_CREDENTIAL_ERROR = "Client device credential is required";
     private static final String NO_DEVICE_CERTIFICATE_ERROR = "Client device certificate is required";
     private final IotAuthClient iotAuthClient;
+    private final DeviceAuthClient deviceAuthClient;
     private final String serviceName;
     private final AuthorizationHandler authorizationHandler;
     private final ExecutorService cloudCallThreadPool;
@@ -49,15 +51,18 @@ public class VerifyClientDeviceIdentityOperationHandler
      *
      * @param context              operation continuation handler
      * @param iotAuthClient        auth client for client device calls
+     * @param deviceAuthClient     device auth client to check for internal clients
      * @param authorizationHandler authorization handler
      * @param cloudCallThreadPool  executor to run the call to the cloud asynchronously
      */
     public VerifyClientDeviceIdentityOperationHandler(
             OperationContinuationHandlerContext context, IotAuthClient iotAuthClient,
-            AuthorizationHandler authorizationHandler, ExecutorService cloudCallThreadPool) {
+            DeviceAuthClient deviceAuthClient, AuthorizationHandler authorizationHandler,
+            ExecutorService cloudCallThreadPool) {
 
         super(context);
         this.iotAuthClient = iotAuthClient;
+        this.deviceAuthClient = deviceAuthClient;
         serviceName = context.getAuthenticationData().getIdentityLabel();
         this.authorizationHandler = authorizationHandler;
         this.cloudCallThreadPool = cloudCallThreadPool;
@@ -89,9 +94,15 @@ public class VerifyClientDeviceIdentityOperationHandler
             }
             String certificate = getCertificateFromCredential(request.getCredential());
             try {
-                Optional<String> certificateId = iotAuthClient.getActiveCertificateId(certificate);
                 VerifyClientDeviceIdentityResponse response = new VerifyClientDeviceIdentityResponse();
-                return response.withIsValidClientDevice(certificateId.isPresent());
+                // Allow internal clients to verify their identities
+                if (deviceAuthClient.isGreengrassComponent(certificate)) {
+                    response.withIsValidClientDevice(true);
+                } else {
+                    Optional<String> certificateId = iotAuthClient.getActiveCertificateId(certificate);
+                    response.withIsValidClientDevice(certificateId.isPresent());
+                }
+                return response;
             } catch (Exception e) {
                 logger.atError().cause(e).log("Unable to verify client device identity");
                 throw new ServiceError("Verifying client device identity failed. Check Greengrass log for details.");

--- a/src/test/java/com/aws/greengrass/device/DeviceAuthClientTest.java
+++ b/src/test/java/com/aws/greengrass/device/DeviceAuthClientTest.java
@@ -22,6 +22,7 @@ import com.aws.greengrass.device.exception.AuthenticationException;
 import com.aws.greengrass.device.exception.AuthorizationException;
 import com.aws.greengrass.device.exception.CloudServiceInteractionException;
 import com.aws.greengrass.device.iot.Certificate;
+import com.aws.greengrass.device.iot.Component;
 import com.aws.greengrass.device.iot.IotAuthClient;
 import com.aws.greengrass.device.iot.Thing;
 import com.aws.greengrass.device.session.Session;
@@ -188,6 +189,18 @@ public class DeviceAuthClientTest {
                 Collections.singleton(
                         Permission.builder().operation("mqtt:publish").resource("mqtt:topic:foo").principal("group1")
                                 .build())));
+
+        boolean authorized = authClient.canDevicePerform(constructAuthorizationRequest());
+
+        assertThat(authorized, is(true));
+        verify(iotClient, never()).isThingAttachedToCertificate(any(), any());
+    }
+
+    @Test
+    void GIVEN_internalClientSession_WHEN_canDevicePerform_THEN_authorizationReturnTrue() throws Exception {
+        Session session = new SessionImpl(new Certificate("certificateId"));
+        session.putAttributeProvider(Component.NAMESPACE, new Component());
+        when(sessionManager.findSession("sessionId")).thenReturn(session);
 
         boolean authorized = authClient.canDevicePerform(constructAuthorizationRequest());
 

--- a/src/test/java/com/aws/greengrass/device/session/MqttSessionFactoryTest.java
+++ b/src/test/java/com/aws/greengrass/device/session/MqttSessionFactoryTest.java
@@ -5,8 +5,10 @@
 
 package com.aws.greengrass.device.session;
 
+import com.aws.greengrass.device.DeviceAuthClient;
 import com.aws.greengrass.device.exception.AuthenticationException;
 import com.aws.greengrass.device.exception.CloudServiceInteractionException;
+import com.aws.greengrass.device.iot.Component;
 import com.aws.greengrass.device.iot.IotAuthClient;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.hamcrest.core.IsNull;
@@ -23,13 +25,17 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 public class MqttSessionFactoryTest {
     @Mock
     private IotAuthClient mockIotAuthClient;
+    @Mock
+    private DeviceAuthClient mockDeviceAuthClient;
     private MqttSessionFactory mqttSessionFactory;
     private final Map<String, String> credentialMap = ImmutableMap.of(
             "certificatePem", "PEM",
@@ -40,7 +46,7 @@ public class MqttSessionFactoryTest {
 
     @BeforeEach
     void beforeEach() {
-        mqttSessionFactory = new MqttSessionFactory(mockIotAuthClient);
+        mqttSessionFactory = new MqttSessionFactory(mockIotAuthClient, mockDeviceAuthClient);
     }
 
     @Test
@@ -75,5 +81,14 @@ public class MqttSessionFactoryTest {
 
         Session session = mqttSessionFactory.createSession(credentialMap);
         assertThat(session, is(IsNull.notNullValue()));
+    }
+
+    @Test
+    void GIVEN_componentWithValidClientId_WHEN_createSession_THEN_returnsSession() throws AuthenticationException {
+        when(mockDeviceAuthClient.isGreengrassComponent(anyString())).thenReturn(true);
+
+        Session session = mqttSessionFactory.createSession(credentialMap);
+        assertThat(session, is(IsNull.notNullValue()));
+        assertThat(session.getSessionAttribute(Component.NAMESPACE, "component"), notNullValue());
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Handle certificates coming from internal components (ie. Bridge).

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
