### PR TITLE
feat: registry cache ttl

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/CertificateEntry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/CertificateEntry.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.iot.registry;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+@AllArgsConstructor
+public class CertificateEntry {
+    private Instant validTill;
+    private String certificateHash;
+    private String iotCertificateId;
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof CertificateEntry)) {
+            return false;
+        }
+        return this.getIotCertificateId()
+                .equals(((CertificateEntry) obj).iotCertificateId);
+    }
+
+    @Override
+    public int hashCode() {
+        return this.getIotCertificateId().hashCode();
+    }
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/CertificateRegistry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/CertificateRegistry.java
@@ -113,6 +113,7 @@ public class CertificateRegistry {
     private Optional<String> getAssociatedCertificateId(String certificatePem) {
         return Optional.ofNullable(getCertificateHash(certificatePem))
                 .map(registry::get)
+                .filter(this::isValidCertificateEntry)
                 .map(CertificateEntry::getIotCertificateId);
     }
 

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/RegistryConfig.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/RegistryConfig.java
@@ -6,5 +6,7 @@
 package com.aws.greengrass.clientdevices.auth.iot.registry;
 
 public class RegistryConfig {
-    public static final int REGISTRY_CACHE_SIZE = 50;
+    protected static final int REGISTRY_CACHE_SIZE = 50;
+    protected static final int REGISTRY_CACHE_ENTRY_TTL_SECONDS = 24 * 60 * 60; // 1 day
+    protected static final int REGISTRY_REFRESH_FREQUENCY_SECONDS = 24 * 60 * 60; // 1 day
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/RegistryRefreshScheduler.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/RegistryRefreshScheduler.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.iot.registry;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+
+public class RegistryRefreshScheduler {
+
+    private final List<Runnable> refreshRunnable = new CopyOnWriteArrayList<>();
+    private final ScheduledExecutorService ses;
+    private ScheduledFuture<?> scheduledFuture;
+
+    /**
+     * Constructor.
+     *
+     * @param ses ScheduledExecutorService for refresh
+     */
+    @Inject
+    public RegistryRefreshScheduler(ScheduledExecutorService ses) {
+        this.ses = ses;
+    }
+
+    /**
+     * Schedules the runnable to be run at configured interval.
+     *
+     * @param runnable Runnable registry refresh
+     */
+    public void schedule(Runnable runnable) {
+        refreshRunnable.add(runnable);
+    }
+
+    /**
+     * Starts registry refresh scheduler.
+     */
+    public void startScheduler() {
+        if (scheduledFuture != null) {
+            scheduledFuture.cancel(true);
+        }
+
+        scheduledFuture = ses.scheduleAtFixedRate(this::runRefresh, RegistryConfig.REGISTRY_REFRESH_FREQUENCY_SECONDS,
+                RegistryConfig.REGISTRY_REFRESH_FREQUENCY_SECONDS, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Stop registry refresh monitor.
+     */
+    public void stopScheduler() {
+        if (scheduledFuture != null) {
+            scheduledFuture.cancel(true);
+        }
+    }
+
+    private void runRefresh() {
+        refreshRunnable.forEach(Runnable::run);
+    }
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistry.java
@@ -87,6 +87,7 @@ public class ThingRegistry {
         Set<CertificateEntry> certSet = registry.get(thing.getThingName());
         if (certSet != null) {
             return certSet.stream()
+                    .filter(this::isValidCertificateEntry)
                     .anyMatch(certEntry -> certEntry.getIotCertificateId().equals(certificate.getIotCertificateId()));
         }
         return false;


### PR DESCRIPTION
**Description of changes:** This change adds TTL to the registry entries and adds a refresh mechanism that removes stale (invalid) registry entries, scheduled to run at the configured frequency. For now, this TTL and the refresh frequency is set to 1 day. These parameters will be made customer-configurable in subsequent PR.

**Why is this change necessary:** To manage registry cache: invalidate registry entries and force-consult cloud after TTL.

**How was this change tested:** Unit tests, integ tests (`mvn verify`)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
