### PR TITLE
refactor: update and get certs based on usage and not within the subscribe

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/CertificateManager.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/CertificateManager.java
@@ -27,7 +27,6 @@ import java.security.KeyPair;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
-import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.time.Clock;
@@ -106,9 +105,9 @@ public class CertificateManager {
     public List<String> getCACertificates() throws KeyStoreException, IOException,
             CertificateEncodingException, CertificateAuthorityNotFoundException {
         List<String> certificatePems = new ArrayList<>();
-        Certificate[] certs = certificateStore.getCaCertificateChain();
-        for (Certificate cert : certs) {
-            certificatePems.add(CertificateHelper.toPem((X509Certificate) cert));
+        X509Certificate[] certs = certificateStore.getCaCertificateChain();
+        for (X509Certificate cert : certs) {
+            certificatePems.add(CertificateHelper.toPem(cert));
         }
         return certificatePems;
     }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -182,9 +182,6 @@ public class ClientDevicesAuthService extends PluginService {
 
         // Subscribe to config updates
         configChangeHandler();
-
-        // Update CA based on the config.
-        updateCAType();
     }
 
     private void configChangeHandler() {
@@ -194,6 +191,7 @@ public class ClientDevicesAuthService extends PluginService {
             }
             logger.atDebug().kv("why", whatHappened).kv("node", node).log();
             Topics deviceGroupTopics = this.config.lookupTopics(CONFIGURATION_CONFIG_KEY, DEVICE_GROUPS_TOPICS);
+            Topic caTypeTopic = this.config.lookup(CONFIGURATION_CONFIG_KEY, CA_TYPE_TOPIC);
 
             // Attempt to update the thread pool size as needed
             try {
@@ -217,12 +215,11 @@ public class ClientDevicesAuthService extends PluginService {
 
             if (whatHappened == WhatHappened.initialized || node == null) {
                 updateDeviceGroups(whatHappened, deviceGroupTopics);
+                updateCAType();
             } else if (node.childOf(DEVICE_GROUPS_TOPICS)) {
                 updateDeviceGroups(whatHappened, deviceGroupTopics);
             } else if (node.childOf(CERTIFICATE_AUTHORITY_TOPIC)) {
-                logger.atInfo("service-config-change").kv("event", whatHappened).kv("node", node)
-                        .log("Requesting re-installation of client device auth component");
-                requestReinstall();
+                updateCAType();
             }
         });
     }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -191,7 +191,6 @@ public class ClientDevicesAuthService extends PluginService {
             }
             logger.atDebug().kv("why", whatHappened).kv("node", node).log();
             Topics deviceGroupTopics = this.config.lookupTopics(CONFIGURATION_CONFIG_KEY, DEVICE_GROUPS_TOPICS);
-            Topic caTypeTopic = this.config.lookup(CONFIGURATION_CONFIG_KEY, CA_TYPE_TOPIC);
 
             // Attempt to update the thread pool size as needed
             try {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/DeviceAuthClient.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/DeviceAuthClient.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.clientdevices.auth;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateStore;
 import com.aws.greengrass.clientdevices.auth.configuration.GroupManager;
 import com.aws.greengrass.clientdevices.auth.exception.AuthorizationException;
+import com.aws.greengrass.clientdevices.auth.exception.CertificateAuthorityNotFoundException;
 import com.aws.greengrass.clientdevices.auth.exception.InvalidSessionException;
 import com.aws.greengrass.clientdevices.auth.iot.Component;
 import com.aws.greengrass.clientdevices.auth.session.Session;
@@ -19,7 +20,6 @@ import software.amazon.awssdk.utils.StringInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.InvalidAlgorithmParameterException;
-import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertPath;
 import java.security.cert.CertPathValidator;
@@ -106,8 +106,8 @@ public class DeviceAuthClient {
             logger.atError().cause(e).log("Unable to load certificate validator");
         } catch (CertPathValidatorException e) {
             logger.atDebug().log("Certificate was not issued by local CA");
-        } catch (KeyStoreException e) {
-            logger.atError().cause(e).log("Unable to load CA keystore");
+        }  catch (CertificateAuthorityNotFoundException e) {
+            logger.atError().cause(e).log("Unable to the find core device CA");
         }
 
         return false;

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/ClientCertificateGenerator.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/ClientCertificateGenerator.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.clientdevices.auth.certificate;
 
+import com.aws.greengrass.clientdevices.auth.exception.CertificateAuthorityNotFoundException;
 import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
@@ -12,7 +13,6 @@ import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.operator.OperatorCreationException;
 
 import java.io.IOException;
-import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.cert.CertificateException;
@@ -81,7 +81,7 @@ public class ClientCertificateGenerator extends CertificateGenerator {
             X509Certificate[] chain = {certificate, caCertificate};
             callback.accept(chain);
         } catch (NoSuchAlgorithmException | OperatorCreationException | CertificateException | IOException
-                | KeyStoreException e) {
+                | CertificateAuthorityNotFoundException e) {
             throw new CertificateGenerationException(e);
         }
     }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/ServerCertificateGenerator.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/ServerCertificateGenerator.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.clientdevices.auth.certificate;
 
+import com.aws.greengrass.clientdevices.auth.exception.CertificateAuthorityNotFoundException;
 import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
@@ -12,7 +13,6 @@ import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.operator.OperatorCreationException;
 
 import java.io.IOException;
-import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.cert.CertificateException;
@@ -79,7 +79,7 @@ public class ServerCertificateGenerator extends CertificateGenerator {
                     Date.from(now),
                     Date.from(now.plusSeconds(certificatesConfig.getServerCertValiditySeconds())));
         } catch (NoSuchAlgorithmException | OperatorCreationException | CertificateException | IOException
-                | KeyStoreException e) {
+                | CertificateAuthorityNotFoundException e) {
             logger.atError().cause(e).log("Failed to generate new server certificate");
             throw new CertificateGenerationException(e);
         }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/exception/CertificateAuthorityNotFoundException.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/exception/CertificateAuthorityNotFoundException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.exception;
+
+public class CertificateAuthorityNotFoundException extends Exception {
+
+    private static final long serialVersionUID = -1L;
+
+    public CertificateAuthorityNotFoundException(String message) {
+        super(message);
+    }
+
+    public CertificateAuthorityNotFoundException(Throwable e) {
+        super(e);
+    }
+
+    public CertificateAuthorityNotFoundException(String message, Throwable e) {
+        super(message, e);
+    }
+}

--- a/src/main/java/com/aws/greengrass/ipc/SubscribeToCertificateUpdatesOperationHandler.java
+++ b/src/main/java/com/aws/greengrass/ipc/SubscribeToCertificateUpdatesOperationHandler.java
@@ -13,6 +13,7 @@ import com.aws.greengrass.clientdevices.auth.CertificateManager;
 import com.aws.greengrass.clientdevices.auth.ClientDevicesAuthService;
 import com.aws.greengrass.clientdevices.auth.api.GetCertificateRequest;
 import com.aws.greengrass.clientdevices.auth.api.GetCertificateRequestOptions;
+import com.aws.greengrass.clientdevices.auth.exception.CertificateAuthorityNotFoundException;
 import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
@@ -154,7 +155,8 @@ public class SubscribeToCertificateUpdatesOperationHandler
                             EncryptionUtils.encodeToPem(PEM_BOUNDARY_PUBLIC_KEY, kp.getPublic().getEncoded()))
                     .withPrivateKey(
                             EncryptionUtils.encodeToPem(PEM_BOUNDARY_PRIVATE_KEY, kp.getPrivate().getEncoded()));
