### PR TITLE
feat: enable offline auth with caching

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/VerifyClientDeviceIdentityTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/VerifyClientDeviceIdentityTest.java
@@ -30,7 +30,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCClient;
 import software.amazon.awssdk.aws.greengrass.VerifyClientDeviceIdentityResponseHandler;
 import software.amazon.awssdk.aws.greengrass.model.ClientDeviceCredential;
-import software.amazon.awssdk.aws.greengrass.model.ServiceError;
 import software.amazon.awssdk.aws.greengrass.model.UnauthorizedError;
 import software.amazon.awssdk.aws.greengrass.model.VerifyClientDeviceIdentityRequest;
 import software.amazon.awssdk.aws.greengrass.model.VerifyClientDeviceIdentityResponse;
@@ -52,7 +51,6 @@ import static com.aws.greengrass.testcommons.testutilities.TestUtils.asyncAssert
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -218,7 +216,7 @@ class VerifyClientDeviceIdentityTest {
     }
 
     @Test
-    void GIVEN_broker_WHEN_verify_client_identity_with_internal_server_exception_THEN_error_is_thrown(
+    void GIVEN_broker_WHEN_verify_client_identity_with_internal_server_exception_THEN_verify_with_cached_result(
             ExtensionContext context)
             throws Exception {
         startNucleusWithConfig("cda.yaml");
@@ -234,16 +232,19 @@ class VerifyClientDeviceIdentityTest {
                     .withCredential(new ClientDeviceCredential()
                             .withClientDeviceCertificate("abc"));
 
-            Exception err = Assertions.assertThrows(Exception.class, () -> {
-                verifyClientIdentity(ipcClient, request, null);
-            });
-            assertEquals(err.getCause().getClass(), ServiceError.class);
+            Pair<CompletableFuture<Void>, Consumer<VerifyClientDeviceIdentityResponse>> cb =
+                    asyncAssertOnConsumer((m) -> {
+                        assertFalse(m.isIsValidClientDevice());
+                    });
+
+            verifyClientIdentity(ipcClient, request, cb.getRight());
+            cb.getLeft().get(10, TimeUnit.SECONDS);
         }
     }
 
     @Test
-    void GIVEN_broker_WHEN_verify_client_identity_with_exception_THEN_error_is_thrown(ExtensionContext context)
-            throws ExecutionException, InterruptedException {
+    void GIVEN_broker_WHEN_verify_client_identity_with_exception_THEN_verify_with_cached_result(ExtensionContext context)
+            throws Exception {
         startNucleusWithConfig("cda.yaml");
         ignoreExceptionOfType(context, NullPointerException.class);
         ignoreExceptionOfType(context, CloudServiceInteractionException.class);
@@ -254,10 +255,13 @@ class VerifyClientDeviceIdentityTest {
                     .withCredential(new ClientDeviceCredential()
                             .withClientDeviceCertificate("abc"));
 
-            Exception err = Assertions.assertThrows(Exception.class, () -> {
-                verifyClientIdentity(ipcClient, request, null);
-            });
-            assertEquals(err.getCause().getClass(), ServiceError.class);
+            Pair<CompletableFuture<Void>, Consumer<VerifyClientDeviceIdentityResponse>> cb =
+                    asyncAssertOnConsumer((m) -> {
+                        assertFalse(m.isIsValidClientDevice());
+                    });
+
+            verifyClientIdentity(ipcClient, request, cb.getRight());
+            cb.getLeft().get(10, TimeUnit.SECONDS);
         }
     }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/api/ClientDevicesAuthServiceApi.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/api/ClientDevicesAuthServiceApi.java
@@ -11,7 +11,9 @@ import com.aws.greengrass.clientdevices.auth.DeviceAuthClient;
 import com.aws.greengrass.clientdevices.auth.exception.AuthenticationException;
 import com.aws.greengrass.clientdevices.auth.exception.AuthorizationException;
 import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationException;
-import com.aws.greengrass.clientdevices.auth.iot.CertificateRegistry;
+import com.aws.greengrass.clientdevices.auth.iot.registry.CertificateRegistry;
+import com.aws.greengrass.clientdevices.auth.iot.registry.RegistryRefreshMonitor;
+import com.aws.greengrass.clientdevices.auth.iot.registry.ThingRegistry;
 import com.aws.greengrass.clientdevices.auth.session.SessionManager;
 
 import java.util.Map;
@@ -26,20 +28,27 @@ public class ClientDevicesAuthServiceApi {
     /**
      * Constructor.
      *
-     * @param certificateRegistry iot auth client
+     * @param certificateRegistry certificate registry
+     * @param thingRegistry       thing registry
      * @param sessionManager      session manager
      * @param deviceAuthClient    device auth client
      * @param certificateManager  certificate manager
+     * @param registryMonitor     registry-refresh monitor
      */
     @Inject
     public ClientDevicesAuthServiceApi(CertificateRegistry certificateRegistry,
+                                       ThingRegistry thingRegistry,
                                        SessionManager sessionManager,
                                        DeviceAuthClient deviceAuthClient,
-                                       CertificateManager certificateManager) {
+                                       CertificateManager certificateManager,
+                                       RegistryRefreshMonitor registryMonitor) {
         this.certificateRegistry = certificateRegistry;
         this.sessionManager = sessionManager;
         this.deviceAuthClient = deviceAuthClient;
         this.certificateManager = certificateManager;
+
+        registryMonitor.addToMonitor(certificateRegistry);
+        registryMonitor.addToMonitor(thingRegistry);
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/CertificateRegistryEntry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/CertificateRegistryEntry.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.iot.registry;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class CertificateRegistryEntry implements RefreshableRegistryEntry {
+    private Instant validTill;
+    private String certificateHash;
+    private String iotCertificateId;
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/RefreshableRegistry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/RefreshableRegistry.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.iot.registry;
+
+public interface RefreshableRegistry {
+    /**
+     * Refresh registry entries.
+     * 1. sync registry entries from the cloud
+     * 2. remove invalid/stale registry entries
+     */
+    void refresh();
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/RefreshableRegistryEntry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/RefreshableRegistryEntry.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.iot.registry;
+
+import java.time.Instant;
+
+public interface RefreshableRegistryEntry {
+    /**
+     * Provides time instant until which the entry is valid.
+     * @return time instant
+     */
+    Instant getValidTill();
+
+    /**
+     * Set the time instant until which the entry is valid.
+     * @param validTill time instant
+     */
+    void setValidTill(Instant validTill);
+
+    /**
+     * Indicates whether the registry entry is valid by checking its TTL.
+     * @return a boolean indicator
+     */
+    default boolean isValid() {
+        return getValidTill().isAfter(Instant.now());
+    }
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/RegistryConfig.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/RegistryConfig.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.iot.registry;
+
+public class RegistryConfig {
+    // TODO: make these configurable
+    public static final long REGISTRY_ENTRY_TTL_SECONDS = 24L * 60L * 60L;  // 1 day
+    public static final long REGISTRY_REFRESH_FREQUENCY_SECONDS = REGISTRY_ENTRY_TTL_SECONDS;
+    public static final int REGISTRY_CACHE_SIZE = 2500;
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/RegistryRefreshMonitor.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/RegistryRefreshMonitor.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.iot.registry;
+
+
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+
+public class RegistryRefreshMonitor {
+
+    private final Set<RefreshableRegistry> monitoredRegistry = new CopyOnWriteArraySet<>();
+    private final ScheduledExecutorService ses;
+    private ScheduledFuture<?> monitorFuture;
+
+    /**
+     * Constructor.
+     *
+     * @param ses ScheduledExecutorService for monitor
+     */
+    @Inject
+    public RegistryRefreshMonitor(ScheduledExecutorService ses) {
+        this.ses = ses;
+    }
+
+    /**
+     * Add a Refreshable registry to the monitor.
+     *
+     * @param registry Refreshable registry
+     */
+    public void addToMonitor(RefreshableRegistry registry) {
+        monitoredRegistry.add(registry);
+    }
+
+    /**
+     * Start Registry monitor.
+     */
+    public void startMonitor() {
+        if (monitorFuture != null) {
+            monitorFuture.cancel(true);
+        }
+        monitorFuture = ses.scheduleAtFixedRate(this::refreshRegistry,
+                RegistryConfig.REGISTRY_REFRESH_FREQUENCY_SECONDS, RegistryConfig.REGISTRY_REFRESH_FREQUENCY_SECONDS,
+                TimeUnit.SECONDS);
+    }
+
+    /**
+     * Stop registry refresh monitor.
+     */
+    public void stopMonitor() {
+        if (monitorFuture != null) {
+            monitorFuture.cancel(true);
+        }
+    }
+
+    private void refreshRegistry() {
+        monitoredRegistry.forEach(RefreshableRegistry::refresh);
+    }
+
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistry.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.iot.registry;
+
+import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
+import com.aws.greengrass.clientdevices.auth.iot.Certificate;
+import com.aws.greengrass.clientdevices.auth.iot.IotAuthClient;
+import com.aws.greengrass.clientdevices.auth.iot.Thing;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import javax.inject.Inject;
+
+public class ThingRegistry implements RefreshableRegistry {
+    // holds mapping of thingName to its registry entry;
+    // size-bound by default cache size, evicts oldest written entry if the max size is reached
+    static final Map<String, ThingRegistryEntry> registry = Collections.synchronizedMap(
+            new LinkedHashMap<String, ThingRegistryEntry>(RegistryConfig.REGISTRY_CACHE_SIZE, 0.75f, false) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry eldest) {
+                    return size() > RegistryConfig.REGISTRY_CACHE_SIZE;
+                }
+            });
+
+    private final IotAuthClient iotAuthClient;
+
+    @Inject
+    public ThingRegistry(IotAuthClient iotAuthClient) {
+        this.iotAuthClient = iotAuthClient;
+    }
+
+    /**
+     * Returns whether the Thing is associated to the given IoT Certificate.
+     * Returns locally registered result when IoT Core cannot be reached.
+     *
+     * @param thing IoT Thing
+     * @param certificate IoT Certificate
+     * @return whether thing is attached to the certificate
+     */
+    public boolean isThingAttachedToCertificate(Thing thing, Certificate certificate) {
+        try {
+            if (iotAuthClient.isThingAttachedToCertificate(thing, certificate)) {
+                registerCertificateForThing(thing, certificate);
+                return true;
+            } else {
+                clearRegistryForThing(thing);
+            }
+        } catch (CloudServiceInteractionException e) {
+            return isCertificateRegisteredForThing(thing, certificate);
+        }
+        return false;
+    }
+
+    /**
+     * Removes stale (invalid) entries from the registry.
+     * TODO: also sync with cloud
+     */
+    @Override
+    public void refresh() {
+        registry.values().removeIf(registryEntry -> !registryEntry.isValid());
+    }
+
+    /**
+     * Clears registry cache.
+     */
+    public void clear() {
+        registry.clear();
+    }
+
+    private void registerCertificateForThing(Thing thing, Certificate certificate) {
+        registry.put(thing.getThingName(),
+                new ThingRegistryEntry(Instant.now().plusSeconds(RegistryConfig.REGISTRY_ENTRY_TTL_SECONDS),
+                        thing.getThingName(), certificate.getIotCertificateId()));
+    }
+
+    private void clearRegistryForThing(Thing thing) {
+        registry.remove(thing.getThingName());
+    }
+
+    private boolean isCertificateRegisteredForThing(Thing thing, Certificate certificate) {
+        return Optional.ofNullable(registry.get(thing.getThingName()))
+                .filter(RefreshableRegistryEntry::isValid)
+                .filter(thingRegistryEntry ->
+                        thingRegistryEntry.getIotCertificateId().equals(certificate.getIotCertificateId()))
+                .isPresent();
+    }
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistryEntry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistryEntry.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.iot.registry;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class ThingRegistryEntry implements RefreshableRegistryEntry {
+    private Instant validTill;
+    private String thingName;
+    private String iotCertificateId;
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactory.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactory.java
@@ -9,32 +9,32 @@ import com.aws.greengrass.clientdevices.auth.DeviceAuthClient;
 import com.aws.greengrass.clientdevices.auth.exception.AuthenticationException;
 import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
 import com.aws.greengrass.clientdevices.auth.iot.Certificate;
-import com.aws.greengrass.clientdevices.auth.iot.CertificateRegistry;
 import com.aws.greengrass.clientdevices.auth.iot.Component;
-import com.aws.greengrass.clientdevices.auth.iot.IotAuthClient;
 import com.aws.greengrass.clientdevices.auth.iot.Thing;
+import com.aws.greengrass.clientdevices.auth.iot.registry.CertificateRegistry;
+import com.aws.greengrass.clientdevices.auth.iot.registry.ThingRegistry;
 
 import java.util.Map;
 import java.util.Optional;
 import javax.inject.Inject;
 
 public class MqttSessionFactory implements SessionFactory {
-    private final IotAuthClient iotAuthClient;
+    private final ThingRegistry thingRegistry;
     private final DeviceAuthClient deviceAuthClient;
     private final CertificateRegistry certificateRegistry;
 
     /**
      * Constructor.
      *
-     * @param iotAuthClient       Iot auth client
+     * @param thingRegistry       Iot Thing Registry
      * @param deviceAuthClient    Device auth client
      * @param certificateRegistry device Certificate registry
      */
     @Inject
-    public MqttSessionFactory(IotAuthClient iotAuthClient,
+    public MqttSessionFactory(ThingRegistry thingRegistry,
                               DeviceAuthClient deviceAuthClient,
                               CertificateRegistry certificateRegistry) {
-        this.iotAuthClient = iotAuthClient;
+        this.thingRegistry = thingRegistry;
         this.deviceAuthClient = deviceAuthClient;
         this.certificateRegistry = certificateRegistry;
     }
@@ -61,7 +61,7 @@ public class MqttSessionFactory implements SessionFactory {
             }
             Thing thing = new Thing(mqttCredential.clientId);
             Certificate cert = new Certificate(certificateId.get());
-            if (!iotAuthClient.isThingAttachedToCertificate(thing, cert)) {
+            if (!thingRegistry.isThingAttachedToCertificate(thing, cert)) {
                 throw new AuthenticationException("unable to authenticate device");
             }
             Session session = new SessionImpl(cert);

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthServiceTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthServiceTest.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.clientdevices.auth;
 
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateExpiryMonitor;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateHelper;
+import com.aws.greengrass.clientdevices.auth.iot.registry.RegistryRefreshMonitor;
 import com.aws.greengrass.componentmanager.KernelConfigResolver;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.dependency.State;
@@ -96,6 +97,9 @@ class ClientDevicesAuthServiceTest {
     @Mock
     CertificateExpiryMonitor certExpiryMonitor;
 
+    @Mock
+    RegistryRefreshMonitor registryRefreshMonitor;
+
     @Captor
     private ArgumentCaptor<GroupConfiguration> configurationCaptor;
 
@@ -112,6 +116,7 @@ class ClientDevicesAuthServiceTest {
         kernel = new Kernel();
         kernel.getContext().put(GroupManager.class, groupManager);
         kernel.getContext().put(CertificateExpiryMonitor.class, certExpiryMonitor);
+        kernel.getContext().put(RegistryRefreshMonitor.class, registryRefreshMonitor);
         kernel.getContext().put(GreengrassServiceClientFactory.class, clientFactory);
 
         lenient().when(clientFactory.getGreengrassV2DataClient()).thenReturn(client);
@@ -272,6 +277,7 @@ class ClientDevicesAuthServiceTest {
         kernel.shutdown();
         kernel = new Kernel().parseArgs("-r", rootDir.toAbsolutePath().toString());
         kernel.getContext().put(CertificateExpiryMonitor.class, certExpiryMonitor);
+        kernel.getContext().put(RegistryRefreshMonitor.class, registryRefreshMonitor);
         kernel.getContext().put(GreengrassServiceClientFactory.class, clientFactory);
         startNucleusWithConfig("config.yaml");
 


### PR DESCRIPTION
**Description of changes:** Enables offline auth with caching. AuthN/AuthZ workflows consult cache when cloud is unreachable.

Notes:
- TTL for cache entries and the periodic cache refresh frequency are set to one day. These parameters will be made configurable.
- Cache-refresh here only removes stale entries, but it is envisioned to sync cache results with cloud also. Cache interface will also support an API to persist cache locally on the filesystem to preserve cache across device power cycles.
- Default cache size is changed from 50 to 2500 entries for now.

Outline:
```
                            interface                           +----------------------------+
                 +-----------------------+                    |                            |
                 |  RefreshableRegistry  |                    | RefreshableRegistryEntry   |
                 |                       |                    |                            |
           +-----+  - refresh()          | -----+             |                            |
           |     |                       |      |             |                            |
           |     |                       |      |             |   - isValid()              |
           |     +-----------------------+      |             |   - getValidTill()         |
           |                                    |             |   - setValidTill()         |
           |                                    |             |                            |
           |              implements            |             |                            |
           v                                    v             +----------------------------+
+-----------------------+           +-------------------+
|                       |           |                   |
|  CertificateRegistry  |           |   ThingRegistry   |
|                       |           |                   |
|                       |           |                   |
+-----------------------+           +-------------------+





                                +------------------------------------------------+
                                |   RegistryRefreshMonitor                       |
                                |                                                |
                                |   - Set<RefreshableRegistry> monitoredRegistry;|
                                |                                                |
                                |   - addToMonitor(RefreshableRegistry)          |
                                |   - startMonitor()                             |
                                |   - stopMonitor()                              |
                                |                                                |
                                +------------------------------------------------+
```

TO-DOs (in a separate PR) :
- periodically sync cache results with cloud
- persist cache on the filesystem
- make cache config parameters customer-configurable.

**Why is this change necessary:** a part of BYOCA.

**How was this change tested:** unit tests, `mvn verify`

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
