### PR TITLE
Extract ca configuration

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -7,17 +7,18 @@ package com.aws.greengrass.clientdevices.auth;
 
 import com.aws.greengrass.authorization.AuthorizationHandler;
 import com.aws.greengrass.clientdevices.auth.api.ClientDevicesAuthServiceApi;
-import com.aws.greengrass.clientdevices.auth.certificate.CertificateStore;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificatesConfig;
+import com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration;
 import com.aws.greengrass.clientdevices.auth.configuration.GroupConfiguration;
 import com.aws.greengrass.clientdevices.auth.configuration.GroupManager;
+import com.aws.greengrass.clientdevices.auth.configuration.RuntimeConfiguration;
 import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
 import com.aws.greengrass.clientdevices.auth.session.MqttSessionFactory;
 import com.aws.greengrass.clientdevices.auth.session.SessionConfig;
 import com.aws.greengrass.clientdevices.auth.session.SessionCreator;
 import com.aws.greengrass.clientdevices.auth.session.SessionManager;
 import com.aws.greengrass.clientdevices.auth.util.ResizableLinkedBlockingQueue;
-import com.aws.greengrass.config.Topic;
+import com.aws.greengrass.config.Node;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.config.WhatHappened;
 import com.aws.greengrass.dependency.ImplementsService;
@@ -28,21 +29,13 @@ import com.aws.greengrass.ipc.SubscribeToCertificateUpdatesOperationHandler;
 import com.aws.greengrass.ipc.VerifyClientDeviceIdentityOperationHandler;
 import com.aws.greengrass.lifecyclemanager.PluginService;
 import com.aws.greengrass.util.Coerce;
-import com.aws.greengrass.util.GreengrassServiceClientFactory;
-import com.aws.greengrass.util.RetryUtils;
-import com.aws.greengrass.util.Utils;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService;
-import software.amazon.awssdk.services.greengrassv2data.model.AccessDeniedException;
-import software.amazon.awssdk.services.greengrassv2data.model.InternalServerException;
-import software.amazon.awssdk.services.greengrassv2data.model.PutCertificateAuthoritiesRequest;
-import software.amazon.awssdk.services.greengrassv2data.model.ThrottlingException;
 
 import java.io.IOException;
 import java.security.KeyStoreException;
 import java.security.cert.CertificateEncodingException;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -64,17 +57,10 @@ public class ClientDevicesAuthService extends PluginService {
     public static final String CLIENT_DEVICES_AUTH_SERVICE_NAME = "aws.greengrass.clientdevices.Auth";
     public static final String DEVICE_GROUPS_TOPICS = "deviceGroups";
     public static final String CA_TYPE_TOPIC = "ca_type";
-    public static final String CA_PASSPHRASE = "ca_passphrase";
-    public static final String CERTIFICATES_KEY = "certificates";
-    public static final String AUTHORITIES_TOPIC = "authorities";
     public static final String PERFORMANCE_TOPIC = "performance";
     public static final String MAX_ACTIVE_AUTH_TOKENS_TOPIC = "maxActiveAuthTokens";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
             .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS, MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES);
-    private static final RetryUtils.RetryConfig SERVICE_EXCEPTION_RETRY_CONFIG =
-            RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofSeconds(3)).maxAttempt(Integer.MAX_VALUE)
-                    .retryableExceptions(uploadCARetryExceptions())
-                    .build();
     public static final String CLOUD_REQUEST_QUEUE_SIZE_TOPIC = "cloudRequestQueueSize";
     public static final String MAX_CONCURRENT_CLOUD_REQUESTS_TOPIC = "maxConcurrentCloudRequests";
 
