### PR TITLE
refactor: move IPC APIs to ClientDevicesAuthServiceAPI

### DIFF
--- a/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/device/ClientDevicesAuthService.java
@@ -43,7 +43,6 @@ import java.security.KeyStoreException;
 import java.security.cert.CertificateEncodingException;
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
@@ -53,7 +52,10 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
+import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.AUTHORIZE_CLIENT_DEVICE_ACTION;
+import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.GET_CLIENT_DEVICE_AUTH_TOKEN;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.SUBSCRIBE_TO_CERTIFICATE_UPDATES;
+import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.VERIFY_CLIENT_DEVICE_IDENTITY;
 
 @SuppressWarnings("PMD.DataClass")
 @ImplementsService(name = ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME)
@@ -228,7 +230,12 @@ public class ClientDevicesAuthService extends PluginService {
         super.postInject();
         try {
             authorizationHandler.registerComponent(this.getName(),
-                    new HashSet<>(Collections.singletonList(SUBSCRIBE_TO_CERTIFICATE_UPDATES)));
+                    new HashSet<>(Arrays.asList(new String[]{
+                            SUBSCRIBE_TO_CERTIFICATE_UPDATES,
+                            VERIFY_CLIENT_DEVICE_IDENTITY,
+                            GET_CLIENT_DEVICE_AUTH_TOKEN,
+                            AUTHORIZE_CLIENT_DEVICE_ACTION
+                    })));
         } catch (com.aws.greengrass.authorization.exceptions.AuthorizationException e) {
             logger.atError("initialize-cda-service-authorization-error", e)
                     .log("Failed to initialize the client device auth service with the Authorization module.");

--- a/src/main/java/com/aws/greengrass/device/ClientDevicesAuthServiceApi.java
+++ b/src/main/java/com/aws/greengrass/device/ClientDevicesAuthServiceApi.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.device;
+
+import com.aws.greengrass.device.exception.AuthenticationException;
+import com.aws.greengrass.device.exception.AuthorizationException;
+import com.aws.greengrass.device.iot.IotAuthClient;
+import com.aws.greengrass.device.session.SessionManager;
+
+import java.util.Map;
+import java.util.Optional;
+import javax.inject.Inject;
+
+public class ClientDevicesAuthServiceApi {
+    private final IotAuthClient iotAuthClient;
+    private final SessionManager sessionManager;
+    private final DeviceAuthClient deviceAuthClient;
+
+    /**
+     * Constructor.
+     *
+     * @param iotAuthClient    iot auth client
+     * @param sessionManager   session manager
+     * @param deviceAuthClient device auth client
+     */
+    @Inject
+    public ClientDevicesAuthServiceApi(IotAuthClient iotAuthClient,
+                                       SessionManager sessionManager,
+                                       DeviceAuthClient deviceAuthClient) {
+        this.iotAuthClient = iotAuthClient;
+        this.sessionManager = sessionManager;
+        this.deviceAuthClient = deviceAuthClient;
+    }
+
+    /**
+     * Verify client device identity.
+     * @param certificatePem PEM encoded client certificate.
+     * @return True if the provided client certificate is trusted.
+     */
+    public boolean verifyClientDeviceIdentity(String certificatePem) {
+        // Allow internal clients to verify their identities
+        if (deviceAuthClient.isGreengrassComponent(certificatePem)) {
+            return true;
+        } else {
+            Optional<String> certificateId = iotAuthClient.getActiveCertificateId(certificatePem);
+            return certificateId.isPresent();
+        }
+    }
+
+    /**
+     * Get client auth token.
+     * @param credentialType    Type of client credentials
+     * @param deviceCredentials Client credential map
+     * @return client auth token to be used for future authorization requests.
+     * @throws AuthenticationException if unable to authenticate client credentials
+     */
+    public String getClientDeviceAuthToken(String credentialType, Map<String, String> deviceCredentials)
+        throws AuthenticationException {
+        return sessionManager.createSession(credentialType, deviceCredentials);
+    }
+
+    /**
+     * Authorize client action.
+     * @param authorizationRequest Authorization request, including auth token, operation, and resource
+     * @return true if the client action is allowed
+     * @throws AuthorizationException if the client action is not allowed
+     */
+    public boolean authorizeClientDeviceAction(AuthorizationRequest authorizationRequest)
+            throws AuthorizationException {
+        return deviceAuthClient.canDevicePerform(authorizationRequest);
+    }
+}

--- a/src/main/java/com/aws/greengrass/ipc/AuthorizeClientDeviceActionOperationHandler.java
+++ b/src/main/java/com/aws/greengrass/ipc/AuthorizeClientDeviceActionOperationHandler.java
@@ -11,6 +11,7 @@ import com.aws.greengrass.authorization.Permission;
 import com.aws.greengrass.authorization.exceptions.AuthorizationException;
 import com.aws.greengrass.device.AuthorizationRequest;
 import com.aws.greengrass.device.ClientDevicesAuthService;
+import com.aws.greengrass.device.ClientDevicesAuthServiceApi;
 import com.aws.greengrass.device.exception.InvalidSessionException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
@@ -38,26 +39,25 @@ public class AuthorizeClientDeviceActionOperationHandler
     private static final String NO_RESOURCE_ERROR = "Resource is required";
     private final String serviceName;
     private final AuthorizationHandler authorizationHandler;
-    private final ClientDevicesAuthService clientDevicesAuthService;
+    private final ClientDevicesAuthServiceApi clientDevicesAuthServiceApi;
 
     /**
      * Constructor.
      *
-     * @param context                  operation continuation handler
-     * @param clientDevicesAuthService client devices auth service handle
-     * @param authorizationHandler     authorization handler
+     * @param context                     operation continuation handler
+     * @param clientDevicesAuthServiceApi client devices auth service handle
+     * @param authorizationHandler        authorization handler
      */
     public AuthorizeClientDeviceActionOperationHandler(
             OperationContinuationHandlerContext context,
-            ClientDevicesAuthService clientDevicesAuthService,
+            ClientDevicesAuthServiceApi clientDevicesAuthServiceApi,
             AuthorizationHandler authorizationHandler
-
     ) {
 
         super(context);
         serviceName = context.getAuthenticationData().getIdentityLabel();
         this.authorizationHandler = authorizationHandler;
-        this.clientDevicesAuthService = clientDevicesAuthService;
+        this.clientDevicesAuthServiceApi = clientDevicesAuthServiceApi;
     }
 
     @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.PreserveStackTrace"})
@@ -72,7 +72,7 @@ public class AuthorizeClientDeviceActionOperationHandler
             }
             AuthorizationRequest authorizationRequest = getAuthzRequest(request);
             try {
-                boolean isAuthorized = clientDevicesAuthService.authorizeClientDeviceAction(authorizationRequest);
+                boolean isAuthorized = clientDevicesAuthServiceApi.authorizeClientDeviceAction(authorizationRequest);
                 AuthorizeClientDeviceActionResponse response = new AuthorizeClientDeviceActionResponse();
                 return response.withIsAuthorized(isAuthorized);
             } catch (InvalidSessionException e) {
@@ -120,12 +120,9 @@ public class AuthorizeClientDeviceActionOperationHandler
 
     @Override
     public void handleStreamEvent(EventStreamJsonMessage eventStreamJsonMessage) {
-
     }
 
     @Override
     protected void onStreamClosed() {
-
     }
-
 }