-        } catch (CertificateEncodingException | IOException | KeyStoreException e) {
+        } catch (CertificateEncodingException | IOException | KeyStoreException
+                | CertificateAuthorityNotFoundException e) {
             logger.atError().cause(e).log("Unable to attach certificates to the response");
             throw new ServiceError("Subscribe to certificate update failed. Check Greengrass log for details.");
         }

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthServiceTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthServiceTest.java
@@ -64,6 +64,7 @@ import java.util.stream.Collectors;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasProperty;
@@ -71,9 +72,9 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -340,13 +341,12 @@ class ClientDevicesAuthServiceTest {
         assertThat(initialCA, not(thirdCA));
         assertThat(getCaPassphrase(), not(initialCaPassPhrase));
 
-        verify(client, atMost(3)).putCertificateAuthorities(putCARequestArgumentCaptor.capture());
+        verify(client, times(3)).putCertificateAuthorities(putCARequestArgumentCaptor.capture());
         List<List<String>> certificatesInRequests =
                 putCARequestArgumentCaptor.getAllValues().stream().map(
                         PutCertificateAuthoritiesRequest::coreDeviceCertificates).collect(
                         Collectors.toList());
-        assertThat("putCertificateAuthorities is called for at most 3 times",
-                certificatesInRequests.size()<=3);
+        assertThat(certificatesInRequests, contains(initialCACerts, secondCACerts, thirdCACerts));
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/certificate/CertificateExpiryMonitorTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/certificate/CertificateExpiryMonitorTest.java
@@ -38,7 +38,6 @@ import static org.mockito.Mockito.mock;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 public class CertificateExpiryMonitorTest {
-    private static final String TEST_PASSPHRASE = "testPassphrase";
     private static final String SUBJECT_PRINCIPAL
             = "CN=testCNC\\=USST\\=WashingtonL\\=SeattleO\\=Amazon.com Inc.OU\\=Amazon Web Services";
     private static final X500Name SUBJECT = new X500Name(SUBJECT_PRINCIPAL);
@@ -58,8 +57,7 @@ public class CertificateExpiryMonitorTest {
         certificatesConfig = new CertificatesConfig(configTopics);
 
         certificateStore = new CertificateStore(tmpPath);
-        certificateStore.update(TEST_PASSPHRASE, CertificateStore.CAType.RSA_2048);
-
+        certificateStore.setCertificateStoreConfig(configTopics, configTopics.lookupTopics("runtime"));
         certExpiryMonitor = new CertificateExpiryMonitor(mock(ScheduledExecutorService.class), mock(ConnectivityInfoProvider.class), Clock.systemUTC());
     }
 

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/certificate/ServerCertificateGeneratorTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/certificate/ServerCertificateGeneratorTest.java
@@ -5,10 +5,10 @@
 
 package com.aws.greengrass.clientdevices.auth.certificate;
 
+import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationException;
 import com.aws.greengrass.componentmanager.KernelConfigResolver;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.Context;
-import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.KeyPurposeId;
@@ -41,10 +41,8 @@ import static org.mockito.Mockito.verify;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 public class ServerCertificateGeneratorTest {
-    private static final String TEST_PASSPHRASE = "testPassphrase";
     private static final String SUBJECT_PRINCIPAL
             = "CN=testCNC\\=USST\\=WashingtonL\\=SeattleO\\=Amazon.com Inc.OU\\=Amazon Web Services";
-
     @Mock
     private Consumer<X509Certificate> mockCallback;
 
@@ -59,12 +57,12 @@ public class ServerCertificateGeneratorTest {
     void setup() throws KeyStoreException, NoSuchAlgorithmException {
         X500Name subject = new X500Name(SUBJECT_PRINCIPAL);
         publicKey = CertificateStore.newRSAKeyPair().getPublic();
-        CertificateStore certificateStore = new CertificateStore(tmpPath);
-        certificateStore.update(TEST_PASSPHRASE, CertificateStore.CAType.RSA_2048);
+        CertificateStore certificateStore = new CertificateStore(tmpPath );
         configurationTopics = Topics.of(new Context(), KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null);
         CertificatesConfig certificatesConfig = new CertificatesConfig(configurationTopics);
         certificateGenerator = new ServerCertificateGenerator(subject, publicKey, mockCallback, certificateStore,
                 certificatesConfig, Clock.systemUTC());
+        certificateStore.setCertificateStoreConfig(configurationTopics, configurationTopics.lookupTopics("runtime"));
     }
 
     @AfterEach

--- a/src/test/resources/com/aws/greengrass/clientdevices/auth/config_with_ec_ca.yaml
+++ b/src/test/resources/com/aws/greengrass/clientdevices/auth/config_with_ec_ca.yaml
@@ -2,10 +2,10 @@
 services:
   aws.greengrass.clientdevices.Auth:
     configuration:
-      ca_type: ["ECDSA_P256"]
+      certificateAuthority:
+        ca_type: ["ECDSA_P256"]
   main:
     lifecycle:
-      install:
-        all: echo All installed
+      install: echo All installed
     dependencies:
       - aws.greengrass.clientdevices.Auth


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
1. Request reinstall when the configuration related to the CA changes. This will reinstall the components that depend on client device auth for CA. 
2. Upload CA out of the config subscription thread to avoid blocking as it includes re-tryable cloud calls. 
3. Update and get CA based on their usage by the caller and move it out of the config subscription logic. 


**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
