### PR TITLE
feat: enable offline certificate registry access

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/VerifyClientDeviceIdentityTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/VerifyClientDeviceIdentityTest.java
@@ -241,7 +241,7 @@ class VerifyClientDeviceIdentityTest {
     }
 
     @Test
-    void GIVEN_broker_WHEN_verify_client_identity_with_exception_THEN_error_is_thrown(ExtensionContext context)
+    void GIVEN_broker_WHEN_verify_client_identity_with_exception_THEN_return_cached_result(ExtensionContext context)
             throws Exception {
         startNucleusWithConfig("cda.yaml");
         ignoreExceptionOfType(context, NullPointerException.class);

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/VerifyClientDeviceIdentityTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/VerifyClientDeviceIdentityTest.java
@@ -30,6 +30,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCClient;
 import software.amazon.awssdk.aws.greengrass.VerifyClientDeviceIdentityResponseHandler;
 import software.amazon.awssdk.aws.greengrass.model.ClientDeviceCredential;
+import software.amazon.awssdk.aws.greengrass.model.ServiceError;
 import software.amazon.awssdk.aws.greengrass.model.UnauthorizedError;
 import software.amazon.awssdk.aws.greengrass.model.VerifyClientDeviceIdentityRequest;
 import software.amazon.awssdk.aws.greengrass.model.VerifyClientDeviceIdentityResponse;
@@ -51,6 +52,7 @@ import static com.aws.greengrass.testcommons.testutilities.TestUtils.asyncAssert
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -216,7 +218,7 @@ class VerifyClientDeviceIdentityTest {
     }
 
     @Test
-    void GIVEN_broker_WHEN_verify_client_identity_with_internal_server_exception_THEN_verify_with_cached_result(
+    void GIVEN_broker_WHEN_verify_client_identity_with_internal_server_exception_THEN_error_is_thrown(
             ExtensionContext context)
             throws Exception {
         startNucleusWithConfig("cda.yaml");
@@ -232,17 +234,16 @@ class VerifyClientDeviceIdentityTest {
                     .withCredential(new ClientDeviceCredential()
                             .withClientDeviceCertificate("abc"));
 
-            Pair<CompletableFuture<Void>, Consumer<VerifyClientDeviceIdentityResponse>> cb =
-                    asyncAssertOnConsumer((m) -> assertFalse(m.isIsValidClientDevice()));
-
-            verifyClientIdentity(ipcClient, request, cb.getRight());
-            cb.getLeft().get(10, TimeUnit.SECONDS);
+            Exception err = Assertions.assertThrows(Exception.class, () -> {
+                verifyClientIdentity(ipcClient, request, null);
+            });
+            assertEquals(err.getCause().getClass(), ServiceError.class);
         }
     }
 
     @Test
-    void GIVEN_broker_WHEN_verify_client_identity_with_exception_THEN_return_cached_result(ExtensionContext context)
-            throws Exception {
+    void GIVEN_broker_WHEN_verify_client_identity_with_exception_THEN_error_is_thrown(ExtensionContext context)
+            throws ExecutionException, InterruptedException {
         startNucleusWithConfig("cda.yaml");
         ignoreExceptionOfType(context, NullPointerException.class);
         ignoreExceptionOfType(context, CloudServiceInteractionException.class);
@@ -253,11 +254,10 @@ class VerifyClientDeviceIdentityTest {
                     .withCredential(new ClientDeviceCredential()
                             .withClientDeviceCertificate("abc"));
 
-            Pair<CompletableFuture<Void>, Consumer<VerifyClientDeviceIdentityResponse>> cb =
-                    asyncAssertOnConsumer((m) -> assertFalse(m.isIsValidClientDevice()));
-
-            verifyClientIdentity(ipcClient, request, cb.getRight());
-            cb.getLeft().get(10, TimeUnit.SECONDS);
+            Exception err = Assertions.assertThrows(Exception.class, () -> {
+                verifyClientIdentity(ipcClient, request, null);
+            });
+            assertEquals(err.getCause().getClass(), ServiceError.class);
         }
     }
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/VerifyClientDeviceIdentityTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/VerifyClientDeviceIdentityTest.java
@@ -30,7 +30,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCClient;
 import software.amazon.awssdk.aws.greengrass.VerifyClientDeviceIdentityResponseHandler;
 import software.amazon.awssdk.aws.greengrass.model.ClientDeviceCredential;
-import software.amazon.awssdk.aws.greengrass.model.ServiceError;
 import software.amazon.awssdk.aws.greengrass.model.UnauthorizedError;
 import software.amazon.awssdk.aws.greengrass.model.VerifyClientDeviceIdentityRequest;
 import software.amazon.awssdk.aws.greengrass.model.VerifyClientDeviceIdentityResponse;
@@ -52,7 +51,6 @@ import static com.aws.greengrass.testcommons.testutilities.TestUtils.asyncAssert
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -218,7 +216,7 @@ class VerifyClientDeviceIdentityTest {
     }
 
     @Test
-    void GIVEN_broker_WHEN_verify_client_identity_with_internal_server_exception_THEN_error_is_thrown(
+    void GIVEN_broker_WHEN_verify_client_identity_with_internal_server_exception_THEN_verify_with_cached_result(
             ExtensionContext context)
             throws Exception {
         startNucleusWithConfig("cda.yaml");
@@ -234,16 +232,17 @@ class VerifyClientDeviceIdentityTest {
                     .withCredential(new ClientDeviceCredential()
                             .withClientDeviceCertificate("abc"));
 
-            Exception err = Assertions.assertThrows(Exception.class, () -> {
-                verifyClientIdentity(ipcClient, request, null);
-            });
-            assertEquals(err.getCause().getClass(), ServiceError.class);
+            Pair<CompletableFuture<Void>, Consumer<VerifyClientDeviceIdentityResponse>> cb =
+                    asyncAssertOnConsumer((m) -> assertFalse(m.isIsValidClientDevice()));
+
+            verifyClientIdentity(ipcClient, request, cb.getRight());
+            cb.getLeft().get(10, TimeUnit.SECONDS);
         }
     }
 
     @Test
     void GIVEN_broker_WHEN_verify_client_identity_with_exception_THEN_error_is_thrown(ExtensionContext context)
-            throws ExecutionException, InterruptedException {
+            throws Exception {
         startNucleusWithConfig("cda.yaml");
         ignoreExceptionOfType(context, NullPointerException.class);
         ignoreExceptionOfType(context, CloudServiceInteractionException.class);
@@ -254,10 +253,11 @@ class VerifyClientDeviceIdentityTest {
                     .withCredential(new ClientDeviceCredential()
                             .withClientDeviceCertificate("abc"));
 
-            Exception err = Assertions.assertThrows(Exception.class, () -> {
-                verifyClientIdentity(ipcClient, request, null);
-            });
-            assertEquals(err.getCause().getClass(), ServiceError.class);
+            Pair<CompletableFuture<Void>, Consumer<VerifyClientDeviceIdentityResponse>> cb =
+                    asyncAssertOnConsumer((m) -> assertFalse(m.isIsValidClientDevice()));
+
+            verifyClientIdentity(ipcClient, request, cb.getRight());
+            cb.getLeft().get(10, TimeUnit.SECONDS);
         }
     }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistry.java
@@ -36,12 +36,13 @@ public class ThingRegistry {
 
     /**
      * Returns whether the Thing is associated to the given IoT Certificate.
-     * Returns locally registered result when IoT Core cannot be reached.
+     * Returns valid locally registered result when IoT Core cannot be reached.
      * TODO: add a separate refreshable caching layer for offline auth
      *
      * @param thing IoT Thing
      * @param certificate IoT Certificate
      * @return whether thing is attached to the certificate
+     * @throws CloudServiceInteractionException when thing <-> certificate association cannot be verified
      */
     public boolean isThingAttachedToCertificate(Thing thing, Certificate certificate) {
         try {
@@ -52,7 +53,10 @@ public class ThingRegistry {
                 clearRegistryForThing(thing);
             }
         } catch (CloudServiceInteractionException e) {
-            return isCertificateRegisteredForThing(thing, certificate);
+            if (isCertificateRegisteredForThing(thing, certificate)) {
+                return true;
+            }
+            throw e;
         }
         return false;
     }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistry.java
@@ -19,7 +19,7 @@ import javax.inject.Inject;
 public class ThingRegistry {
     // holds mapping of thingName to IoT Certificate ID;
     // size-bound by default cache size, evicts oldest written entry if the max size is reached
-    static final Map<String, String> registry = Collections.synchronizedMap(
+    private final Map<String, String> registry = Collections.synchronizedMap(
             new LinkedHashMap<String, String>(RegistryConfig.REGISTRY_CACHE_SIZE, 0.75f, false) {
                 @Override
                 protected boolean removeEldestEntry(Map.Entry eldest) {

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/registry/CertificateRegistryTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/registry/CertificateRegistryTest.java
@@ -5,9 +5,9 @@
 
 package com.aws.greengrass.clientdevices.auth.iot.registry;
 
+import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
 import com.aws.greengrass.clientdevices.auth.iot.IotAuthClient;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,7 +20,11 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.anyString;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -42,25 +46,20 @@ class CertificateRegistryTest {
         registry = new CertificateRegistry(mockIotAuthClient);
     }
 
-    @AfterEach
-    void afterEach() {
-        registry.clear();
-    }
-
     @Test
     void GIVEN_validAndActiveCertificatePem_WHEN_getIotCertificateIdForPem_THEN_certificateIdReturned() {
         when(mockIotAuthClient.getActiveCertificateId(anyString())).thenReturn(Optional.of(mockCertId));
 
-        registry.isCertificateValid(mockCertPem);
+        assertTrue(registry.isCertificateValid(mockCertPem));
         Optional<String> certificateId = registry.getIotCertificateIdForPem(mockCertPem);
 
-        // Assert that we only call the cloud a single time
+        // Assert that we only make cloud request once
         assertThat(certificateId.get(), is(mockCertId));
         verify(mockIotAuthClient, times(1)).getActiveCertificateId(anyString());
     }
 
     @Test
-    void GIVEN_certificatePem_and_cloudProperResponse_WHEN_getIotCertificateIdForPem_THEN_certificateIdReturned() {
+    void GIVEN_certificatePem_and_uncachedCertId_WHEN_getIotCertificateIdForPem_THEN_certificateIdFetched() {
         when(mockIotAuthClient.getActiveCertificateId(anyString())).thenReturn(Optional.of(mockCertId));
 
         Optional<String> certificateId = registry.getIotCertificateIdForPem(mockCertPem);
@@ -79,7 +78,6 @@ class CertificateRegistryTest {
         // request certificateId for the same certificatePem multiple times;
         // actual cloud request should be made only once and cached value should be returned for subsequent calls
         assertThat(registry.getIotCertificateIdForPem(mockCertPem).get(), is(mockCertId));
-        assertThat(registry.getIotCertificateIdForPem(mockCertPem).get(), is(mockCertId));
         verify(mockIotAuthClient, times(1)).getActiveCertificateId(anyString());
     }
 
@@ -92,7 +90,29 @@ class CertificateRegistryTest {
         // request certificateId for the same invalid certificatePem multiple times;
         // new cloud request should be made every time and result should not be cached
         assertThat(registry.getIotCertificateIdForPem(mockCertPem), is(Optional.empty()));
+        verify(mockIotAuthClient, times(2)).getActiveCertificateId(anyString());
+    }
+
+    @Test
+    void GIVEN_unreachable_cloud_WHEN_isCertificateValid_THEN_return_cached_result() {
+        // cache result before going offline
+        when(mockIotAuthClient.getActiveCertificateId(anyString())).thenReturn(Optional.of(mockCertId));
+        assertTrue(registry.isCertificateValid(mockCertPem));
+
+        // go offline
+        reset(mockIotAuthClient);
+        doThrow(CloudServiceInteractionException.class).when(mockIotAuthClient).getActiveCertificateId(anyString());
+
+        // verify cached result
+        assertTrue(registry.isCertificateValid(mockCertPem));
+        assertThat(registry.getIotCertificateIdForPem(mockCertPem), is(Optional.of(mockCertId)));
+    }
+
+    @Test
+    void GIVEN_offline_initialization_WHEN_isCertificateValid_THEN_return_false_by_default() {
+        doThrow(CloudServiceInteractionException.class).when(mockIotAuthClient).getActiveCertificateId(anyString());
+
+        assertFalse(registry.isCertificateValid(mockCertPem));
         assertThat(registry.getIotCertificateIdForPem(mockCertPem), is(Optional.empty()));
-        verify(mockIotAuthClient, times(3)).getActiveCertificateId(anyString());
     }
 }

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/registry/CertificateRegistryTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/registry/CertificateRegistryTest.java
@@ -20,8 +20,8 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.reset;
@@ -109,10 +109,10 @@ class CertificateRegistryTest {
     }
 
     @Test
-    void GIVEN_offline_initialization_WHEN_isCertificateValid_THEN_return_false_by_default() {
+    void GIVEN_offline_initialization_WHEN_isCertificateValid_THEN_throw_exception() {
         doThrow(CloudServiceInteractionException.class).when(mockIotAuthClient).getActiveCertificateId(anyString());
 
-        assertFalse(registry.isCertificateValid(mockCertPem));
-        assertThat(registry.getIotCertificateIdForPem(mockCertPem), is(Optional.empty()));
+        assertThrows(CloudServiceInteractionException.class, () -> registry.isCertificateValid(mockCertPem));
+        assertThrows(CloudServiceInteractionException.class, () -> registry.getIotCertificateIdForPem(mockCertPem));
     }
 }

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistryTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistryTest.java
@@ -18,7 +18,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
@@ -53,8 +52,6 @@ class ThingRegistryTest {
         reset(mockIotAuthClient);
         when(mockIotAuthClient.isThingAttachedToCertificate(any(Thing.class), any(Certificate.class))).thenReturn(false);
         assertFalse(registry.isThingAttachedToCertificate(mockThing, mockCertificate));
-        // registry should be cleared for negative result
-        assertNull(ThingRegistry.registry.get(mockThing.getThingName()));
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistryTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistryTest.java
@@ -19,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.reset;
@@ -71,11 +72,12 @@ class ThingRegistryTest {
     }
 
     @Test
-    void GIVEN_offline_initialization_WHEN_isThingAttachedToCertificate_THEN_return_false_by_default() {
+    void GIVEN_offline_initialization_WHEN_isThingAttachedToCertificate_THEN_throws_exception() {
         doThrow(CloudServiceInteractionException.class)
                 .when(mockIotAuthClient).isThingAttachedToCertificate(any(), any());
 
-        assertFalse(registry.isThingAttachedToCertificate(mockThing, mockCertificate));
+        assertThrows(CloudServiceInteractionException.class, () ->
+                registry.isThingAttachedToCertificate(mockThing, mockCertificate));
         verify(mockIotAuthClient, times(1)).isThingAttachedToCertificate(any(), any());
     }
 


### PR DESCRIPTION
**Description of changes:** CertificateRegistry returns locally registered results when cloud is unreachable.

**Why is this change necessary:** required for enabling offline auth

**How was this change tested:** unit tests, integ tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.