--- a/src/main/java/com/aws/greengrass/ipc/AuthorizeClientDeviceActionOperationHandler.java
+++ b/src/main/java/com/aws/greengrass/ipc/AuthorizeClientDeviceActionOperationHandler.java
@@ -11,7 +11,6 @@ import com.aws.greengrass.authorization.Permission;
 import com.aws.greengrass.authorization.exceptions.AuthorizationException;
 import com.aws.greengrass.device.AuthorizationRequest;
 import com.aws.greengrass.device.ClientDevicesAuthService;
-import com.aws.greengrass.device.DeviceAuthClient;
 import com.aws.greengrass.device.exception.InvalidSessionException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
@@ -39,18 +38,18 @@ public class AuthorizeClientDeviceActionOperationHandler
     private static final String NO_RESOURCE_ERROR = "Resource is required";
     private final String serviceName;
     private final AuthorizationHandler authorizationHandler;
-    private final DeviceAuthClient deviceAuthClient;
+    private final ClientDevicesAuthService clientDevicesAuthService;
 
     /**
      * Constructor.
      *
-     * @param context              operation continuation handler
-     * @param deviceAuthClient     device auth client
-     * @param authorizationHandler authorization handler
+     * @param context                  operation continuation handler
+     * @param clientDevicesAuthService client devices auth service handle
+     * @param authorizationHandler     authorization handler
      */
     public AuthorizeClientDeviceActionOperationHandler(
             OperationContinuationHandlerContext context,
-            DeviceAuthClient deviceAuthClient,
+            ClientDevicesAuthService clientDevicesAuthService,
             AuthorizationHandler authorizationHandler
 
     ) {
@@ -58,7 +57,7 @@ public class AuthorizeClientDeviceActionOperationHandler
         super(context);
         serviceName = context.getAuthenticationData().getIdentityLabel();
         this.authorizationHandler = authorizationHandler;
-        this.deviceAuthClient = deviceAuthClient;
+        this.clientDevicesAuthService = clientDevicesAuthService;
     }
 
     @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.PreserveStackTrace"})