@@ -82,7 +68,6 @@ public class ClientDevicesAuthService extends PluginService {
 
     private final CertificateManager certificateManager;
 
-    private final GreengrassServiceClientFactory clientFactory;
 
     private final ClientDevicesAuthServiceApi clientDevicesAuthServiceApi;
     private final DeviceConfiguration deviceConfiguration;
@@ -96,13 +81,16 @@ public class ClientDevicesAuthService extends PluginService {
     private final ThreadPoolExecutor cloudCallThreadPool;
     private int cloudCallQueueSize;
 
+    private CAConfiguration caConfiguration;
+    private RuntimeConfiguration runtimeConfiguration;
+
+
     /**
      * Constructor.
      *
      * @param topics                      Root Configuration topic for this service
      * @param groupManager                Group configuration management
      * @param certificateManager          Certificate management
-     * @param clientFactory               Greengrass cloud service client factory
      * @param deviceConfiguration         core device configuration
      * @param authorizationHandler        authorization handler for IPC calls
      * @param greengrassCoreIPCService    core IPC service
@@ -112,8 +100,8 @@ public class ClientDevicesAuthService extends PluginService {
      */
     @SuppressWarnings("PMD.ExcessiveParameterList")
     @Inject
-    public ClientDevicesAuthService(Topics topics, GroupManager groupManager, CertificateManager certificateManager,
-                                    GreengrassServiceClientFactory clientFactory,
+    public ClientDevicesAuthService(Topics topics, GroupManager groupManager,
+                                    CertificateManager certificateManager,
                                     DeviceConfiguration deviceConfiguration,
                                     AuthorizationHandler authorizationHandler,
                                     GreengrassCoreIPCService greengrassCoreIPCService,
@@ -130,13 +118,18 @@ public class ClientDevicesAuthService extends PluginService {
         this.clientDevicesAuthServiceApi = clientDevicesAuthServiceApi;
         this.groupManager = groupManager;
         this.certificateManager = certificateManager;
-        this.clientFactory = clientFactory;
         this.deviceConfiguration = deviceConfiguration;
         this.authorizationHandler = authorizationHandler;
         this.greengrassCoreIPCService = greengrassCoreIPCService;
         SessionCreator.registerSessionFactory("mqtt", mqttSessionFactory);
-        certificateManager.updateCertificatesConfiguration(new CertificatesConfig(this.getConfig()));
-        sessionManager.setSessionConfig(new SessionConfig(this.getConfig()));
+        certificateManager.updateCertificatesConfiguration(new CertificatesConfig(getConfig()));
+        sessionManager.setSessionConfig(new SessionConfig(getConfig()));
+    }
+
+    private void onConfigurationChanged() {
+        runtimeConfiguration = new RuntimeConfiguration(getRuntimeConfig());
+        caConfiguration = new CAConfiguration(getConfig());
+        certificateManager.updateCAConfiguration(caConfiguration);
     }
 
     private int getValidCloudCallQueueSize(Topics topics) {
@@ -161,60 +154,66 @@ public class ClientDevicesAuthService extends PluginService {
      * |    |---- deviceGroups:
      * |         |---- definitions : {}
      * |         |---- policies : {}
-     * |    |---- ca_type: [...]
+     * |    |---- certificateAuthority:
+     * |         |---- privateKeyUri: "..."
+     * |         |---- certificateUri: "..."
+     * |         |---- ca_type: [...]
      * |    |---- certificates: {}
      * |---- runtime
      * |    |---- ca_passphrase: "..."
      * |    |---- certificates:
      * |         |---- authorities: [...]
+     * |
      */
     @Override
     protected void install() throws InterruptedException {
         super.install();
-        configChangeHandler();
+        subscribeToConfigChanges();
     }
 
-    private void configChangeHandler() {
-        this.config.lookupTopics(CONFIGURATION_CONFIG_KEY).subscribe((whatHappened, node) -> {
-            if (whatHappened == WhatHappened.timestampUpdated || whatHappened == WhatHappened.interiorAdded) {
+    private void subscribeToConfigChanges() {
+        onConfigurationChanged();
+        config.lookupTopics(CONFIGURATION_CONFIG_KEY).subscribe(this::configChangeHandler);
+    }
+
+    private void configChangeHandler(WhatHappened whatHappened, Node node) {
+        if (whatHappened == WhatHappened.timestampUpdated || whatHappened == WhatHappened.interiorAdded) {
+            return;
+        }
+        logger.atDebug().kv("why", whatHappened).kv("node", node).log();
+        onConfigurationChanged();
+        Topics deviceGroupTopics = this.config.lookupTopics(CONFIGURATION_CONFIG_KEY, DEVICE_GROUPS_TOPICS);
+
+        // Attempt to update the thread pool size as needed
+        try {
+            int threadPoolSize = Coerce.toInt(this.config.findOrDefault(DEFAULT_THREAD_POOL_SIZE,
+                    CONFIGURATION_CONFIG_KEY, PERFORMANCE_TOPIC, MAX_CONCURRENT_CLOUD_REQUESTS_TOPIC));
+            if (threadPoolSize >= cloudCallThreadPool.getCorePoolSize()) {
+                cloudCallThreadPool.setMaximumPoolSize(threadPoolSize);
+            }
+        } catch (IllegalArgumentException e) {
+            logger.atWarn().log("Unable to update CDA threadpool size due to {}", e.getMessage());
+        }
+
+        if (whatHappened != WhatHappened.initialized && node != null && node.childOf(CLOUD_REQUEST_QUEUE_SIZE_TOPIC)) {
+            BlockingQueue<Runnable> q = cloudCallThreadPool.getQueue();
+            if (q instanceof ResizableLinkedBlockingQueue) {
+                cloudCallQueueSize = getValidCloudCallQueueSize(this.config);
+                ((ResizableLinkedBlockingQueue) q).resize(cloudCallQueueSize);
+            }
+        }
+
+        if (whatHappened == WhatHappened.initialized || node == null) {
+            updateDeviceGroups(whatHappened, deviceGroupTopics);
+            updateCAType();
+        } else if (node.childOf(DEVICE_GROUPS_TOPICS)) {
+            updateDeviceGroups(whatHappened, deviceGroupTopics);
+        } else if (node.childOf(CA_TYPE_TOPIC)) {
+            if (caConfiguration.getCaTypeList().isEmpty()) {
                 return;
             }
-            logger.atDebug().kv("why", whatHappened).kv("node", node).log();
-            Topics deviceGroupTopics = this.config.lookupTopics(CONFIGURATION_CONFIG_KEY, DEVICE_GROUPS_TOPICS);
-            Topic caTypeTopic = this.config.lookup(CONFIGURATION_CONFIG_KEY, CA_TYPE_TOPIC);
-
-            // Attempt to update the thread pool size as needed
-            try {
-                int threadPoolSize = Coerce.toInt(this.config.findOrDefault(DEFAULT_THREAD_POOL_SIZE,
-                        CONFIGURATION_CONFIG_KEY, PERFORMANCE_TOPIC, MAX_CONCURRENT_CLOUD_REQUESTS_TOPIC));
-                if (threadPoolSize >= cloudCallThreadPool.getCorePoolSize()) {
-                    cloudCallThreadPool.setMaximumPoolSize(threadPoolSize);
-                }
-            } catch (IllegalArgumentException e) {
-                logger.atWarn().log("Unable to update CDA threadpool size due to {}", e.getMessage());
-            }
-
-            if (whatHappened != WhatHappened.initialized && node != null
-                    && node.childOf(CLOUD_REQUEST_QUEUE_SIZE_TOPIC)) {
-                BlockingQueue<Runnable> q = cloudCallThreadPool.getQueue();
-                if (q instanceof ResizableLinkedBlockingQueue) {
-                    cloudCallQueueSize = getValidCloudCallQueueSize(this.config);
-                    ((ResizableLinkedBlockingQueue) q).resize(cloudCallQueueSize);
-                }
-            }
-
-            if (whatHappened == WhatHappened.initialized || node == null) {
-                updateDeviceGroups(whatHappened, deviceGroupTopics);
-                updateCAType(caTypeTopic);
-            } else if (node.childOf(DEVICE_GROUPS_TOPICS)) {
-                updateDeviceGroups(whatHappened, deviceGroupTopics);
-            } else if (node.childOf(CA_TYPE_TOPIC)) {
-                if (caTypeTopic.getOnce() == null) {
-                    return;
-                }
-                updateCAType(caTypeTopic);
-            }
-        });
+            updateCAType();
+        }
     }
 
     @Override
@@ -234,12 +233,10 @@ public class ClientDevicesAuthService extends PluginService {
         super.postInject();
         try {
             authorizationHandler.registerComponent(this.getName(),
-                    new HashSet<>(Arrays.asList(new String[]{
-                            SUBSCRIBE_TO_CERTIFICATE_UPDATES,
+                    new HashSet<>(Arrays.asList(SUBSCRIBE_TO_CERTIFICATE_UPDATES,
                             VERIFY_CLIENT_DEVICE_IDENTITY,
                             GET_CLIENT_DEVICE_AUTH_TOKEN,
-                            AUTHORIZE_CLIENT_DEVICE_ACTION
-                    })));
+                            AUTHORIZE_CLIENT_DEVICE_ACTION)));
         } catch (com.aws.greengrass.authorization.exceptions.AuthorizationException e) {
             logger.atError("initialize-cda-service-authorization-error", e)
                     .log("Failed to initialize the client device auth service with the Authorization module.");
@@ -274,50 +271,25 @@ public class ClientDevicesAuthService extends PluginService {
         }
     }
 
-    private void updateCAType(Topic topic) {
+    private void updateCAType() {
+        String thingName = Coerce.toString(deviceConfiguration.getThingName());
         try {
-            List<String> caTypeList = Coerce.toStringList(topic);
-            logger.atDebug().kv("CA type", caTypeList).log("CA type list updated");
+            certificateManager.update(runtimeConfiguration.getCaPassphrase());
+            certificateManager.uploadCoreDeviceCAs(thingName);
 
-            if (Utils.isEmpty(caTypeList)) {
-                logger.atDebug().log("CA type list null or empty. Defaulting to RSA");
-                certificateManager.update(getPassphrase(), CertificateStore.CAType.RSA_2048);
-            } else {
-                if (caTypeList.size() > 1) {
-                    logger.atWarn().log("Only one CA type is supported. Ignoring subsequent CAs in the list.");
-                }
-                String caType = caTypeList.get(0);
-                certificateManager.update(getPassphrase(), CertificateStore.CAType.valueOf(caType));
-            }
-
-            List<String> caCerts = certificateManager.getCACertificates();
-            uploadCoreDeviceCAs(caCerts);
-            updateCACertificateConfig(caCerts);
-            updateCaPassphraseConfig(certificateManager.getCaPassPhrase());
+            runtimeConfiguration.updateCACertificates(certificateManager.getCACertificates());
+            runtimeConfiguration.updateCAPassphrase(certificateManager.getCaPassPhrase());
         } catch (CloudServiceInteractionException e) {
             logger.atError().cause(e)
-                    .kv("coreThingName", deviceConfiguration.getThingName())
+                    .kv("coreThingName", thingName)
                     .log("Unable to upload core CA certificates to the cloud");
-        } catch (KeyStoreException | IOException | CertificateEncodingException | IllegalArgumentException
-                e) {
+        } catch (KeyStoreException | IOException | CertificateEncodingException | IllegalArgumentException e) {
             serviceErrored(e);
         }
     }
 
     void updateCACertificateConfig(List<String> caCerts) {
-        Topic caCertsTopic = getRuntimeConfig().lookup(CERTIFICATES_KEY, AUTHORITIES_TOPIC);
-        caCertsTopic.withValue(caCerts);
-    }
-
-    void updateCaPassphraseConfig(String passphrase) {
-        Topic caPassphrase = getRuntimeConfig().lookup(CA_PASSPHRASE);
-        // TODO: This passphrase needs to be encrypted prior to storing in TLOG
-        caPassphrase.withValue(passphrase);
-    }
-
-    private String getPassphrase() {
-        Topic caPassphrase = getRuntimeConfig().lookup(CA_PASSPHRASE).dflt("");
-        return Coerce.toString(caPassphrase);
+        runtimeConfiguration.updateCACertificates(caCerts);
     }
 
     @Override
@@ -326,31 +298,5 @@ public class ClientDevicesAuthService extends PluginService {
         // and injected in the constructor and we won't be able to restart it after it stops.
         cloudCallThreadPool.shutdown();
         return super.close(waitForDependers);
-    }
-
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
-    private void uploadCoreDeviceCAs(List<String> certificatePemList) {
-        String thingName = Coerce.toString(deviceConfiguration.getThingName());
-        PutCertificateAuthoritiesRequest request =
-                PutCertificateAuthoritiesRequest.builder().coreDeviceThingName(thingName)
-                        .coreDeviceCertificates(certificatePemList).build();
-        try {
-            RetryUtils.runWithRetry(SERVICE_EXCEPTION_RETRY_CONFIG,
-                    () -> clientFactory.getGreengrassV2DataClient().putCertificateAuthorities(request),
-                    "put-core-ca-certificate", logger);
-        } catch (InterruptedException e) {
-            logger.atError().cause(e).log("Put core CA certificates got interrupted");
-            // interrupt the current thread so that higher-level interrupt handlers can take care of it
-            Thread.currentThread().interrupt();
-        } catch (Exception e) {
-            throw new CloudServiceInteractionException("Failed to put core CA certificates to cloud. Check that the "
-                    + "core device's IoT policy grants the greengrass:PutCertificateAuthorities permission.",e);
-        }
-    }
-
-    private static List<Class> uploadCARetryExceptions() {
-        return Arrays.asList(ThrottlingException.class,
-                InternalServerException.class,
-                AccessDeniedException.class);
     }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfiguration.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfiguration.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.configuration;
+
+import com.aws.greengrass.clientdevices.auth.certificate.CertificateStore;
+import com.aws.greengrass.config.Topic;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.util.Coerce;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
+
+/**
+ * Represents the certificateAuthority and ca_type part of the component configuration. Acts as an adapter
+ * from the GG Topics to the domain.
+ * <p>
+ * |---- configuration
+ * |    |---- certificateAuthority:
+ * |          |---- privateKeyUri: "..."
+ * |          |---- certificateUri: "..."
+ * |          |---- ca_type: [...]
+ * </p>
+ */
+public class CAConfiguration {
+    public static final String CA_CERTIFICATE_URI = "certificateUri";
+    public static final String CA_PRIVATE_KEY_URI = "privateKeyUri";
+    public static final String CA_TYPE_KEY = "ca_type";
+    public static final String CERTIFICATE_AUTHORITY_TOPIC = "certificateAuthority";
+    private static final Logger logger = LogManager.getLogger(CAConfiguration.class);
+    private final Topics config;
+
+    public CAConfiguration(Topics config) {
+        this.config = config;
+    }
+
+    private Topics getCAConfigTopics() {
+        return config.lookupTopics(CONFIGURATION_CONFIG_KEY, CERTIFICATE_AUTHORITY_TOPIC);
+    }
+
+    /**
+     * Returns the configuration value for ca_type.
+     */
+    public List<String> getCaTypeList() {
+        Topic caTypeTopic = getCAConfigTopics().lookup(CA_TYPE_KEY);
+
+        if (caTypeTopic.getOnce() == null) {
+            return Collections.emptyList();
+        }
+
+        return Coerce.toStringList(caTypeTopic.getOnce());
+    }
+
+    /**
+     * Returns the certificate type based on the ca_types configuration. If it is empty the type will
+     * default to RSA_2048, otherwise it will use the first value of that list.
+     */
+    public CertificateStore.CAType getCaType() {
+        List<String> caTypeList = getCaTypeList();
+        logger.atDebug().kv("CA type", caTypeList).log("CA type list updated");
+
+        if (caTypeList.isEmpty()) {
+            logger.atDebug().log("CA type list null or empty. Defaulting to RSA");
+            return  CertificateStore.CAType.RSA_2048;
+        }
+
+        if (caTypeList.size() > 1) {
+            logger.atWarn().log("Only one CA type is supported. Ignoring subsequent CAs in the list.");
+        }
+
+        String caType = caTypeList.get(0);
+        return CertificateStore.CAType.valueOf(caType);
+    }
+
+
+    /**
+     * Returns the privateKeyUri value from the configuration.
+     */
+    public String getCaPrivateKeyUri() {
+        Topic privateKeyUriTopic = getCAConfigTopics().find(CA_PRIVATE_KEY_URI);
+        return Coerce.toString(privateKeyUriTopic);
+    }
+
+    /**
+     * Returns the certificateUri from the configuration.
+     */
+    public String getCaCertificateUri() {
+        Topic privateKeyUriTopic = getCAConfigTopics().find(CA_CERTIFICATE_URI);
+        return Coerce.toString(privateKeyUriTopic);
+    }
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/RuntimeConfiguration.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/RuntimeConfiguration.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.configuration;
+
+import com.aws.greengrass.config.Topic;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.util.Coerce;
+
+import java.util.List;
+
+/**
+ * Manages the runtime configuration for the plugin. It allows to read and write
+ * to topics under the runtime key. Acts as an adapter from the GG Runtime Topics to the domain.
+ * <p>
+ * |---- runtime
+ * |    |---- ca_passphrase: "..."
+ * |    |---- certificates:
+ * |         |---- authorities: [...]
+ * |
+ * </p>
+ */
+public final class RuntimeConfiguration {
+    public static final String CA_PASSPHRASE_KEY = "ca_passphrase";
+    private static final String AUTHORITIES_KEY = "authorities";
+    private static final String CERTIFICATES_KEY = "certificates";
+    private final Topics config;
+
+
+    public RuntimeConfiguration(Topics config) {
+        this.config = config;
+    }
+
+    /**
+     * Returns the runtime configuration value for the ca_passphrase.
+     */
+    public String getCaPassphrase() {
+        Topic caPassphrase = config.lookup(CA_PASSPHRASE_KEY).dflt("");
+        return Coerce.toString(caPassphrase);
+    }
+
+    /**
+     * Updates the configuration value for certificates.
+     *
+     * @param caCerts list of caCerts
+     */
+    public void updateCACertificates(List<String> caCerts) {
+        Topic caCertsTopic = config.lookup(CERTIFICATES_KEY, AUTHORITIES_KEY);
+        caCertsTopic.withValue(caCerts);
+    }
+
+    /**
+     * Updates the runtime configuration value for ca_passphrase.
+     *
+     * @param passphrase new passphrase
+     */
+    public void updateCAPassphrase(String passphrase) {
+        Topic caPassphrase = config.lookup(CA_PASSPHRASE_KEY);
+        // TODO: This passphrase needs to be encrypted prior to storing in TLOG
+        caPassphrase.withValue(passphrase);
+    }
+
+}

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/CertificateManagerTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/CertificateManagerTest.java
@@ -5,20 +5,22 @@
 
 package com.aws.greengrass.clientdevices.auth;
 
+import com.aws.greengrass.clientdevices.auth.api.CertificateUpdateEvent;
+import com.aws.greengrass.clientdevices.auth.api.GetCertificateRequest;
+import com.aws.greengrass.clientdevices.auth.api.GetCertificateRequestOptions;
 import com.aws.greengrass.clientdevices.auth.certificate.CISShadowMonitor;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateExpiryMonitor;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateStore;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificatesConfig;
+import com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration;
+import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationException;
 import com.aws.greengrass.clientdevices.auth.iot.ConnectivityInfoProvider;
 import com.aws.greengrass.componentmanager.KernelConfigResolver;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.Context;
-import com.aws.greengrass.clientdevices.auth.api.CertificateUpdateEvent;
-import com.aws.greengrass.clientdevices.auth.api.GetCertificateRequest;
-import com.aws.greengrass.clientdevices.auth.api.GetCertificateRequestOptions;
-import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.TestUtils;
+import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import com.aws.greengrass.util.Pair;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,19 +59,28 @@ public class CertificateManagerTest {
     @Mock
     CISShadowMonitor mockShadowMonitor;
 
+    @Mock
+    GreengrassServiceClientFactory clientFactory;
+
+
     @TempDir
     Path tmpPath;
 
     private CertificateManager certificateManager;
 
     @BeforeEach
-    void beforeEach() throws KeyStoreException {
+    void beforeEach() throws KeyStoreException, CertificateEncodingException, IOException {
         certificateManager = new CertificateManager(new CertificateStore(tmpPath), mockConnectivityInfoProvider,
-                mockCertExpiryMonitor, mockShadowMonitor, Clock.systemUTC());
-        certificateManager.update("", CertificateStore.CAType.RSA_2048);
+                mockCertExpiryMonitor, mockShadowMonitor, Clock.systemUTC(), clientFactory);
+
         CertificatesConfig certificatesConfig = new CertificatesConfig(
                 Topics.of(new Context(), KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null));
+        CAConfiguration caConfiguration = new CAConfiguration(
+                Topics.of(new Context(), KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null));
+
         certificateManager.updateCertificatesConfiguration(certificatesConfig);
+        certificateManager.updateCAConfiguration(caConfiguration);
+        certificateManager.update("");
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthServiceTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthServiceTest.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.clientdevices.auth;
 
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateExpiryMonitor;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateHelper;
+import com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration;
 import com.aws.greengrass.clientdevices.auth.configuration.ConfigurationFormatVersion;
 import com.aws.greengrass.clientdevices.auth.configuration.GroupConfiguration;
 import com.aws.greengrass.clientdevices.auth.configuration.GroupManager;
@@ -311,10 +312,14 @@ class ClientDevicesAuthServiceTest {
 
         kernel.getContext().runOnPublishQueueAndWait(() -> {
             kernel.locate(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME).getConfig()
-                    .lookup(KernelConfigResolver.CONFIGURATION_CONFIG_KEY, ClientDevicesAuthService.CA_TYPE_TOPIC);
+                    .lookup(KernelConfigResolver.CONFIGURATION_CONFIG_KEY,
+                            CAConfiguration.CERTIFICATE_AUTHORITY_TOPIC,
+                            ClientDevicesAuthService.CA_TYPE_TOPIC);
         });
         Topic topic = kernel.locate(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME).getConfig()
-                .lookup(KernelConfigResolver.CONFIGURATION_CONFIG_KEY, ClientDevicesAuthService.CA_TYPE_TOPIC);
+                .lookup(KernelConfigResolver.CONFIGURATION_CONFIG_KEY,
+                        CAConfiguration.CERTIFICATE_AUTHORITY_TOPIC,
+                        ClientDevicesAuthService.CA_TYPE_TOPIC);
         topic.withValue(Collections.singletonList("RSA_2048"));
         // Block until subscriber has finished updating
         kernel.getContext().waitForPublishQueueToClear();

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthServiceTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthServiceTest.java
@@ -12,6 +12,7 @@ import com.aws.greengrass.clientdevices.auth.configuration.ConfigurationFormatVe
 import com.aws.greengrass.clientdevices.auth.configuration.GroupConfiguration;
 import com.aws.greengrass.clientdevices.auth.configuration.GroupManager;
 import com.aws.greengrass.clientdevices.auth.configuration.Permission;
+import com.aws.greengrass.clientdevices.auth.configuration.RuntimeConfiguration;
 import com.aws.greengrass.clientdevices.auth.exception.AuthorizationException;
 import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
 import com.aws.greengrass.componentmanager.KernelConfigResolver;
@@ -61,6 +62,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.RUNTIME_STORE_NAMESPACE_TOPIC;
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
@@ -232,7 +234,7 @@ class ClientDevicesAuthServiceTest {
 
     @Test
     void GIVEN_updated_ca_certs_WHEN_updateCACertificateConfig_THEN_cert_topic_updated()
-            throws InterruptedException, ServiceLoadException, IOException {
+            throws InterruptedException, ServiceLoadException {
         startNucleusWithConfig("config.yaml");
 
         ClientDevicesAuthService clientDevicesAuthService =
@@ -288,7 +290,7 @@ class ClientDevicesAuthServiceTest {
 
     private String getCaPassphrase() {
         Topic caPassphraseTopic = kernel.findServiceTopic(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME)
-                .lookup("runtime", "ca_passphrase");
+                .lookup(RUNTIME_STORE_NAMESPACE_TOPIC, RuntimeConfiguration.CA_PASSPHRASE_KEY);
         return (String) caPassphraseTopic.toPOJO();
     }
 
@@ -314,12 +316,12 @@ class ClientDevicesAuthServiceTest {
             kernel.locate(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME).getConfig()
                     .lookup(KernelConfigResolver.CONFIGURATION_CONFIG_KEY,
                             CAConfiguration.CERTIFICATE_AUTHORITY_TOPIC,
-                            ClientDevicesAuthService.CA_TYPE_TOPIC);
+                            CAConfiguration.CA_TYPE_KEY);
         });
         Topic topic = kernel.locate(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME).getConfig()
                 .lookup(KernelConfigResolver.CONFIGURATION_CONFIG_KEY,
                         CAConfiguration.CERTIFICATE_AUTHORITY_TOPIC,
-                        ClientDevicesAuthService.CA_TYPE_TOPIC);
+                        CAConfiguration.CA_TYPE_KEY);
         topic.withValue(Collections.singletonList("RSA_2048"));
         // Block until subscriber has finished updating
         kernel.getContext().waitForPublishQueueToClear();

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfigurationTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfigurationTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.configuration;
+
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.dependency.Context;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static com.aws.greengrass.clientdevices.auth.ClientDevicesAuthService.CA_TYPE_TOPIC;
+import static com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration.CA_CERTIFICATE_URI;
+import static com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration.CA_PRIVATE_KEY_URI;
+import static com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration.CERTIFICATE_AUTHORITY_TOPIC;
+import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+public class CAConfigurationTest {
+    private Topics configurationTopics;
+
+    @BeforeEach
+    void beforeEach() {
+        configurationTopics = Topics.of(new Context(), CONFIGURATION_CONFIG_KEY, null);
+    }
+
+    @AfterEach
+    void afterEach() throws IOException {
+        configurationTopics.getContext().close();
+    }
+
+    @Test
+    public void GIVEN_cdaDefaultConfiguration_WHEN_getCATypeList_THEN_returnsEmptyList() {
+        CAConfiguration caConfiguration = new CAConfiguration(configurationTopics);
+        assertThat(caConfiguration.getCaTypeList(), is(Collections.emptyList()));
+    }
+
+    @Test
+    public void GIVEN_cdaDefaultConfiguration_WHEN_getCAKeyUri_THEN_returnsNull() {
+        CAConfiguration caConfiguration = new CAConfiguration(configurationTopics);
+        assertThat(caConfiguration.getCaPrivateKeyUri(), is(nullValue()));
+    }
+
+    @Test
+    public void GIVEN_cdaDefaultConfiguration_WHEN_getCACertUri_THEN_returnsNull() {
+        CAConfiguration caConfiguration = new CAConfiguration(configurationTopics);
+        assertThat(caConfiguration.getCaCertificateUri(), is(nullValue()));
+    }
+
+    @Test
+    public void GIVEN_cdaConfiguration_WHEN_getCACertUri_THEN_returnsCACertUri() {
+        CAConfiguration caConfiguration = new CAConfiguration(configurationTopics);
+        assertThat(caConfiguration.getCaCertificateUri(), is(nullValue()));
+        configurationTopics.lookup(CONFIGURATION_CONFIG_KEY, CERTIFICATE_AUTHORITY_TOPIC, CA_CERTIFICATE_URI)
+                .withValue("file:///cert-uri");
+        caConfiguration = new CAConfiguration(configurationTopics);
+        assertThat(caConfiguration.getCaCertificateUri(), is("file:///cert-uri"));
+    }
+
+    @Test
+    public void GIVEN_cdaConfiguration_WHEN_getCAKeyUri_THEN_returnsCACertUri() {
+        CAConfiguration caConfiguration = new CAConfiguration(configurationTopics);
+        assertThat(caConfiguration.getCaPrivateKeyUri(), is(nullValue()));
+        configurationTopics.lookup(CONFIGURATION_CONFIG_KEY, CERTIFICATE_AUTHORITY_TOPIC, CA_PRIVATE_KEY_URI)
+                .withValue("file:///key-uri");
+        caConfiguration = new CAConfiguration(configurationTopics);
+        assertThat(caConfiguration.getCaPrivateKeyUri(), is("file:///key-uri"));
+    }
+
+    @Test
+    public void GIVEN_cdaConfiguration_WHEN_getCATypeList_THEN_returnsCATypeList() {
+        CAConfiguration caConfiguration = new CAConfiguration(configurationTopics);
+        assertThat(caConfiguration.getCaTypeList(), is(Collections.emptyList()));
+        configurationTopics.lookup(CONFIGURATION_CONFIG_KEY, CERTIFICATE_AUTHORITY_TOPIC, CA_TYPE_TOPIC)
+                .withValue(Arrays.asList("RSA_2048","EC_DSA"));
+        caConfiguration = new CAConfiguration(configurationTopics);
+        assertThat(caConfiguration.getCaTypeList(), is(Arrays.asList("RSA_2048","EC_DSA")));
+    }
+}

--- a/src/test/resources/com/aws/greengrass/clientdevices/auth/config_with_ec_ca.yaml
+++ b/src/test/resources/com/aws/greengrass/clientdevices/auth/config_with_ec_ca.yaml
@@ -2,10 +2,10 @@
 services:
   aws.greengrass.clientdevices.Auth:
     configuration:
-      ca_type: ["ECDSA_P256"]
+      certificateAuthority:
+        ca_type: ["ECDSA_P256"]
   main:
     lifecycle:
-      install:
-        all: echo All installed
+      install: ""
     dependencies:
       - aws.greengrass.clientdevices.Auth


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
This PR refactors the `ClientDeviceAuthService` by extracting some of its existing functionality to separate classes. Here is an overview of what changed:

* Moved CA configuration related code to the CAConfiguration which will be responsible for interfacing with topics and extracting the CA configuration values from the topics. (Basically acting as an Adapter)
* Moved the `uploadCoreDeviceCAs` method to the Certificate manager
* Splitted the handler method from the subscription method.

**Why is this change necessary:**
The `ClientDeviceAuthService` should be only be responsible for the plugin lifecycle and logic regarding how to access, update configuration and upload CAs to the cloud is not the responsibility of the `ClientDeviceAuthService`. This will hopefully make things a bit easier to reason about and maintain.

**How was this change tested:**
Given no new additional functionality was introduced (just moved methods around and I did not delete existing apis) the tests covering existing functionality are covering this changes. To test the changes run `mvn test`

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
