### PR TITLE
fix: do not throw an error when cloud upload fails

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -295,7 +295,7 @@ public class ClientDevicesAuthService extends PluginService {
             updateCACertificateConfig(caCerts);
             updateCaPassphraseConfig(certificateManager.getCaPassPhrase());
         } catch (CloudServiceInteractionException e) {
-            logger.atError().cause(e).log("Unable to upload core CA certs to the cloud. ");
+            logger.atError().log(e.getMessage());
         } catch (KeyStoreException | IOException | CertificateEncodingException | IllegalArgumentException
                 e) {
             serviceErrored(e);
@@ -346,7 +346,7 @@ public class ClientDevicesAuthService extends PluginService {
                     .log("Failed to put core CA certificates to cloud. Check that the core device's IoT policy grants"
                             + " the greengrass:PutCertificateAuthorities permission.");
             throw new CloudServiceInteractionException(
-                    String.format("Failed to put core %s CA certificates to cloud", thingName), e);
+                    String.format("Failed to upload core %s CA certificates to cloud", thingName), e);
         }
     }
 

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -295,7 +295,9 @@ public class ClientDevicesAuthService extends PluginService {
             updateCACertificateConfig(caCerts);
             updateCaPassphraseConfig(certificateManager.getCaPassPhrase());
         } catch (CloudServiceInteractionException e) {
-            logger.atError().log(e.getMessage());
+            logger.atError().cause(e)
+                    .kv("coreThingName", deviceConfiguration.getThingName())
+                    .log("Unable to upload core CA certificates to the cloud");
         } catch (KeyStoreException | IOException | CertificateEncodingException | IllegalArgumentException
                 e) {
             serviceErrored(e);
@@ -341,12 +343,8 @@ public class ClientDevicesAuthService extends PluginService {
             // interrupt the current thread so that higher-level interrupt handlers can take care of it
             Thread.currentThread().interrupt();
         } catch (Exception e) {
-            logger.atError().cause(e)
-                    .kv("coreThingName", thingName)
-                    .log("Failed to put core CA certificates to cloud. Check that the core device's IoT policy grants"
-                            + " the greengrass:PutCertificateAuthorities permission.");
-            throw new CloudServiceInteractionException(
-                    String.format("Failed to upload core %s CA certificates to cloud", thingName), e);
+            throw new CloudServiceInteractionException("Failed to put core CA certificates to cloud. Check that the "
+                    + "core device's IoT policy grants the greengrass:PutCertificateAuthorities permission.",e);
         }
     }
 

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthServiceTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthServiceTest.java
@@ -7,14 +7,15 @@ package com.aws.greengrass.clientdevices.auth;
 
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateExpiryMonitor;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateHelper;
-import com.aws.greengrass.componentmanager.KernelConfigResolver;
-import com.aws.greengrass.config.Topic;
-import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.clientdevices.auth.configuration.ConfigurationFormatVersion;
 import com.aws.greengrass.clientdevices.auth.configuration.GroupConfiguration;
 import com.aws.greengrass.clientdevices.auth.configuration.GroupManager;
 import com.aws.greengrass.clientdevices.auth.configuration.Permission;
 import com.aws.greengrass.clientdevices.auth.exception.AuthorizationException;
+import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
+import com.aws.greengrass.componentmanager.KernelConfigResolver;
+import com.aws.greengrass.config.Topic;
+import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
 import com.aws.greengrass.mqttclient.spool.SpoolerStoreException;
@@ -356,13 +357,13 @@ class ClientDevicesAuthServiceTest {
     }
 
     @Test
-    void GIVEN_cloud_service_error_WHEN_update_ca_type_THEN_service_in_error_state(ExtensionContext context)
+    void GIVEN_cloud_service_error_WHEN_update_ca_type_THEN_service_in_running_state(ExtensionContext context)
             throws InterruptedException {
         ignoreExceptionOfType(context, ResourceNotFoundException.class);
-
+        ignoreExceptionOfType(context, CloudServiceInteractionException.class);
         when(client.putCertificateAuthorities(any(PutCertificateAuthoritiesRequest.class))).thenThrow(
                 ResourceNotFoundException.class);
-        startNucleusWithConfig("config_with_ec_ca.yaml", State.ERRORED);
+        startNucleusWithConfig("config_with_ec_ca.yaml", State.RUNNING);
     }
 
     private X509Certificate pemToX509Certificate(String certPem) throws IOException, CertificateException {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
When uploading the core CA to cloud fails, CDA retries for certain type of exceptions like `ThrottlingException` and `InternalServerException` where as for all other exceptions, the service goes into error state. 

But with this change, for all other non-retryable exceptions, we log the exception but do not put the service in error state. We retry for `AccessDeniedException` as well.  

**Why is this change necessary:**
When we support offline authentication, client devices do not get the core device CAs from the cloud. So, even when the core device fails to upload the core CAs to cloud, client device auth component should be running as the client devices do not rely on them in all the cases. 

**How was this change tested:**
Updated test. 

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