@@ -73,7 +72,7 @@ public class AuthorizeClientDeviceActionOperationHandler
             }
             AuthorizationRequest authorizationRequest = getAuthzRequest(request);
             try {
-                boolean isAuthorized = deviceAuthClient.canDevicePerform(authorizationRequest);
+                boolean isAuthorized = clientDevicesAuthService.authorizeClientDeviceAction(authorizationRequest);
                 AuthorizeClientDeviceActionResponse response = new AuthorizeClientDeviceActionResponse();
                 return response.withIsAuthorized(isAuthorized);
             } catch (InvalidSessionException e) {

--- a/src/main/java/com/aws/greengrass/ipc/GetClientDeviceAuthTokenOperationHandler.java
+++ b/src/main/java/com/aws/greengrass/ipc/GetClientDeviceAuthTokenOperationHandler.java
@@ -10,6 +10,7 @@ import com.aws.greengrass.authorization.AuthorizationHandler;
 import com.aws.greengrass.authorization.Permission;
 import com.aws.greengrass.authorization.exceptions.AuthorizationException;
 import com.aws.greengrass.device.ClientDevicesAuthService;
+import com.aws.greengrass.device.ClientDevicesAuthServiceApi;
 import com.aws.greengrass.device.exception.AuthenticationException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
@@ -43,28 +44,28 @@ public class GetClientDeviceAuthTokenOperationHandler
     private static final String NO_DEVICE_CREDENTIAL_ERROR = "Invalid client device credentials";
     private final String serviceName;
     private final AuthorizationHandler authorizationHandler;
-    private final ClientDevicesAuthService clientDevicesAuthService;
+    private final ClientDevicesAuthServiceApi clientDevicesAuthServiceApi;
     private final Map<String, String> credentialMap = new HashMap<>();
     private final ExecutorService cloudCallThreadPool;
 
     /**
      * Constructor.
      *
-     * @param context                  operation continuation handler
-     * @param clientDevicesAuthService client devices auth service handle
-     * @param authorizationHandler     authorization handler
-     * @param cloudCallThreadPool      executor to run the call to the cloud asynchronously
+     * @param context                     operation continuation handler
+     * @param clientDevicesAuthServiceApi client devices auth service handle
+     * @param authorizationHandler        authorization handler
+     * @param cloudCallThreadPool         executor to run the call to the cloud asynchronously
      */
     public GetClientDeviceAuthTokenOperationHandler(
             OperationContinuationHandlerContext context,
-            ClientDevicesAuthService clientDevicesAuthService,
+            ClientDevicesAuthServiceApi clientDevicesAuthServiceApi,
             AuthorizationHandler authorizationHandler,
             ExecutorService cloudCallThreadPool
     ) {
 
         super(context);
         serviceName = context.getAuthenticationData().getIdentityLabel();
-        this.clientDevicesAuthService = clientDevicesAuthService;
+        this.clientDevicesAuthServiceApi = clientDevicesAuthServiceApi;
         this.authorizationHandler = authorizationHandler;
         this.cloudCallThreadPool = cloudCallThreadPool;
     }
@@ -95,7 +96,7 @@ public class GetClientDeviceAuthTokenOperationHandler
             }
             Map<String, String> credentialMap = mapOfMqttCredential(request.getCredential());
             try {
-                String sessionId = clientDevicesAuthService.getClientDeviceAuthToken(MQTT_CREDENTIAL_TYPE,
+                String sessionId = clientDevicesAuthServiceApi.getClientDeviceAuthToken(MQTT_CREDENTIAL_TYPE,
                         credentialMap);
                 GetClientDeviceAuthTokenResponse response = new GetClientDeviceAuthTokenResponse();
                 return response.withClientDeviceAuthToken(sessionId);
@@ -143,12 +144,9 @@ public class GetClientDeviceAuthTokenOperationHandler
 
     @Override
     public void handleStreamEvent(EventStreamJsonMessage eventStreamJsonMessage) {
-
     }
 
     @Override
     protected void onStreamClosed() {
-
     }
-
 }

--- a/src/main/java/com/aws/greengrass/ipc/VerifyClientDeviceIdentityOperationHandler.java
+++ b/src/main/java/com/aws/greengrass/ipc/VerifyClientDeviceIdentityOperationHandler.java
@@ -10,6 +10,7 @@ import com.aws.greengrass.authorization.AuthorizationHandler;
 import com.aws.greengrass.authorization.Permission;
 import com.aws.greengrass.authorization.exceptions.AuthorizationException;
 import com.aws.greengrass.device.ClientDevicesAuthService;
+import com.aws.greengrass.device.ClientDevicesAuthServiceApi;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.util.Utils;
@@ -37,7 +38,7 @@ public class VerifyClientDeviceIdentityOperationHandler
     private static final String UNAUTHORIZED_ERROR = "Not Authorized";
     private static final String NO_DEVICE_CREDENTIAL_ERROR = "Client device credential is required";
     private static final String NO_DEVICE_CERTIFICATE_ERROR = "Client device certificate is required";
-    private final ClientDevicesAuthService clientDevicesAuthService;
+    private final ClientDevicesAuthServiceApi clientDevicesAuthServiceApi;
     private final String serviceName;
     private final AuthorizationHandler authorizationHandler;
     private final ExecutorService cloudCallThreadPool;
@@ -45,20 +46,20 @@ public class VerifyClientDeviceIdentityOperationHandler
     /**
      * Constructor.
      *
-     * @param context                  operation continuation handler
-     * @param clientDevicesAuthService client devices auth service handle
-     * @param authorizationHandler     authorization handler
-     * @param cloudCallThreadPool      executor to run the call to the cloud asynchronously
+     * @param context                     operation continuation handler
+     * @param clientDevicesAuthServiceApi client devices auth service handle
+     * @param authorizationHandler        authorization handler
+     * @param cloudCallThreadPool         executor to run the call to the cloud asynchronously
      */
     public VerifyClientDeviceIdentityOperationHandler(
-            OperationContinuationHandlerContext context, ClientDevicesAuthService clientDevicesAuthService,
+            OperationContinuationHandlerContext context, ClientDevicesAuthServiceApi clientDevicesAuthServiceApi,
             AuthorizationHandler authorizationHandler, ExecutorService cloudCallThreadPool) {
 
         super(context);
-        this.clientDevicesAuthService = clientDevicesAuthService;
-        serviceName = context.getAuthenticationData().getIdentityLabel();
+        this.clientDevicesAuthServiceApi = clientDevicesAuthServiceApi;
         this.authorizationHandler = authorizationHandler;
         this.cloudCallThreadPool = cloudCallThreadPool;
+        serviceName = context.getAuthenticationData().getIdentityLabel();
     }
 
     @Override
@@ -88,7 +89,7 @@ public class VerifyClientDeviceIdentityOperationHandler
             String certificate = getCertificateFromCredential(request.getCredential());
             try {
                 VerifyClientDeviceIdentityResponse response = new VerifyClientDeviceIdentityResponse();
-                response.withIsValidClientDevice(clientDevicesAuthService.verifyClientDeviceIdentity(certificate));
+                response.withIsValidClientDevice(clientDevicesAuthServiceApi.verifyClientDeviceIdentity(certificate));
                 return response;
             } catch (Exception e) {
                 logger.atError().cause(e).log("Unable to verify client device identity");

--- a/src/main/java/com/aws/greengrass/ipc/VerifyClientDeviceIdentityOperationHandler.java
+++ b/src/main/java/com/aws/greengrass/ipc/VerifyClientDeviceIdentityOperationHandler.java
@@ -10,8 +10,6 @@ import com.aws.greengrass.authorization.AuthorizationHandler;
 import com.aws.greengrass.authorization.Permission;
 import com.aws.greengrass.authorization.exceptions.AuthorizationException;
 import com.aws.greengrass.device.ClientDevicesAuthService;
-import com.aws.greengrass.device.DeviceAuthClient;
-import com.aws.greengrass.device.iot.IotAuthClient;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.util.Utils;
@@ -25,7 +23,6 @@ import software.amazon.awssdk.aws.greengrass.model.VerifyClientDeviceIdentityRes
 import software.amazon.awssdk.eventstreamrpc.OperationContinuationHandlerContext;
 import software.amazon.awssdk.eventstreamrpc.model.EventStreamJsonMessage;
 
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
@@ -40,8 +37,7 @@ public class VerifyClientDeviceIdentityOperationHandler
     private static final String UNAUTHORIZED_ERROR = "Not Authorized";
     private static final String NO_DEVICE_CREDENTIAL_ERROR = "Client device credential is required";
     private static final String NO_DEVICE_CERTIFICATE_ERROR = "Client device certificate is required";
-    private final IotAuthClient iotAuthClient;
-    private final DeviceAuthClient deviceAuthClient;
+    private final ClientDevicesAuthService clientDevicesAuthService;
     private final String serviceName;
     private final AuthorizationHandler authorizationHandler;
     private final ExecutorService cloudCallThreadPool;
@@ -49,20 +45,17 @@ public class VerifyClientDeviceIdentityOperationHandler
     /**
      * Constructor.
      *
-     * @param context              operation continuation handler
-     * @param iotAuthClient        auth client for client device calls
-     * @param deviceAuthClient     device auth client to check for internal clients
-     * @param authorizationHandler authorization handler
-     * @param cloudCallThreadPool  executor to run the call to the cloud asynchronously
+     * @param context                  operation continuation handler
+     * @param clientDevicesAuthService client devices auth service handle
+     * @param authorizationHandler     authorization handler
+     * @param cloudCallThreadPool      executor to run the call to the cloud asynchronously
      */
     public VerifyClientDeviceIdentityOperationHandler(
-            OperationContinuationHandlerContext context, IotAuthClient iotAuthClient,
-            DeviceAuthClient deviceAuthClient, AuthorizationHandler authorizationHandler,
-            ExecutorService cloudCallThreadPool) {
+            OperationContinuationHandlerContext context, ClientDevicesAuthService clientDevicesAuthService,
+            AuthorizationHandler authorizationHandler, ExecutorService cloudCallThreadPool) {
 
         super(context);
-        this.iotAuthClient = iotAuthClient;
-        this.deviceAuthClient = deviceAuthClient;
+        this.clientDevicesAuthService = clientDevicesAuthService;
         serviceName = context.getAuthenticationData().getIdentityLabel();
         this.authorizationHandler = authorizationHandler;
         this.cloudCallThreadPool = cloudCallThreadPool;
@@ -95,13 +88,7 @@ public class VerifyClientDeviceIdentityOperationHandler
             String certificate = getCertificateFromCredential(request.getCredential());
             try {
                 VerifyClientDeviceIdentityResponse response = new VerifyClientDeviceIdentityResponse();
-                // Allow internal clients to verify their identities
-                if (deviceAuthClient.isGreengrassComponent(certificate)) {
-                    response.withIsValidClientDevice(true);
-                } else {
-                    Optional<String> certificateId = iotAuthClient.getActiveCertificateId(certificate);
-                    response.withIsValidClientDevice(certificateId.isPresent());
-                }
+                response.withIsValidClientDevice(clientDevicesAuthService.verifyClientDeviceIdentity(certificate));
                 return response;
             } catch (Exception e) {
                 logger.atError().cause(e).log("Unable to verify client device identity");


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Move IPC API functionality into ClientDevicesAuthServiceApi class so that it can also be used directly by internal clients.

This change also removes external dependence on the DeviceAuthClient, which will allow us to remove some of that dead code in a subsequent PR.

**Why is this change necessary:**
This change is needed in simplify Moquette changes needed to handle session eviction. Specifically, this enables Moquette to create sessions in one shot, rather than creating a session based on client certificate and then attaching thing information.

**How was this change tested:**
Unit / integ tests. Manual tests with updated Moquette.

**Any additional information or context required to review the change:**
Corresponding Moquette change: https://github.com/aws-greengrass/aws-greengrass-moquette-mqtt/pull/102

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
