### PR TITLE
refactor: add initial interface for CA store

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/CertificateManager.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/CertificateManager.java
@@ -16,9 +16,13 @@ import com.aws.greengrass.clientdevices.auth.certificate.CertificateStore;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificatesConfig;
 import com.aws.greengrass.clientdevices.auth.certificate.ClientCertificateGenerator;
 import com.aws.greengrass.clientdevices.auth.certificate.ServerCertificateGenerator;
+import com.aws.greengrass.clientdevices.auth.certificate.certificateauthority.BringYourOwnCAStore;
+import com.aws.greengrass.clientdevices.auth.certificate.certificateauthority.CAStore;
+import com.aws.greengrass.clientdevices.auth.certificate.certificateauthority.GeneratedCAStore;
 import com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration;
 import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationException;
 import com.aws.greengrass.clientdevices.auth.iot.ConnectivityInfoProvider;
+import com.aws.greengrass.util.Utils;
 import lombok.NonNull;
 
 import java.io.IOException;
@@ -46,6 +50,8 @@ public class CertificateManager {
     private CertificatesConfig certificatesConfig;
     @SuppressWarnings("PMD.UnusedPrivateField")
     private CAConfiguration caConfiguration;
+    @SuppressWarnings("PMD.UnusedPrivateField")
+    private CAStore caStore = null;
 
 
     /**
@@ -81,6 +87,7 @@ public class CertificateManager {
      */
     public void setCAConfiguration(CAConfiguration caConfiguration) {
         this.caConfiguration = caConfiguration;
+        setCertificateAuthorityStore();
     }
 
     /**
@@ -91,6 +98,16 @@ public class CertificateManager {
      */
     public void update(String caPassphrase, CertificateStore.CAType caType) throws KeyStoreException {
         certificateStore.update(caPassphrase, caType);
+    }
+
+    private void setCertificateAuthorityStore() {
+        String caCertificateUri = caConfiguration.getCaCertificateUri();
+        String caPrivateKeyUri = caConfiguration.getCaPrivateKeyUri();
+        if (Utils.isEmpty(caCertificateUri) && Utils.isEmpty(caPrivateKeyUri)) {
+            caStore = new GeneratedCAStore();
+        } else {
+            caStore = new BringYourOwnCAStore();
+        }
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/certificateauthority/BringYourOwnCAStore.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/certificateauthority/BringYourOwnCAStore.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.certificate.certificateauthority;
+
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+
+public class BringYourOwnCAStore implements CAStore {
+
+    @Override
+    public X509Certificate[] getCACertificateChain() {
+        return new X509Certificate[0];
+    }
+
+    @Override
+    public X509Certificate getCACertificate() {
+        return null;
+    }
+
+    @Override
+    public PrivateKey getCAPrivateKey() {
+        return null;
+    }
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/certificateauthority/CAStore.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/certificateauthority/CAStore.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.certificate.certificateauthority;
+
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+
+public interface CAStore {
+    X509Certificate[] getCACertificateChain();
+
+    PrivateKey getCAPrivateKey();
+
+    X509Certificate getCACertificate();
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/certificateauthority/GeneratedCAStore.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/certificateauthority/GeneratedCAStore.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.certificate.certificateauthority;
+
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+
+public class GeneratedCAStore implements CAStore {
+
+    @Override
+    public X509Certificate[] getCACertificateChain() {
+        return new X509Certificate[0];
+    }
+
+    @Override
+    public PrivateKey getCAPrivateKey() {
+        return null;
+    }
+
+    @Override
+    public X509Certificate getCACertificate() {
+        return null;
+    }
+}
+


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add initial interface for the CAStore. This will be used to get CA from either BYOCA Store or the generatedCA Store. 

**Why is this change necessary:**

**How was this change tested:**
Tests will be added when the methods are properly implemented. 

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
