### PR TITLE
fix: rename and namespace sessionCapacity config

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/GetClientDeviceAuthTokenTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/GetClientDeviceAuthTokenTest.java
@@ -51,6 +51,7 @@ import java.util.function.Consumer;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 import static com.aws.greengrass.device.ClientDevicesAuthService.CLOUD_QUEUE_SIZE_TOPIC;
+import static com.aws.greengrass.device.ClientDevicesAuthService.SETTINGS_TOPIC;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static com.aws.greengrass.testcommons.testutilities.TestUtils.asyncAssertOnConsumer;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -174,7 +175,7 @@ class GetClientDeviceAuthTokenTest {
 
         // Update the cloud queue size to 1 so that we'll just reject the second request
         kernel.findServiceTopic(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME)
-                .lookup(CONFIGURATION_CONFIG_KEY, CLOUD_QUEUE_SIZE_TOPIC).withValue(1);
+                .lookup(CONFIGURATION_CONFIG_KEY, SETTINGS_TOPIC, CLOUD_QUEUE_SIZE_TOPIC).withValue(1);
         kernel.getContext().waitForPublishQueueToClear();
 
         // Verify that we get a good error that the request couldn't be queued

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/GetClientDeviceAuthTokenTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/GetClientDeviceAuthTokenTest.java
@@ -51,7 +51,7 @@ import java.util.function.Consumer;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 import static com.aws.greengrass.device.ClientDevicesAuthService.CLOUD_QUEUE_SIZE_TOPIC;
-import static com.aws.greengrass.device.ClientDevicesAuthService.SETTINGS_TOPIC;
+import static com.aws.greengrass.device.ClientDevicesAuthService.PERFORMANCE_TOPIC;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static com.aws.greengrass.testcommons.testutilities.TestUtils.asyncAssertOnConsumer;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -175,7 +175,7 @@ class GetClientDeviceAuthTokenTest {
 
         // Update the cloud queue size to 1 so that we'll just reject the second request
         kernel.findServiceTopic(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME)
-                .lookup(CONFIGURATION_CONFIG_KEY, SETTINGS_TOPIC, CLOUD_QUEUE_SIZE_TOPIC).withValue(1);
+                .lookup(CONFIGURATION_CONFIG_KEY, PERFORMANCE_TOPIC, CLOUD_QUEUE_SIZE_TOPIC).withValue(1);
         kernel.getContext().waitForPublishQueueToClear();
 
         // Verify that we get a good error that the request couldn't be queued

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/GetClientDeviceAuthTokenTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/GetClientDeviceAuthTokenTest.java
@@ -50,7 +50,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
-import static com.aws.greengrass.device.ClientDevicesAuthService.CLOUD_QUEUE_SIZE_TOPIC;
+import static com.aws.greengrass.device.ClientDevicesAuthService.CLOUD_REQUEST_QUEUE_SIZE_TOPIC;
 import static com.aws.greengrass.device.ClientDevicesAuthService.PERFORMANCE_TOPIC;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static com.aws.greengrass.testcommons.testutilities.TestUtils.asyncAssertOnConsumer;
@@ -175,7 +175,7 @@ class GetClientDeviceAuthTokenTest {
 
         // Update the cloud queue size to 1 so that we'll just reject the second request
         kernel.findServiceTopic(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME)
-                .lookup(CONFIGURATION_CONFIG_KEY, PERFORMANCE_TOPIC, CLOUD_QUEUE_SIZE_TOPIC).withValue(1);
+                .lookup(CONFIGURATION_CONFIG_KEY, PERFORMANCE_TOPIC, CLOUD_REQUEST_QUEUE_SIZE_TOPIC).withValue(1);
         kernel.getContext().waitForPublishQueueToClear();
 
         // Verify that we get a good error that the request couldn't be queued

--- a/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
@@ -147,7 +147,8 @@ public class ClientDevicesAuthService extends PluginService {
 
     private int getValidCloudCallQueueSize(Topics topics) {
         int newSize = Coerce.toInt(
-                topics.findOrDefault(DEFAULT_CLOUD_CALL_QUEUE_SIZE, CONFIGURATION_CONFIG_KEY, CLOUD_QUEUE_SIZE_TOPIC));
+                topics.findOrDefault(DEFAULT_CLOUD_CALL_QUEUE_SIZE,
+                        CONFIGURATION_CONFIG_KEY, SETTINGS_TOPIC, CLOUD_QUEUE_SIZE_TOPIC));
         if (newSize <= 0) {
             logger.atWarn().log("{} illegal size, will not change the queue size from {}",
                     CLOUD_QUEUE_SIZE_TOPIC, cloudCallQueueSize);
@@ -159,6 +160,11 @@ public class ClientDevicesAuthService extends PluginService {
     /**
      * Certificate Manager Service uses the following topic structure:
      * |---- configuration
+     * |    |---- settings:
+     * |         |---- cloudQueueSize: "..."
+     * |         |---- threadPoolSize: "..."
+     * |         |---- deviceAuthToken:
+     * |              |---- maxActiveAuthTokens: "..."
      * |    |---- deviceGroups:
      * |         |---- definitions : {}
      * |         |---- policies : {}
@@ -183,7 +189,7 @@ public class ClientDevicesAuthService extends PluginService {
             // Attempt to update the thread pool size as needed
             try {
                 int threadPoolSize = Coerce.toInt(this.config.findOrDefault(DEFAULT_THREAD_POOL_SIZE,
-                        CONFIGURATION_CONFIG_KEY, THREAD_POOL_SIZE_TOPIC));
+                        CONFIGURATION_CONFIG_KEY, SETTINGS_TOPIC, THREAD_POOL_SIZE_TOPIC));
                 if (threadPoolSize >= cloudCallThreadPool.getCorePoolSize()) {
                     cloudCallThreadPool.setMaximumPoolSize(threadPoolSize);
                 }

--- a/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
@@ -66,6 +66,9 @@ public class ClientDevicesAuthService extends PluginService {
     public static final String CA_PASSPHRASE = "ca_passphrase";
     public static final String CERTIFICATES_KEY = "certificates";
     public static final String AUTHORITIES_TOPIC = "authorities";
+    public static final String SETTINGS_TOPIC = "settings";
+    public static final String DEVICE_AUTH_TOKEN_TOPIC = "deviceAuthToken";
+    public static final String MAX_ACTIVE_AUTH_TOKENS_TOPIC = "maxActiveAuthTokens";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
             .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS, MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES);
     private static final RetryUtils.RetryConfig SERVICE_EXCEPTION_RETRY_CONFIG =
@@ -90,6 +93,7 @@ public class ClientDevicesAuthService extends PluginService {
     // Limit the queue size before we start rejecting requests
     private static final int DEFAULT_CLOUD_CALL_QUEUE_SIZE = 100;
     private static final int DEFAULT_THREAD_POOL_SIZE = 1;
+    public static final int DEFAULT_MAX_ACTIVE_AUTH_TOKENS = 2500;
     // Create a threadpool for calling the cloud. Single thread will be used by default.
     private final ThreadPoolExecutor cloudCallThreadPool;
     private int cloudCallQueueSize;

--- a/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
@@ -66,8 +66,7 @@ public class ClientDevicesAuthService extends PluginService {
     public static final String CA_PASSPHRASE = "ca_passphrase";
     public static final String CERTIFICATES_KEY = "certificates";
     public static final String AUTHORITIES_TOPIC = "authorities";
-    public static final String SETTINGS_TOPIC = "settings";
-    public static final String DEVICE_AUTH_TOKEN_TOPIC = "deviceAuthToken";
+    public static final String PERFORMANCE_TOPIC = "performance";
     public static final String MAX_ACTIVE_AUTH_TOKENS_TOPIC = "maxActiveAuthTokens";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
             .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS, MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES);
@@ -148,7 +147,7 @@ public class ClientDevicesAuthService extends PluginService {
     private int getValidCloudCallQueueSize(Topics topics) {
         int newSize = Coerce.toInt(
                 topics.findOrDefault(DEFAULT_CLOUD_CALL_QUEUE_SIZE,
-                        CONFIGURATION_CONFIG_KEY, SETTINGS_TOPIC, CLOUD_QUEUE_SIZE_TOPIC));
+                        CONFIGURATION_CONFIG_KEY, PERFORMANCE_TOPIC, CLOUD_QUEUE_SIZE_TOPIC));
         if (newSize <= 0) {
             logger.atWarn().log("{} illegal size, will not change the queue size from {}",
                     CLOUD_QUEUE_SIZE_TOPIC, cloudCallQueueSize);
@@ -160,11 +159,10 @@ public class ClientDevicesAuthService extends PluginService {
     /**
      * Certificate Manager Service uses the following topic structure:
      * |---- configuration
-     * |    |---- settings:
+     * |    |---- performance:
      * |         |---- cloudQueueSize: "..."
      * |         |---- threadPoolSize: "..."
-     * |         |---- deviceAuthToken:
-     * |              |---- maxActiveAuthTokens: "..."
+     * |         |---- maxActiveAuthTokens: "..."
      * |    |---- deviceGroups:
      * |         |---- definitions : {}
      * |         |---- policies : {}
@@ -189,7 +187,7 @@ public class ClientDevicesAuthService extends PluginService {
             // Attempt to update the thread pool size as needed
             try {
                 int threadPoolSize = Coerce.toInt(this.config.findOrDefault(DEFAULT_THREAD_POOL_SIZE,
-                        CONFIGURATION_CONFIG_KEY, SETTINGS_TOPIC, THREAD_POOL_SIZE_TOPIC));
+                        CONFIGURATION_CONFIG_KEY, PERFORMANCE_TOPIC, THREAD_POOL_SIZE_TOPIC));
                 if (threadPoolSize >= cloudCallThreadPool.getCorePoolSize()) {
                     cloudCallThreadPool.setMaximumPoolSize(threadPoolSize);
                 }

--- a/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
@@ -160,8 +160,8 @@ public class ClientDevicesAuthService extends PluginService {
      * Certificate Manager Service uses the following topic structure:
      * |---- configuration
      * |    |---- performance:
-     * |         |---- cloudQueueSize: "..."
-     * |         |---- threadPoolSize: "..."
+     * |         |---- cloudRequestQueueSize: "..."
+     * |         |---- maxConcurrentCloudRequests: "..."
      * |         |---- maxActiveAuthTokens: "..."
      * |    |---- deviceGroups:
      * |         |---- definitions : {}

--- a/src/main/java/com/aws/greengrass/device/session/SessionConfig.java
+++ b/src/main/java/com/aws/greengrass/device/session/SessionConfig.java
@@ -13,9 +13,8 @@ import com.aws.greengrass.util.Coerce;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.aws.greengrass.device.ClientDevicesAuthService.DEFAULT_MAX_ACTIVE_AUTH_TOKENS;
-import static com.aws.greengrass.device.ClientDevicesAuthService.DEVICE_AUTH_TOKEN_TOPIC;
 import static com.aws.greengrass.device.ClientDevicesAuthService.MAX_ACTIVE_AUTH_TOKENS_TOPIC;
-import static com.aws.greengrass.device.ClientDevicesAuthService.SETTINGS_TOPIC;
+import static com.aws.greengrass.device.ClientDevicesAuthService.PERFORMANCE_TOPIC;
 
 @SuppressWarnings("PMD.DataClass")
 public class SessionConfig {
@@ -74,7 +73,7 @@ public class SessionConfig {
             return DEFAULT_SESSION_CAPACITY;
         }
         int configValue = Coerce.toInt(configuration.findOrDefault(DEFAULT_SESSION_CAPACITY,
-                SETTINGS_TOPIC, DEVICE_AUTH_TOKEN_TOPIC, MAX_ACTIVE_AUTH_TOKENS_TOPIC));
+                PERFORMANCE_TOPIC, MAX_ACTIVE_AUTH_TOKENS_TOPIC));
 
         int clamped = Math.max(MIN_SESSION_CAPACITY, Math.min(MAX_SESSION_CAPACITY, configValue));
         if (clamped != configValue) {

--- a/src/test/java/com/aws/greengrass/device/session/SessionConfigTest.java
+++ b/src/test/java/com/aws/greengrass/device/session/SessionConfigTest.java
@@ -18,9 +18,8 @@ import java.io.IOException;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 import static com.aws.greengrass.device.ClientDevicesAuthService.DEFAULT_MAX_ACTIVE_AUTH_TOKENS;
-import static com.aws.greengrass.device.ClientDevicesAuthService.DEVICE_AUTH_TOKEN_TOPIC;
 import static com.aws.greengrass.device.ClientDevicesAuthService.MAX_ACTIVE_AUTH_TOKENS_TOPIC;
-import static com.aws.greengrass.device.ClientDevicesAuthService.SETTINGS_TOPIC;
+import static com.aws.greengrass.device.ClientDevicesAuthService.PERFORMANCE_TOPIC;
 import static com.aws.greengrass.device.session.SessionConfig.MAX_SESSION_CAPACITY;
 import static com.aws.greengrass.device.session.SessionConfig.MIN_SESSION_CAPACITY;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -52,7 +51,7 @@ class SessionConfigTest {
     public void GIVEN_default_session_capacity_WHEN_update_configuration_THEN_returns_updated_capacity() {
         assertThat(sessionConfig.getSessionCapacity(), is(equalTo(DEFAULT_MAX_ACTIVE_AUTH_TOKENS)));
         int newCapacity = 1;
-        configurationTopics.lookup(SETTINGS_TOPIC, DEVICE_AUTH_TOKEN_TOPIC, MAX_ACTIVE_AUTH_TOKENS_TOPIC)
+        configurationTopics.lookup(PERFORMANCE_TOPIC, MAX_ACTIVE_AUTH_TOKENS_TOPIC)
                 .withValue(newCapacity);
         // block until config changes are merged in
         configurationTopics.context.waitForPublishQueueToClear();
@@ -63,27 +62,23 @@ class SessionConfigTest {
     public void GIVEN_invalid_configured_session_capacity_WHEN_getSessionCapacity_THEN_returns_clamped_capacity() {
         // zero capacity
         int configuredCapacity = 0;
-        configurationTopics.lookup(SETTINGS_TOPIC, DEVICE_AUTH_TOKEN_TOPIC, MAX_ACTIVE_AUTH_TOKENS_TOPIC)
-                .withValue(configuredCapacity);
+        configurationTopics.lookup(PERFORMANCE_TOPIC, MAX_ACTIVE_AUTH_TOKENS_TOPIC).withValue(configuredCapacity);
         configurationTopics.context.waitForPublishQueueToClear();
         assertThat(sessionConfig.getSessionCapacity(), is(equalTo(MIN_SESSION_CAPACITY)));
 
         // overflown integer
         int overflown = Integer.MAX_VALUE + 1;
-        configurationTopics.lookup(SETTINGS_TOPIC, DEVICE_AUTH_TOKEN_TOPIC, MAX_ACTIVE_AUTH_TOKENS_TOPIC)
-                .withValue(overflown);
+        configurationTopics.lookup(PERFORMANCE_TOPIC, MAX_ACTIVE_AUTH_TOKENS_TOPIC).withValue(overflown);
         configurationTopics.context.waitForPublishQueueToClear();
         assertThat(sessionConfig.getSessionCapacity(), is(equalTo(MIN_SESSION_CAPACITY)));
 
         // integer max value
-        configurationTopics.lookup(SETTINGS_TOPIC, DEVICE_AUTH_TOKEN_TOPIC, MAX_ACTIVE_AUTH_TOKENS_TOPIC)
-                .withValue(Integer.MAX_VALUE);
+        configurationTopics.lookup(PERFORMANCE_TOPIC, MAX_ACTIVE_AUTH_TOKENS_TOPIC).withValue(Integer.MAX_VALUE);
         configurationTopics.context.waitForPublishQueueToClear();
         assertThat(sessionConfig.getSessionCapacity(), is(equalTo(MAX_SESSION_CAPACITY)));
 
         String empty = "";
-        configurationTopics.lookup(SETTINGS_TOPIC, DEVICE_AUTH_TOKEN_TOPIC, MAX_ACTIVE_AUTH_TOKENS_TOPIC)
-                .withValue(empty);
+        configurationTopics.lookup(PERFORMANCE_TOPIC, MAX_ACTIVE_AUTH_TOKENS_TOPIC).withValue(empty);
         configurationTopics.context.waitForPublishQueueToClear();
         assertThat(sessionConfig.getSessionCapacity(), is(equalTo(MIN_SESSION_CAPACITY)));
     }


### PR DESCRIPTION
**Description of changes:** 
- rename and namespace `sessionCapacity` config to `configuration.performance.maxActiveAuthTokens`
- update `sessionCapacity` default to 2500
- clamp invalid configured `sessionCapacity` values to the valid range instead of default
- rename `cloudQueueSize` -> `cloudRequestQueueSize` , `threadPoolSize` -> `maxConcurrentCloudRequests`
- namespace `cloudRequestQueueSize` and `maxConcurrentCloudRequests` config under `configuration.performance`

New CDA config:
```
     |---- configuration
     |    |---- performance:
     |         |---- cloudRequestQueueSize: "..."
     |         |---- maxConcurrentCloudRequests: "..."
     |         |---- maxActiveAuthTokens: "..."
     |    |---- deviceGroups:
     |         |---- definitions : {}
     |         |---- policies : {}
     |    |---- ca_type: [...]
     |    |---- certificates: {}
     |---- runtime
     |    |---- ca_passphrase: "..."
     |    |---- certificates:
     |         |---- authorities: [...]
```

**How was this change tested:** `mvn clean package`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
