### PR TITLE
fix: only rotate certs when cis connectivity info changes

### DIFF
--- a/src/test/java/com/aws/greengrass/clientdevices/auth/certificate/CISShadowMonitorTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/certificate/CISShadowMonitorTest.java
@@ -41,7 +41,6 @@ import software.amazon.awssdk.services.greengrassv2data.model.ConnectivityInfo;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.security.KeyStoreException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -121,6 +120,11 @@ public class CISShadowMonitorTest {
     @Test
     @SuppressWarnings("unchecked")
     void GIVEN_CISShadowMonitor_WHEN_start_monitor_OR_reconnect_THEN_get_shadow_is_processed() throws Exception {
+        // make connectivity call yield the same response each time.
+        // so for this scenario, the monitor starts up (we process get shadow response) and we
+        // simulate a reconnection (process another get shadow response);
+        // no extra rotations should occur.
+        connectivityInfoProvider.setMode(FakeConnectivityInfoProvider.Mode.CONSTANT);
 
         int shadowInitialVersion = 1;
         Map<String, Object> shadowInitialDesiredState = Utils.immutableMap("field", "value");
@@ -424,7 +428,7 @@ public class CISShadowMonitorTest {
     /**
      * Verify that certificates are rotated only when connectivity info changes.
      *
-     * @throws KeyStoreException n/a
+     * @throws CertificateGenerationException n/a
      */
     private void verifyCertsRotatedWhenConnectivityChanges() throws CertificateGenerationException {
         verify(certificateGenerator, times(connectivityInfoProvider.getNumUniqueConnectivityInfoResponses()))


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Simplified version of https://github.com/aws-greengrass/aws-greengrass-client-device-auth/pull/76. This change modifies `CISShadowMonitor` so that it rotates certificates when it _detects a change in the CIS connectivity info_, rather than a change in shadow document version.  

**Why is this change necessary:**

This fixes an issue where certificates are rotated unnecessarily when a recconect occurs (when we process a CIS shadow, we publish reported state to it, bumping the version. if a recconect occurs in the future, certs will be rotated even if connectivity info hasn't changed, because `CISShadowMonitor` only cared that the shadow version changed)

**How was this change tested:**

Unit tests

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
