### PR TITLE
fix: cert gen fixes

### DIFF
--- a/src/main/java/com/aws/greengrass/certificatemanager/certificate/CertificateRequestGenerator.java
+++ b/src/main/java/com/aws/greengrass/certificatemanager/certificate/CertificateRequestGenerator.java
@@ -52,9 +52,9 @@ public final class CertificateRequestGenerator {
      * @throws IOException fails to add SAN Extension to CSR builder
      */
     public static String createCSR(KeyPair keyPair,
-                                                  String thingName,
-                                                  List<InetAddress> ipAddresses,
-                                                  List<String> dnsNames) throws OperatorCreationException, IOException {
+                                   String thingName,
+                                   List<InetAddress> ipAddresses,
+                                   List<String> dnsNames) throws OperatorCreationException, IOException {
 
         // Create PKCS10 certificate request
         X500Principal x500Principal = getx500PrincipalForThing(thingName);
@@ -117,7 +117,7 @@ public final class CertificateRequestGenerator {
      * @return RDN sequence.
      */
     private static X500Principal getx500PrincipalForThing(String commonName) {
-        String distinguishedName = String.format("CN=%sC=%sST=%sL=%sO=%sOU=%s",
+        String distinguishedName = String.format("CN=%s,C=%s,ST=%s,L=%s,O=%s,OU=%s",
                 commonName,
                 CSR_COUNTRY,
                 CSR_PROVINCE,

--- a/src/test/java/com/aws/greengrass/certificatemanager/certificate/CertificateHelperTest.java
+++ b/src/test/java/com/aws/greengrass/certificatemanager/certificate/CertificateHelperTest.java
@@ -77,7 +77,7 @@ public class CertificateHelperTest {
         certificateStore.update(TEST_PASSPHRASE, CAType.RSA_2048);
 
         KeyPair kp = CertificateStore.newRSAKeyPair();
-        String csr = CertificateRequestGenerator.createCSR(kp, TEST_CN, null, null);
+        String csr = CertificateRequestGenerator.createCSR(kp, TEST_CN);
 
         X509Certificate certificate = signServerCSRWithCA(csr, Collections.emptyList());
         assertThat(certificate.getSigAlgName(), equalTo(RSA_CERT_SIG_ALG));
@@ -89,7 +89,7 @@ public class CertificateHelperTest {
         certificateStore.update(TEST_PASSPHRASE, CAType.ECDSA_P256);
 
         KeyPair kp = CertificateStore.newECKeyPair();
-        String csr = CertificateRequestGenerator.createCSR(kp, TEST_CN, null, null);
+        String csr = CertificateRequestGenerator.createCSR(kp, TEST_CN);
 
         X509Certificate certificate = signServerCSRWithCA(csr, Collections.emptyList());
         assertThat(certificate.getSigAlgName(), equalTo(ECDSA_CERT_SIG_ALG));
@@ -101,7 +101,7 @@ public class CertificateHelperTest {
         certificateStore.update(TEST_PASSPHRASE, CAType.ECDSA_P256);
 
         KeyPair kp = CertificateStore.newRSAKeyPair();
-        String csr = CertificateRequestGenerator.createCSR(kp, TEST_CN, null, null);
+        String csr = CertificateRequestGenerator.createCSR(kp, TEST_CN);
 
         X509Certificate certificate = signServerCSRWithCA(csr, Collections.emptyList());
         assertThat(certificate.getSigAlgName(), equalTo(ECDSA_CERT_SIG_ALG));
@@ -113,7 +113,7 @@ public class CertificateHelperTest {
         certificateStore.update(TEST_PASSPHRASE, CAType.RSA_2048);
 
         KeyPair kp = CertificateStore.newECKeyPair();
-        String csr = CertificateRequestGenerator.createCSR(kp, TEST_CN, null, null);
+        String csr = CertificateRequestGenerator.createCSR(kp, TEST_CN);
 
         X509Certificate certificate = signServerCSRWithCA(csr, Collections.emptyList());
         assertThat(certificate.getSigAlgName(), equalTo(RSA_CERT_SIG_ALG));
@@ -146,7 +146,7 @@ public class CertificateHelperTest {
         certificateStore.update(TEST_PASSPHRASE, CAType.RSA_2048);
 
         KeyPair kp = CertificateStore.newRSAKeyPair();
-        String csr = CertificateRequestGenerator.createCSR(kp, TEST_CN, null, null);
+        String csr = CertificateRequestGenerator.createCSR(kp, TEST_CN);
 
         X509Certificate certificate = signServerCSRWithCA(csr, Collections.singletonList("172.8.8.10"));
         assertThat(certificate.getSigAlgName(), equalTo(RSA_CERT_SIG_ALG));
@@ -159,7 +159,7 @@ public class CertificateHelperTest {
         certificateStore.update(TEST_PASSPHRASE, CAType.RSA_2048);
 
         KeyPair kp = CertificateStore.newRSAKeyPair();
-        String csr = CertificateRequestGenerator.createCSR(kp, TEST_CN, null, null);
+        String csr = CertificateRequestGenerator.createCSR(kp, TEST_CN);
 
         X509Certificate certificate = signServerCSRWithCA(csr, Collections.singletonList("localhost"));
         assertThat(certificate.getSigAlgName(), equalTo(RSA_CERT_SIG_ALG));
@@ -173,7 +173,7 @@ public class CertificateHelperTest {
         certificateStore.update(TEST_PASSPHRASE, CAType.RSA_2048);
 
         KeyPair kp = CertificateStore.newRSAKeyPair();
-        String csr = CertificateRequestGenerator.createCSR(kp, TEST_CN, null, null);
+        String csr = CertificateRequestGenerator.createCSR(kp, TEST_CN);
 
         X509Certificate certificate = signServerCSRWithCA(csr, Arrays.asList("172.8.8.10", "localhost"));
         assertThat(certificate.getSigAlgName(), equalTo(RSA_CERT_SIG_ALG));
@@ -187,7 +187,7 @@ public class CertificateHelperTest {
         certificateStore.update(TEST_PASSPHRASE, CAType.RSA_2048);
 
         KeyPair kp = CertificateStore.newRSAKeyPair();
-        String csr = CertificateRequestGenerator.createCSR(kp, TEST_CN, null, null);
+        String csr = CertificateRequestGenerator.createCSR(kp, TEST_CN);
 
         X509Certificate certificate = signServerCSRWithCA(csr, Arrays.asList("localhost", "localhost"));
         assertThat(certificate.getSigAlgName(), equalTo(RSA_CERT_SIG_ALG));
@@ -201,7 +201,7 @@ public class CertificateHelperTest {
         certificateStore.update(TEST_PASSPHRASE, CAType.RSA_2048);
 
         KeyPair kp = CertificateStore.newRSAKeyPair();
-        String csr = CertificateRequestGenerator.createCSR(kp, TEST_CN, null, null);
+        String csr = CertificateRequestGenerator.createCSR(kp, TEST_CN);
 
         Instant now = Instant.now();
         PKCS10CertificationRequest pkcs10CertificationRequest =

--- a/src/test/java/com/aws/greengrass/certificatemanager/certificate/CertificateHelperTest.java
+++ b/src/test/java/com/aws/greengrass/certificatemanager/certificate/CertificateHelperTest.java
@@ -36,7 +36,7 @@ public class CertificateHelperTest {
     private static final String EXPECTED_ISSUER_PRINCIPAL
             = "CN=Greengrass Core CA,L=Seattle,ST=Washington,OU=Amazon Web Services,O=Amazon.com Inc.,C=US";
     private static final String EXPECTED_SUBJECT_PRINCIPAL
-            = "CN=testCNC\\=USST\\=WashingtonL\\=SeattleO\\=Amazon.com Inc.OU\\=Amazon Web Services";
+            = "CN=testCN,C=US,ST=Washington,L=Seattle,O=Amazon.com Inc.,OU=Amazon Web Services";
     private static final String RSA_CERT_SIG_ALG = "SHA256WITHRSA";
     private static final String ECDSA_CERT_SIG_ALG = "SHA256WITHECDSA";
 

--- a/src/test/java/com/aws/greengrass/certificatemanager/certificate/CertificateRequestGeneratorTest.java
+++ b/src/test/java/com/aws/greengrass/certificatemanager/certificate/CertificateRequestGeneratorTest.java
@@ -64,7 +64,7 @@ class CertificateRequestGeneratorTest {
             "MQIDAQAB";
 
     private static final String TEST_CSR = "-----BEGIN CERTIFICATE REQUEST-----\n" +
-            "MIIDAjCCAeoCAQAwgYcxHDAaBgNVBAsTE0FtYXpvbiBXZWIgU2VydmljZXMxGDAW\n" +
+            "MIICzTCCAbUCAQAwgYcxHDAaBgNVBAsTE0FtYXpvbiBXZWIgU2VydmljZXMxGDAW\n" +
             "BgNVBAoTD0FtYXpvbi5jb20gSW5jLjEQMA4GA1UEBxMHU2VhdHRsZTETMBEGA1UE\n" +
             "CBMKV2FzaGluZ3RvbjELMAkGA1UEBhMCVVMxGTAXBgNVBAMTEENTUkdlbmVyYXRv\n" +
             "clRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCxCHT3zdDxDTIH\n" +
@@ -73,14 +73,13 @@ class CertificateRequestGeneratorTest {
             "UVIheiPfsNMo9pAyQ2WnzhkWzcY6mWd349aWn0kWxbf3EqowTc+qnjxpSLkajoZy\n" +
             "ndAmotlyl3FLJ/2KNbfEKs4Kz2EQ95SzA6JNEuPvBQ3JQGX2N6+vTkqTxiN0NUbK\n" +
             "anEJRNt3Lf5Hwh+gAy4s9CakVOvdV9r9+aR4q/4rbY0tV3k7eI5M/L7IylZobqlV\n" +
-            "MiSjDEQxAgMBAAGgNTAzBgkqhkiG9w0BCQ4xJjAkMCIGA1UdEQQbMBmHBMCoAQGC\n" +
-            "EXNvbWVmYWtlLmhvc3QuY29tMA0GCSqGSIb3DQEBCwUAA4IBAQBJZFtYJriJoh3c\n" +
-            "+oaAFsuoCgD48R1MXqC8ua0X9jSfa/HFu6453QHvZwFyNGJXmuGN3OtlRsUSx8QX\n" +
-            "dQBKzVuMxaQmT9gvOR1co6p4gUYx6xSyJ8kFVOuR7SlQ02VYR8ocSgjYNXKA3hYJ\n" +
-            "LbyPCBwGgyr1jt+xa98dXGC0jIuvMN8nDLGRUkMNnpPOM9S92bjpSBFGl6/+X5uo\n" +
-            "TkJHyuNqwXJzcDWAADhANSJx4d3OEyGs+JZOxjN+HcY+m73jHxugcqfzRX4oQ9ew\n" +
-            "84NxfASp1jLWU+0viwQUo4eH32U22WDZrgIbYsUWp5KHbwqpwTniE2OI1E5kp54i\n" +
-            "8lGRZDBC\n" +
+            "MiSjDEQxAgMBAAGgADANBgkqhkiG9w0BAQsFAAOCAQEAq+74wEM0056PygmYqBKn\n" +
+            "tLr7AEMSuV6GY70PZWQlPQuwgUppxJcCXYZoh4nLJGDEbogBU6YgPAVobOa/7GFi\n" +
+            "g3SnVAY1yWFOw7+qNuWBDzr2LJj5D0Q1U4Gt90vQKXT/j84BU/4o0y0Gd0oKn5Er\n" +
+            "pec4dzf3HtXviqF9ggbejVWe8ZAKx0U2cuQBQS/iNs3JyxxpaqDEWhSMqrxW52Th\n" +
+            "Ut2zLsBQdChoVDqeaHjyPFtIQsuhBIuyWEOfJmmNTJleI+vfmAFpkjVX8x3Z0yvR\n" +
+            "pEBOHpf8rQf2igm5bMLZqUthaDLke7jKZqMZvU5hzo8AX7bAfCI8glLFtx+Yqe8s\n" +
+            "fA==\n" +
             "-----END CERTIFICATE REQUEST-----\n";
 
     @Test

--- a/src/test/java/com/aws/greengrass/certificatemanager/certificate/CertificateRequestGeneratorTest.java
+++ b/src/test/java/com/aws/greengrass/certificatemanager/certificate/CertificateRequestGeneratorTest.java
@@ -63,23 +63,24 @@ class CertificateRequestGeneratorTest {
             "dy3+R8IfoAMuLPQmpFTr3Vfa/fmkeKv+K22NLVd5O3iOTPy+yMpWaG6pVTIkowxE\n" +
             "MQIDAQAB";
 
-    private static final String TEST_CERTIFICATE = "-----BEGIN CERTIFICATE REQUEST-----\n" +
-            "MIIC1jCCAb4CAQAwXDFaMFgGA1UEAxNRQ1NSR2VuZXJhdG9yVGVzdEM9VVNTVD1X\n" +
-            "YXNoaW5ndG9uTD1TZWF0dGxlTz1BbWF6b24uY29tIEluYy5PVT1BbWF6b24gV2Vi\n" +
-            "IFNlcnZpY2VzMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsQh0983Q\n" +
-            "8Q0yB6hqZgMRYjOZj2ln+ZVmsAVME72fhNHFg3x2VjkJM87gtbtOWo4hnA9N4nTP\n" +
-            "0tqJSEJLikDKgYjX5DW5DQm7H8a50HJ+adsY+XFdU3DbBnplt5UShpFu0QlhjapZ\n" +
-            "Wh9HJlFSIXoj37DTKPaQMkNlp84ZFs3GOplnd+PWlp9JFsW39xKqME3Pqp48aUi5\n" +
-            "Go6Gcp3QJqLZcpdxSyf9ijW3xCrOCs9hEPeUswOiTRLj7wUNyUBl9jevr05Kk8Yj\n" +
-            "dDVGympxCUTbdy3+R8IfoAMuLPQmpFTr3Vfa/fmkeKv+K22NLVd5O3iOTPy+yMpW\n" +
-            "aG6pVTIkowxEMQIDAQABoDUwMwYJKoZIhvcNAQkOMSYwJDAiBgNVHREEGzAZhwTA\n" +
-            "qAEBghFzb21lZmFrZS5ob3N0LmNvbTANBgkqhkiG9w0BAQsFAAOCAQEABTSxHYom\n" +
-            "1RvxTDxvYCN06yXd8P5Egso4UUS9Mx9UQYRlCm5hI7wJuE+XkyhhRywbFyUMIBjT\n" +
-            "GchVT/0a1aqWvdBcj5ihElEHW5RbF/TcGVlVcecxCFrgkSNlaWbr7MT6Njl9Kjzv\n" +
-            "aKQ9rXJBzpYzeEDq3M27DI3JJo+Gm6W89QkUA17N4gDOJAamPp8bXgT2b9UEbiam\n" +
-            "J5Dg/2OPkJXx4GwjeWb1dlyiVAH8VM184X0Bgic53kobQdK2xriY+E/w3aFdPfhY\n" +
-            "8Qxp6HYHUH34ditVxY6tjGNh10CbG+5ELGN106mN1r67fQn+ptly2HI/jltQLVaI\n" +
-            "euAr+8WShnD05g==\n" +
+    private static final String TEST_CSR = "-----BEGIN CERTIFICATE REQUEST-----\n" +
+            "MIIDAjCCAeoCAQAwgYcxHDAaBgNVBAsTE0FtYXpvbiBXZWIgU2VydmljZXMxGDAW\n" +
+            "BgNVBAoTD0FtYXpvbi5jb20gSW5jLjEQMA4GA1UEBxMHU2VhdHRsZTETMBEGA1UE\n" +
+            "CBMKV2FzaGluZ3RvbjELMAkGA1UEBhMCVVMxGTAXBgNVBAMTEENTUkdlbmVyYXRv\n" +
+            "clRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCxCHT3zdDxDTIH\n" +
+            "qGpmAxFiM5mPaWf5lWawBUwTvZ+E0cWDfHZWOQkzzuC1u05ajiGcD03idM/S2olI\n" +
+            "QkuKQMqBiNfkNbkNCbsfxrnQcn5p2xj5cV1TcNsGemW3lRKGkW7RCWGNqllaH0cm\n" +
+            "UVIheiPfsNMo9pAyQ2WnzhkWzcY6mWd349aWn0kWxbf3EqowTc+qnjxpSLkajoZy\n" +
+            "ndAmotlyl3FLJ/2KNbfEKs4Kz2EQ95SzA6JNEuPvBQ3JQGX2N6+vTkqTxiN0NUbK\n" +
+            "anEJRNt3Lf5Hwh+gAy4s9CakVOvdV9r9+aR4q/4rbY0tV3k7eI5M/L7IylZobqlV\n" +
+            "MiSjDEQxAgMBAAGgNTAzBgkqhkiG9w0BCQ4xJjAkMCIGA1UdEQQbMBmHBMCoAQGC\n" +
+            "EXNvbWVmYWtlLmhvc3QuY29tMA0GCSqGSIb3DQEBCwUAA4IBAQBJZFtYJriJoh3c\n" +
+            "+oaAFsuoCgD48R1MXqC8ua0X9jSfa/HFu6453QHvZwFyNGJXmuGN3OtlRsUSx8QX\n" +
+            "dQBKzVuMxaQmT9gvOR1co6p4gUYx6xSyJ8kFVOuR7SlQ02VYR8ocSgjYNXKA3hYJ\n" +
+            "LbyPCBwGgyr1jt+xa98dXGC0jIuvMN8nDLGRUkMNnpPOM9S92bjpSBFGl6/+X5uo\n" +
+            "TkJHyuNqwXJzcDWAADhANSJx4d3OEyGs+JZOxjN+HcY+m73jHxugcqfzRX4oQ9ew\n" +
+            "84NxfASp1jLWU+0viwQUo4eH32U22WDZrgIbYsUWp5KHbwqpwTniE2OI1E5kp54i\n" +
+            "8lGRZDBC\n" +
             "-----END CERTIFICATE REQUEST-----\n";
 
     @Test
@@ -105,13 +106,10 @@ class CertificateRequestGeneratorTest {
         PrivateKey privateKey = kf.generatePrivate(new PKCS8EncodedKeySpec(encodedPrivateKey));
         KeyPair keyPair = new KeyPair(publicKey, privateKey);
         // Assert Cert Request generation
-        String expectedCSR = TEST_CERTIFICATE;
+        String expectedCSR = TEST_CSR;
         // Windows support
         expectedCSR = expectedCSR.replace("\n", System.lineSeparator());
         String actualCSR = CertificateRequestGenerator.createCSR(keyPair, thingName, ipAddresses, dnsNames);
         assertThat(actualCSR, is(expectedCSR));
-
     }
-
-    // TODO: Add additional test cases
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Properly constructs the X500 Principal which is used as the Subject in generated certificates.

This change also removes some code that is no longer needed.

**Why is this change necessary:**

**How was this change tested:**
Manual testing to ensure OpenSSL can parse the subject in broker server certs

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
