### PR TITLE
revert: configurable client cert rotation period

### DIFF
--- a/src/main/java/com/aws/greengrass/certificatemanager/certificate/CertificatesConfig.java
+++ b/src/main/java/com/aws/greengrass/certificatemanager/certificate/CertificatesConfig.java
@@ -16,21 +16,16 @@ public class CertificatesConfig {
 
     static final int MAX_SERVER_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 10; // 10 days
     static final int MIN_SERVER_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 2; // 2 days
-    static final int MAX_CLIENT_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 10; // 10 days
-    static final int MIN_CLIENT_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 2; // 2 days
     static final int DEFAULT_SERVER_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 7; // 7 days
     static final int DEFAULT_CLIENT_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 7; // 7 days
     static final boolean DEFAULT_DISABLE_CERTIFICATE_ROTATION = false;
 
     private static final String CERTIFICATES_CONFIGURATION = "certificates";
     private static final String SERVER_CERT_VALIDITY_SECONDS = "serverCertificateValiditySeconds";
-    private static final String CLIENT_CERT_VALIDITY_SECONDS = "clientCertificateValiditySeconds";
     private static final String DISABLE_CERTIFICATE_ROTATION = "disableCertificateRotation";
 
     static final String[] PATH_SERVER_CERT_EXPIRY_SECONDS =
             {KernelConfigResolver.CONFIGURATION_CONFIG_KEY, CERTIFICATES_CONFIGURATION, SERVER_CERT_VALIDITY_SECONDS};
-    static final String[] PATH_CLIENT_CERT_EXPIRY_SECONDS =
-            {KernelConfigResolver.CONFIGURATION_CONFIG_KEY, CERTIFICATES_CONFIGURATION, CLIENT_CERT_VALIDITY_SECONDS};
     static final String[] PATH_DISABLE_CERTIFICATE_ROTATION =
             {KernelConfigResolver.CONFIGURATION_CONFIG_KEY, CERTIFICATES_CONFIGURATION, DISABLE_CERTIFICATE_ROTATION};
 
@@ -70,20 +65,7 @@ public class CertificatesConfig {
      * @return Client certificate validity in seconds
      */
     public int getClientCertValiditySeconds() {
-        int configuredValidityPeriod = Coerce.toInt(configuration.findOrDefault(DEFAULT_CLIENT_CERT_EXPIRY_SECONDS,
-                PATH_CLIENT_CERT_EXPIRY_SECONDS));
-        if (configuredValidityPeriod > MAX_CLIENT_CERT_EXPIRY_SECONDS) {
-            LOGGER.atWarn().kv(CLIENT_CERT_VALIDITY_SECONDS, configuredValidityPeriod)
-                    .kv("maxAllowable", MAX_CLIENT_CERT_EXPIRY_SECONDS)
-                    .log("Using maximum allowable duration for client certificate validity period");
-            return MAX_CLIENT_CERT_EXPIRY_SECONDS;
-        } else if (configuredValidityPeriod < MIN_CLIENT_CERT_EXPIRY_SECONDS) {
-            LOGGER.atWarn().kv(CLIENT_CERT_VALIDITY_SECONDS, configuredValidityPeriod)
-                    .kv("minAllowable", MAX_CLIENT_CERT_EXPIRY_SECONDS)
-                    .log("Using minimum allowable duration for client certificate validity period");
-            return MIN_CLIENT_CERT_EXPIRY_SECONDS;
-        }
-        return configuredValidityPeriod;
+        return DEFAULT_CLIENT_CERT_EXPIRY_SECONDS;
     }
 
     /**

--- a/src/test/java/com/aws/greengrass/certificatemanager/certificate/CertificatesConfigTest.java
+++ b/src/test/java/com/aws/greengrass/certificatemanager/certificate/CertificatesConfigTest.java
@@ -64,18 +64,4 @@ public class CertificatesConfigTest {
                 is(equalTo(CertificatesConfig.DEFAULT_CLIENT_CERT_EXPIRY_SECONDS)));
     }
 
-    @Test
-    public void GIVEN_largeClientCertValidity_WHEN_getClientCertValiditySeconds_THEN_returnsMaxExpiry() {
-        configurationTopics.lookup(CertificatesConfig.PATH_CLIENT_CERT_EXPIRY_SECONDS)
-                .withValue(2 * CertificatesConfig.MAX_CLIENT_CERT_EXPIRY_SECONDS);
-        assertThat(certificatesConfig.getClientCertValiditySeconds(),
-                is(equalTo(CertificatesConfig.MAX_CLIENT_CERT_EXPIRY_SECONDS)));
-    }
-
-    @Test
-    public void GIVEN_smallClientCertValidity_WHEN_getClientCertValiditySeconds_THEN_returnsMinExpiry() {
-        configurationTopics.lookup(CertificatesConfig.PATH_CLIENT_CERT_EXPIRY_SECONDS).withValue(60 * 60 * 24); // 1 day
-        assertThat(certificatesConfig.getClientCertValiditySeconds(),
-                is(equalTo(CertificatesConfig.MIN_CLIENT_CERT_EXPIRY_SECONDS)));
-    }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Removes the `clientCertificateValiditySeconds` config

**Why is this change necessary:**
We are not releasing this, so it should be removed

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
