### PR TITLE
feat: add closeClientDeviceAuthSession to API wrapper

### DIFF
--- a/src/main/java/com/aws/greengrass/device/ClientDevicesAuthServiceApi.java
+++ b/src/main/java/com/aws/greengrass/device/ClientDevicesAuthServiceApi.java
@@ -63,6 +63,16 @@ public class ClientDevicesAuthServiceApi {
     }
 
     /**
+     * Close client auth session.
+     *
+     * <P>Note that closing auth sessions is strictly optional</P>
+     * @param authToken Auth token corresponding to the session to be closed.
+     */
+    public void closeClientDeviceAuthSession(String authToken) {
+        sessionManager.closeSession(authToken);
+    }
+
+    /**
      * Authorize client action.
      * @param authorizationRequest Authorization request, including auth token, operation, and resource
      * @return true if the client action is allowed


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Re-add closeClientDeviceAuthSession API to opportunistically close sessions even though it's not required

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
