### PR TITLE
refactor: update certificate manager using CA configuration

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/CertificateManager.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/CertificateManager.java
@@ -95,21 +95,22 @@ public class CertificateManager {
         String caPassphraseFromConfig = caConfiguration.getCaPassphrase();
         CertificateStore.CAType caTypeFromConfig = getCAType(caConfiguration.getCaTypeList());
         certificateStore.update(caPassphraseFromConfig, caTypeFromConfig);
-        updateCaPassphraseConfig();
+        updateCaRuntimeConfig();
     }
 
     private CertificateStore.CAType getCAType(List<String> caTypeList) {
         if (Utils.isEmpty(caTypeList)) {
+            logger.atDebug().log("CA type list null or empty. Defaulting to RSA");
             return CertificateStore.CAType.RSA_2048;
         } else {
             if (caTypeList.size() > 1) {
-                logger.atDebug().log("Only one CA type is supported. Ignoring subsequent CAs in the list.");
+                logger.atDebug().log("Only one CA type is supported. Ignoring subsequent CAs in the list");
             }
             return CertificateStore.CAType.valueOf(caTypeList.get(0));
         }
     }
 
-    void updateCaPassphraseConfig() {
+    private void updateCaRuntimeConfig() {
         caConfiguration.updateCaPassphraseConfig(certificateStore.getCaPassphrase());
     }
 

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/CertificateManager.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/CertificateManager.java
@@ -90,8 +90,10 @@ public class CertificateManager {
      * Update the certificate manager.
      *
      * @throws KeyStoreException if unable to load the CA key store
+     * @throws CertificateEncodingException if unable to get the CA certificates
+     * @throws IOException if unable to get the CA certificates
      */
-    public synchronized void update() throws KeyStoreException {
+    public synchronized void update() throws KeyStoreException, CertificateEncodingException, IOException {
         String caPassphraseFromConfig = caConfiguration.getCaPassphrase();
         CertificateStore.CAType caTypeFromConfig = getCAType(caConfiguration.getCaTypeList());
         certificateStore.update(caPassphraseFromConfig, caTypeFromConfig);
@@ -110,8 +112,9 @@ public class CertificateManager {
         }
     }
 
-    private void updateCaRuntimeConfig() {
+    private void updateCaRuntimeConfig() throws CertificateEncodingException, KeyStoreException, IOException {
         caConfiguration.updateCaPassphraseConfig(certificateStore.getCaPassphrase());
+        caConfiguration.updateCaCertificateConfig(getCACertificates());
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -282,7 +282,6 @@ public class ClientDevicesAuthService extends PluginService {
             certificateManager.update();
             List<String> caCerts = certificateManager.getCACertificates();
             uploadCoreDeviceCAs(caCerts);
-            updateCACertificateConfig(caCerts);
         } catch (CloudServiceInteractionException e) {
             logger.atError().cause(e)
                     .kv("coreThingName", deviceConfiguration.getThingName())
@@ -293,10 +292,6 @@ public class ClientDevicesAuthService extends PluginService {
         }
     }
 
-    void updateCACertificateConfig(List<String> caCerts) {
-        Topic caCertsTopic = getRuntimeConfig().lookup(CERTIFICATES_KEY, AUTHORITIES_TOPIC);
-        caCertsTopic.withValue(caCerts);
-    }
 
     @Override
     protected CompletableFuture<Void> close(boolean waitForDependers) {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfiguration.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfiguration.java
@@ -25,7 +25,8 @@ public class CAConfiguration {
     private final String caPrivateKeyUri;
     private final String caCertificateUri;
     private final List<String> caTypeList;
-    private final String caPassphrase;
+    private String caPassphrase;
+    private final Topics cdaConfigTopics;
 
     /**
      * Creates CA configuration object with the latest CDA config.
@@ -33,6 +34,7 @@ public class CAConfiguration {
      * @param cdaConfigTopics CDA service configuration topics
      */
     public CAConfiguration(Topics cdaConfigTopics) {
+        this.cdaConfigTopics = cdaConfigTopics;
         Topics certificateAuthorityTopics = cdaConfigTopics.lookupTopics(CONFIGURATION_CONFIG_KEY,
                 CERTIFICATE_AUTHORITY_TOPIC);
         caPrivateKeyUri = Coerce.toString(certificateAuthorityTopics.find(CA_PRIVATE_KEY_URI));
@@ -40,6 +42,11 @@ public class CAConfiguration {
         caTypeList = Coerce.toStringList(certificateAuthorityTopics.find(CA_TYPE_TOPIC));
 
         Topics cdaRuntimeTopics = cdaConfigTopics.lookupTopics(RUNTIME_STORE_NAMESPACE_TOPIC);
-        caPassphrase = Coerce.toString(cdaRuntimeTopics.find(CA_PASSPHRASE));
+        caPassphrase = Coerce.toString(cdaRuntimeTopics.lookup(CA_PASSPHRASE).dflt(""));
+    }
+
+    public void updateCaPassphraseConfig(String newPassphrase) {
+        cdaConfigTopics.lookup(RUNTIME_STORE_NAMESPACE_TOPIC, CA_PASSPHRASE).withValue(newPassphrase);
+        caPassphrase = newPassphrase;
     }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfiguration.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfiguration.java
@@ -11,7 +11,9 @@ import lombok.Getter;
 
 import java.util.List;
 
+import static com.aws.greengrass.clientdevices.auth.ClientDevicesAuthService.AUTHORITIES_TOPIC;
 import static com.aws.greengrass.clientdevices.auth.ClientDevicesAuthService.CA_PASSPHRASE;
+import static com.aws.greengrass.clientdevices.auth.ClientDevicesAuthService.CERTIFICATES_KEY;
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 import static com.aws.greengrass.lifecyclemanager.GreengrassService.RUNTIME_STORE_NAMESPACE_TOPIC;
 
@@ -48,5 +50,10 @@ public class CAConfiguration {
     public void updateCaPassphraseConfig(String newPassphrase) {
         cdaConfigTopics.lookup(RUNTIME_STORE_NAMESPACE_TOPIC, CA_PASSPHRASE).withValue(newPassphrase);
         caPassphrase = newPassphrase;
+    }
+
+    public void updateCaCertificateConfig(List<String> caCertificates) {
+        cdaConfigTopics.lookup(RUNTIME_STORE_NAMESPACE_TOPIC, CERTIFICATES_KEY, AUTHORITIES_TOPIC)
+                .withValue(caCertificates);
     }
 }

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/CertificateManagerTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/CertificateManagerTest.java
@@ -165,28 +165,6 @@ public class CertificateManagerTest {
                 certificateManager.subscribeToCertificateUpdates(null));
     }
 
-//    @Test
-//    void GIVEN_updated_ca_certs_WHEN_updateCACertificateConfig_THEN_cert_topic_updated()
-//            throws InterruptedException, ServiceLoadException, IOException {
-//        startNucleusWithConfig("config.yaml");
-//
-//        ClientDevicesAuthService clientDevicesAuthService =
-//                (ClientDevicesAuthService) kernel.locate(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME);
-//
-//        List<String> expectedCACerts = new ArrayList<>(Arrays.asList("CA1"));
-//        clientDevicesAuthService.updateCACertificateConfig(expectedCACerts);
-//        assertCaCertTopicContains(expectedCACerts);
-//
-//        expectedCACerts.add("CA2");
-//        clientDevicesAuthService.updateCACertificateConfig(expectedCACerts);
-//        assertCaCertTopicContains(expectedCACerts);
-//
-//        expectedCACerts.remove("CA1");
-//        expectedCACerts.add("CA3");
-//        clientDevicesAuthService.updateCACertificateConfig(expectedCACerts);
-//        assertCaCertTopicContains(expectedCACerts);
-//    }
-
     void assertCaCertTopicContains(List<String> expectedCerts) {
         Topic caCertTopic = cdaConfig.lookup(RUNTIME_STORE_NAMESPACE_TOPIC, CERTIFICATES_KEY, AUTHORITIES_TOPIC);
         List<String> caPemList = (List<String>) caCertTopic.toPOJO();

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/CertificateManagerTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/CertificateManagerTest.java
@@ -12,6 +12,7 @@ import com.aws.greengrass.clientdevices.auth.certificate.CISShadowMonitor;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateExpiryMonitor;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateStore;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificatesConfig;
+import com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration;
 import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationException;
 import com.aws.greengrass.clientdevices.auth.iot.ConnectivityInfoProvider;
 import com.aws.greengrass.componentmanager.KernelConfigResolver;
@@ -66,10 +67,11 @@ public class CertificateManagerTest {
     void beforeEach() throws KeyStoreException {
         certificateManager = new CertificateManager(new CertificateStore(tmpPath), mockConnectivityInfoProvider,
                 mockCertExpiryMonitor, mockShadowMonitor, Clock.systemUTC());
-        certificateManager.update("", CertificateStore.CAType.RSA_2048);
-        CertificatesConfig certificatesConfig = new CertificatesConfig(
-                Topics.of(new Context(), KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null));
+        Topics cdaConfig = Topics.of(new Context(), KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null);
+        CertificatesConfig certificatesConfig = new CertificatesConfig(cdaConfig);
         certificateManager.updateCertificatesConfiguration(certificatesConfig);
+        certificateManager.setCAConfiguration(new CAConfiguration(cdaConfig));
+        certificateManager.update();
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthServiceTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthServiceTest.java
@@ -23,7 +23,6 @@ import com.aws.greengrass.mqttclient.spool.SpoolerStoreException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
-import org.hamcrest.collection.IsIterableContainingInAnyOrder;
 import org.hamcrest.collection.IsMapContaining;
 import org.hamcrest.collection.IsMapWithSize;
 import org.junit.jupiter.api.AfterEach;
@@ -51,8 +50,6 @@ import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -228,36 +225,6 @@ class ClientDevicesAuthServiceTest {
             }
         });
         Assertions.assertTrue(countDownLatch.await(TEST_TIME_OUT_SEC, TimeUnit.SECONDS));
-    }
-
-    @Test
-    void GIVEN_updated_ca_certs_WHEN_updateCACertificateConfig_THEN_cert_topic_updated()
-            throws InterruptedException, ServiceLoadException, IOException {
-        startNucleusWithConfig("config.yaml");
-
-        ClientDevicesAuthService clientDevicesAuthService =
-                (ClientDevicesAuthService) kernel.locate(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME);
-
-        List<String> expectedCACerts = new ArrayList<>(Arrays.asList("CA1"));
-        clientDevicesAuthService.updateCACertificateConfig(expectedCACerts);
-        assertCaCertTopicContains(expectedCACerts);
-
-        expectedCACerts.add("CA2");
-        clientDevicesAuthService.updateCACertificateConfig(expectedCACerts);
-        assertCaCertTopicContains(expectedCACerts);
-
-        expectedCACerts.remove("CA1");
-        expectedCACerts.add("CA3");
-        clientDevicesAuthService.updateCACertificateConfig(expectedCACerts);
-        assertCaCertTopicContains(expectedCACerts);
-    }
-
-    void assertCaCertTopicContains(List<String> expectedCerts) {
-        Topic caCertTopic = kernel.findServiceTopic(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME)
-                .lookup("runtime", "certificates", "authorities");
-        List<String> caPemList = (List<String>) caCertTopic.toPOJO();
-        Assertions.assertNotNull(caPemList);
-        assertThat(caPemList, IsIterableContainingInAnyOrder.containsInAnyOrder(expectedCerts.toArray()));
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfigurationTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfigurationTest.java
@@ -91,7 +91,7 @@ public class CAConfigurationTest {
     public void GIVEN_cdaConfiguration_WHEN_getCaPassphrase_THEN_returnsCAPassphrase() {
         configurationTopics.lookup(RUNTIME_STORE_NAMESPACE_TOPIC, CA_PASSPHRASE)
                 .withValue("passphrase");
-        assertThat(caConfiguration.getCaPassphrase(), is(nullValue()));
+        assertThat(caConfiguration.getCaPassphrase(), is(""));
         caConfiguration = new CAConfiguration(configurationTopics);
         assertThat(caConfiguration.getCaPassphrase(), is("passphrase"));
     }

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfigurationTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfigurationTest.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.clientdevices.auth.configuration;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.util.Coerce;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,8 +19,10 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 
+import static com.aws.greengrass.clientdevices.auth.ClientDevicesAuthService.AUTHORITIES_TOPIC;
 import static com.aws.greengrass.clientdevices.auth.ClientDevicesAuthService.CA_PASSPHRASE;
 import static com.aws.greengrass.clientdevices.auth.ClientDevicesAuthService.CA_TYPE_TOPIC;
+import static com.aws.greengrass.clientdevices.auth.ClientDevicesAuthService.CERTIFICATES_KEY;
 import static com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration.CA_CERTIFICATE_URI;
 import static com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration.CA_PRIVATE_KEY_URI;
 import static com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration.CERTIFICATE_AUTHORITY_TOPIC;
@@ -94,6 +97,22 @@ public class CAConfigurationTest {
         assertThat(caConfiguration.getCaPassphrase(), is(""));
         caConfiguration = new CAConfiguration(configurationTopics);
         assertThat(caConfiguration.getCaPassphrase(), is("passphrase"));
+    }
+
+    @Test
+    public void GIVEN_cdaConfiguration_WHEN_updateCaPassphrase_THEN_updateCAPassphraseWithoutReInstantiation() {
+        assertThat(caConfiguration.getCaPassphrase(), is(""));
+        caConfiguration.updateCaPassphraseConfig("newPassphrase");
+        assertThat(caConfiguration.getCaPassphrase(), is("newPassphrase"));
+    }
+
+    @Test
+    public void GIVEN_cdaConfiguration_WHEN_updateCaCerts_THEN_updateCaCertsWithoutReInstantiation() {
+        assertThat(Coerce.toStringList(configurationTopics.lookup(RUNTIME_STORE_NAMESPACE_TOPIC,
+                CERTIFICATES_KEY, AUTHORITIES_TOPIC)), is(Collections.emptyList()));
+        caConfiguration.updateCaCertificateConfig(Arrays.asList("CA_CERT"));
+        assertThat(Coerce.toStringList(configurationTopics.lookup(RUNTIME_STORE_NAMESPACE_TOPIC,
+                CERTIFICATES_KEY, AUTHORITIES_TOPIC)), is(Arrays.asList("CA_CERT")));
     }
 
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Update certificate manager based on CA config object. 
- Synchronize the update operation of certificate manager. 
- Make runtime config keys non-final. 
- Update runtime configuration in certificate manager


Some of these changes will be moved to CertificateStore in the later PRs. 

**Why is this change necessary:**

**How was this change tested:**
Updated tests

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
