### PR TITLE
refactor: extract logic not related to ClientDevicesAuthService to ot…

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/CertificateManager.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/CertificateManager.java
@@ -18,8 +18,17 @@ import com.aws.greengrass.clientdevices.auth.certificate.ClientCertificateGenera
 import com.aws.greengrass.clientdevices.auth.certificate.ServerCertificateGenerator;
 import com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration;
 import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationException;
+import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
 import com.aws.greengrass.clientdevices.auth.iot.ConnectivityInfoProvider;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.util.GreengrassServiceClientFactory;
+import com.aws.greengrass.util.RetryUtils;
 import lombok.NonNull;
+import software.amazon.awssdk.services.greengrassv2data.model.AccessDeniedException;
+import software.amazon.awssdk.services.greengrassv2data.model.InternalServerException;
+import software.amazon.awssdk.services.greengrassv2data.model.PutCertificateAuthoritiesRequest;
+import software.amazon.awssdk.services.greengrassv2data.model.ThrottlingException;
 
 import java.io.IOException;
 import java.security.KeyPair;
@@ -29,6 +38,8 @@ import java.security.PublicKey;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.time.Clock;
+import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -43,9 +54,10 @@ public class CertificateManager {
     private final CISShadowMonitor cisShadowMonitor;
     private final Clock clock;
     private final Map<GetCertificateRequest, CertificateGenerator> certSubscriptions = new ConcurrentHashMap<>();
-    private CertificatesConfig certificatesConfig;
-    @SuppressWarnings("PMD.UnusedPrivateField")
+    private final GreengrassServiceClientFactory clientFactory;
     private CAConfiguration caConfiguration;
+    private CertificatesConfig certificatesConfig;
+    private static final Logger logger = LogManager.getLogger(CAConfiguration.class);
 
 
     /**
@@ -56,41 +68,42 @@ public class CertificateManager {
      * @param certExpiryMonitor        Certificate Expiry Monitor
      * @param cisShadowMonitor         CIS Shadow Monitor
      * @param clock                    clock
+     * @param clientFactory            Greengrass cloud service client factory
      */
     @Inject
     public CertificateManager(CertificateStore certificateStore,
                               ConnectivityInfoProvider connectivityInfoProvider,
                               CertificateExpiryMonitor certExpiryMonitor,
                               CISShadowMonitor cisShadowMonitor,
-                              Clock clock) {
+                              Clock clock,
+                              GreengrassServiceClientFactory clientFactory) {
         this.certificateStore = certificateStore;
         this.connectivityInfoProvider = connectivityInfoProvider;
         this.certExpiryMonitor = certExpiryMonitor;
         this.cisShadowMonitor = cisShadowMonitor;
         this.clock = clock;
+        this.clientFactory = clientFactory;
     }
 
     public void updateCertificatesConfiguration(CertificatesConfig certificatesConfig) {
         this.certificatesConfig = certificatesConfig;
     }
 
-    /**
-     * Update the CA configuration with the latest CDA config.
-     *
-     * @param caConfiguration CA configuration object
-     */
-    public void setCAConfiguration(CAConfiguration caConfiguration) {
+    public void updateCAConfiguration(CAConfiguration caConfiguration) {
         this.caConfiguration = caConfiguration;
     }
 
     /**
      * Initialize the certificate manager.
-     * @param caPassphrase  CA Passphrase
-     * @param caType        CA type
+     *
+     * @param caPassphrase CA Passphrase
      * @throws KeyStoreException if unable to load the CA key store
+     * @throws CertificateEncodingException if unable to get certificate encoding
+     * @throws IOException if unable to write certificate
      */
-    public void update(String caPassphrase, CertificateStore.CAType caType) throws KeyStoreException {
-        certificateStore.update(caPassphrase, caType);
+    public void update(String caPassphrase) throws KeyStoreException,
+            CertificateEncodingException, IOException {
+        certificateStore.update(caPassphrase, caConfiguration.getCaType());
     }
 
     /**
@@ -113,8 +126,8 @@ public class CertificateManager {
      * Return a list of CA certificates used to issue client certs.
      *
      * @return a list of CA certificates for issuing client certs
-     * @throws KeyStoreException if unable to retrieve the certificate
-     * @throws IOException if unable to write certificate
+     * @throws KeyStoreException            if unable to retrieve the certificate
+     * @throws IOException                  if unable to write certificate
      * @throws CertificateEncodingException if unable to get certificate encoding
      */
     public List<String> getCACertificates() throws KeyStoreException, IOException, CertificateEncodingException {
@@ -133,8 +146,8 @@ public class CertificateManager {
      * Subscribe to certificate updates.
      * <p>
      * The certificate manager will save the given request and generate a new certificate under the following scenarios:
-     *   1) The previous certificate is nearing expiry
-     *   2) GGC connectivity information changes (for server certificates only)
+     * 1) The previous certificate is nearing expiry
+     * 2) GGC connectivity information changes (for server certificates only)
      * Certificates will continue to be generated until the client calls unsubscribeFromCertificateUpdates.
      * </p>
      * An initial certificate will be generated and sent to the consumer prior to this function returning.
@@ -240,4 +253,48 @@ public class CertificateManager {
         cisShadowMonitor.removeFromMonitor(gen);
     }
 
+
+    private RetryUtils.RetryConfig getRetryConfig() {
+        List<Class> retriableExceptions = Arrays.asList(
+                ThrottlingException.class,
+                InternalServerException.class,
+                AccessDeniedException.class);
+
+        return RetryUtils.RetryConfig.builder()
+                .initialRetryInterval(Duration.ofSeconds(3))
+                .maxAttempt(Integer.MAX_VALUE)
+                .retryableExceptions(retriableExceptions)
+                .build();
+    }
+
+    /**
+     * Uploads the stored certificates to the cloud.
+     *
+     * @param thingName  Core device name
+     *
+     * @throws CertificateEncodingException  If unable to get certificate encoding
+     * @throws KeyStoreException if unable to retrieve the certificate
+     * @throws IOException If unable to read certificate
+     */
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    public void uploadCoreDeviceCAs(String thingName) throws CertificateEncodingException, KeyStoreException,
+            IOException {
+        List<String> certificatePemList = getCACertificates();
+
+        PutCertificateAuthoritiesRequest request =
+                PutCertificateAuthoritiesRequest.builder().coreDeviceThingName(thingName)
+                        .coreDeviceCertificates(certificatePemList).build();
+        try {
+            RetryUtils.runWithRetry(getRetryConfig(),
+                    () -> clientFactory.getGreengrassV2DataClient().putCertificateAuthorities(request),
+                    "put-core-ca-certificate", logger);
+        } catch (InterruptedException e) {
+            logger.atInfo().log("Put core CA certificates got interrupted");
+            // interrupt the current thread so that higher-level interrupt handlers can take care of it
+            Thread.currentThread().interrupt();
+        } catch (Exception e) {
+            throw new CloudServiceInteractionException("Failed to put core CA certificates to cloud. Check that the "
+                    + "core device's IoT policy grants the greengrass:PutCertificateAuthorities permission.", e);
+        }
+    }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -129,7 +129,7 @@ public class ClientDevicesAuthService extends PluginService {
 
     private void onConfigurationChanged() {
         runtimeConfiguration = new RuntimeConfiguration(getRuntimeConfig());
-        caConfiguration = new CAConfiguration(getConfig());
+        caConfiguration = CAConfiguration.from(getConfig());
         certificateManager.updateCAConfiguration(caConfiguration);
     }
 

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -158,7 +158,7 @@ public class ClientDevicesAuthService extends PluginService {
      * |    |---- certificateAuthority:
      * |         |---- privateKeyUri: "..."
      * |         |---- certificateUri: "..."
-     * |         |---- ca_type: [...]
+     * |         |---- caType: [...]
      * |    |---- certificates: {}
      * |---- runtime
      * |    |---- ca_passphrase: "..."

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -7,18 +7,18 @@ package com.aws.greengrass.clientdevices.auth;
 
 import com.aws.greengrass.authorization.AuthorizationHandler;
 import com.aws.greengrass.clientdevices.auth.api.ClientDevicesAuthServiceApi;
-import com.aws.greengrass.clientdevices.auth.certificate.CertificateStore;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificatesConfig;
 import com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration;
 import com.aws.greengrass.clientdevices.auth.configuration.GroupConfiguration;
 import com.aws.greengrass.clientdevices.auth.configuration.GroupManager;
+import com.aws.greengrass.clientdevices.auth.configuration.RuntimeConfiguration;
 import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
 import com.aws.greengrass.clientdevices.auth.session.MqttSessionFactory;
 import com.aws.greengrass.clientdevices.auth.session.SessionConfig;
 import com.aws.greengrass.clientdevices.auth.session.SessionCreator;
 import com.aws.greengrass.clientdevices.auth.session.SessionManager;
 import com.aws.greengrass.clientdevices.auth.util.ResizableLinkedBlockingQueue;
-import com.aws.greengrass.config.Topic;
+import com.aws.greengrass.config.Node;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.config.WhatHappened;
 import com.aws.greengrass.dependency.ImplementsService;
@@ -29,21 +29,13 @@ import com.aws.greengrass.ipc.SubscribeToCertificateUpdatesOperationHandler;
 import com.aws.greengrass.ipc.VerifyClientDeviceIdentityOperationHandler;
 import com.aws.greengrass.lifecyclemanager.PluginService;
 import com.aws.greengrass.util.Coerce;
-import com.aws.greengrass.util.GreengrassServiceClientFactory;
-import com.aws.greengrass.util.RetryUtils;
-import com.aws.greengrass.util.Utils;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService;
-import software.amazon.awssdk.services.greengrassv2data.model.AccessDeniedException;
-import software.amazon.awssdk.services.greengrassv2data.model.InternalServerException;
-import software.amazon.awssdk.services.greengrassv2data.model.PutCertificateAuthoritiesRequest;
-import software.amazon.awssdk.services.greengrassv2data.model.ThrottlingException;
 
 import java.io.IOException;
 import java.security.KeyStoreException;
 import java.security.cert.CertificateEncodingException;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -53,7 +45,8 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 
-import static com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration.CERTIFICATE_AUTHORITY_TOPIC;
+import static com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration.CA_TYPE_KEY;
+import static com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration.DEPRECATED_CA_TYPE_KEY;
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.AUTHORIZE_CLIENT_DEVICE_ACTION;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.GET_CLIENT_DEVICE_AUTH_TOKEN;
@@ -65,18 +58,10 @@ import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.VER
 public class ClientDevicesAuthService extends PluginService {
     public static final String CLIENT_DEVICES_AUTH_SERVICE_NAME = "aws.greengrass.clientdevices.Auth";
     public static final String DEVICE_GROUPS_TOPICS = "deviceGroups";
-    public static final String CA_TYPE_TOPIC = "ca_type";
-    public static final String CA_PASSPHRASE = "ca_passphrase";
-    public static final String CERTIFICATES_KEY = "certificates";
-    public static final String AUTHORITIES_TOPIC = "authorities";
     public static final String PERFORMANCE_TOPIC = "performance";
     public static final String MAX_ACTIVE_AUTH_TOKENS_TOPIC = "maxActiveAuthTokens";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
             .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS, MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES);
-    private static final RetryUtils.RetryConfig SERVICE_EXCEPTION_RETRY_CONFIG =
-            RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofSeconds(3)).maxAttempt(Integer.MAX_VALUE)
-                    .retryableExceptions(uploadCARetryExceptions())
-                    .build();
     public static final String CLOUD_REQUEST_QUEUE_SIZE_TOPIC = "cloudRequestQueueSize";
     public static final String MAX_CONCURRENT_CLOUD_REQUESTS_TOPIC = "maxConcurrentCloudRequests";
 
@@ -84,7 +69,6 @@ public class ClientDevicesAuthService extends PluginService {
 
     private final CertificateManager certificateManager;
 
-    private final GreengrassServiceClientFactory clientFactory;
 
     private final ClientDevicesAuthServiceApi clientDevicesAuthServiceApi;
     private final DeviceConfiguration deviceConfiguration;
@@ -98,13 +82,16 @@ public class ClientDevicesAuthService extends PluginService {
     private final ThreadPoolExecutor cloudCallThreadPool;
     private int cloudCallQueueSize;
 
+    private CAConfiguration caConfiguration;
+    private RuntimeConfiguration runtimeConfiguration;
+
+
     /**
      * Constructor.
      *
      * @param topics                      Root Configuration topic for this service
      * @param groupManager                Group configuration management
      * @param certificateManager          Certificate management
-     * @param clientFactory               Greengrass cloud service client factory
      * @param deviceConfiguration         core device configuration
      * @param authorizationHandler        authorization handler for IPC calls
      * @param greengrassCoreIPCService    core IPC service
@@ -114,8 +101,8 @@ public class ClientDevicesAuthService extends PluginService {
      */
     @SuppressWarnings("PMD.ExcessiveParameterList")
     @Inject
-    public ClientDevicesAuthService(Topics topics, GroupManager groupManager, CertificateManager certificateManager,
-                                    GreengrassServiceClientFactory clientFactory,
+    public ClientDevicesAuthService(Topics topics, GroupManager groupManager,
+                                    CertificateManager certificateManager,
                                     DeviceConfiguration deviceConfiguration,
                                     AuthorizationHandler authorizationHandler,
                                     GreengrassCoreIPCService greengrassCoreIPCService,
@@ -132,14 +119,18 @@ public class ClientDevicesAuthService extends PluginService {
         this.clientDevicesAuthServiceApi = clientDevicesAuthServiceApi;
         this.groupManager = groupManager;
         this.certificateManager = certificateManager;
-        this.clientFactory = clientFactory;
         this.deviceConfiguration = deviceConfiguration;
         this.authorizationHandler = authorizationHandler;
         this.greengrassCoreIPCService = greengrassCoreIPCService;
         SessionCreator.registerSessionFactory("mqtt", mqttSessionFactory);
-        certificateManager.updateCertificatesConfiguration(new CertificatesConfig(this.getConfig()));
-        sessionManager.setSessionConfig(new SessionConfig(this.getConfig()));
-        certificateManager.setCAConfiguration(new CAConfiguration(this.getConfig()));
+        certificateManager.updateCertificatesConfiguration(new CertificatesConfig(getConfig()));
+        sessionManager.setSessionConfig(new SessionConfig(getConfig()));
+    }
+
+    private void onConfigurationChanged() {
+        runtimeConfiguration = new RuntimeConfiguration(getRuntimeConfig());
+        caConfiguration = new CAConfiguration(getConfig());
+        certificateManager.updateCAConfiguration(caConfiguration);
     }
 
     private int getValidCloudCallQueueSize(Topics topics) {
@@ -164,62 +155,69 @@ public class ClientDevicesAuthService extends PluginService {
      * |    |---- deviceGroups:
      * |         |---- definitions : {}
      * |         |---- policies : {}
-     * |    |---- ca_type: [...]
+     * |    |---- certificateAuthority:
+     * |         |---- privateKeyUri: "..."
+     * |         |---- certificateUri: "..."
+     * |         |---- ca_type: [...]
      * |    |---- certificates: {}
      * |---- runtime
      * |    |---- ca_passphrase: "..."
      * |    |---- certificates:
      * |         |---- authorities: [...]
+     * |
      */
     @Override
     protected void install() throws InterruptedException {
         super.install();
-        configChangeHandler();
+        subscribeToConfigChanges();
     }
 
-    private void configChangeHandler() {
-        this.config.lookupTopics(CONFIGURATION_CONFIG_KEY).subscribe((whatHappened, node) -> {
-            if (whatHappened == WhatHappened.timestampUpdated || whatHappened == WhatHappened.interiorAdded) {
+    private void subscribeToConfigChanges() {
+        onConfigurationChanged();
+        config.lookupTopics(CONFIGURATION_CONFIG_KEY).subscribe(this::configChangeHandler);
+    }
+
+    private void configChangeHandler(WhatHappened whatHappened, Node node) {
+        if (whatHappened == WhatHappened.timestampUpdated || whatHappened == WhatHappened.interiorAdded) {
+            return;
+        }
+        logger.atDebug().kv("why", whatHappened).kv("node", node).log();
+        onConfigurationChanged();
+        // NOTE: This should not live here. The service doesn't have to have knowledge about where/how
+        // keys are stored
+        Topics deviceGroupTopics = this.config.lookupTopics(CONFIGURATION_CONFIG_KEY, DEVICE_GROUPS_TOPICS);
+
+        try {
+            // NOTE: Extract this to a method these are infrastructure concerns.
+            int threadPoolSize = Coerce.toInt(this.config.findOrDefault(DEFAULT_THREAD_POOL_SIZE,
+                    CONFIGURATION_CONFIG_KEY, PERFORMANCE_TOPIC, MAX_CONCURRENT_CLOUD_REQUESTS_TOPIC));
+            if (threadPoolSize >= cloudCallThreadPool.getCorePoolSize()) {
+                cloudCallThreadPool.setMaximumPoolSize(threadPoolSize);
+            }
+        } catch (IllegalArgumentException e) {
+            logger.atWarn().log("Unable to update CDA threadpool size due to {}", e.getMessage());
+        }
+
+        if (whatHappened != WhatHappened.initialized && node != null && node.childOf(CLOUD_REQUEST_QUEUE_SIZE_TOPIC)) {
+            // NOTE: Extract this to a method these are infrastructure concerns.
+            BlockingQueue<Runnable> q = cloudCallThreadPool.getQueue();
+            if (q instanceof ResizableLinkedBlockingQueue) {
+                cloudCallQueueSize = getValidCloudCallQueueSize(this.config);
+                ((ResizableLinkedBlockingQueue) q).resize(cloudCallQueueSize);
+            }
+        }
+
+        if (whatHappened == WhatHappened.initialized || node == null) {
+            updateDeviceGroups(whatHappened, deviceGroupTopics);
+            updateCAType();
+        } else if (node.childOf(DEVICE_GROUPS_TOPICS)) {
+            updateDeviceGroups(whatHappened, deviceGroupTopics);
+        } else if (node.childOf(CA_TYPE_KEY) || node.childOf(DEPRECATED_CA_TYPE_KEY)) {
+            if (caConfiguration.getCaTypeList().isEmpty()) {
                 return;
             }
-            logger.atDebug().kv("why", whatHappened).kv("node", node).log();
-            certificateManager.setCAConfiguration(new CAConfiguration(this.getConfig()));
-            Topics deviceGroupTopics = this.config.lookupTopics(CONFIGURATION_CONFIG_KEY, DEVICE_GROUPS_TOPICS);
-            Topic caTypeTopic = this.config.lookup(CONFIGURATION_CONFIG_KEY, CERTIFICATE_AUTHORITY_TOPIC,
-                    CA_TYPE_TOPIC);
-
-            // Attempt to update the thread pool size as needed
-            try {
-                int threadPoolSize = Coerce.toInt(this.config.findOrDefault(DEFAULT_THREAD_POOL_SIZE,
-                        CONFIGURATION_CONFIG_KEY, PERFORMANCE_TOPIC, MAX_CONCURRENT_CLOUD_REQUESTS_TOPIC));
-                if (threadPoolSize >= cloudCallThreadPool.getCorePoolSize()) {
-                    cloudCallThreadPool.setMaximumPoolSize(threadPoolSize);
-                }
-            } catch (IllegalArgumentException e) {
-                logger.atWarn().log("Unable to update CDA threadpool size due to {}", e.getMessage());
-            }
-
-            if (whatHappened != WhatHappened.initialized && node != null
-                    && node.childOf(CLOUD_REQUEST_QUEUE_SIZE_TOPIC)) {
-                BlockingQueue<Runnable> q = cloudCallThreadPool.getQueue();
-                if (q instanceof ResizableLinkedBlockingQueue) {
-                    cloudCallQueueSize = getValidCloudCallQueueSize(this.config);
-                    ((ResizableLinkedBlockingQueue) q).resize(cloudCallQueueSize);
-                }
-            }
-
-            if (whatHappened == WhatHappened.initialized || node == null) {
-                updateDeviceGroups(whatHappened, deviceGroupTopics);
-                updateCAType(caTypeTopic);
-            } else if (node.childOf(DEVICE_GROUPS_TOPICS)) {
-                updateDeviceGroups(whatHappened, deviceGroupTopics);
-            } else if (node.childOf(CA_TYPE_TOPIC)) {
-                if (caTypeTopic.getOnce() == null) {
-                    return;
-                }
-                updateCAType(caTypeTopic);
-            }
-        });
+            updateCAType();
+        }
     }
 
     @Override
@@ -239,12 +237,10 @@ public class ClientDevicesAuthService extends PluginService {
         super.postInject();
         try {
             authorizationHandler.registerComponent(this.getName(),
-                    new HashSet<>(Arrays.asList(new String[]{
-                            SUBSCRIBE_TO_CERTIFICATE_UPDATES,
+                    new HashSet<>(Arrays.asList(SUBSCRIBE_TO_CERTIFICATE_UPDATES,
                             VERIFY_CLIENT_DEVICE_IDENTITY,
                             GET_CLIENT_DEVICE_AUTH_TOKEN,
-                            AUTHORIZE_CLIENT_DEVICE_ACTION
-                    })));
+                            AUTHORIZE_CLIENT_DEVICE_ACTION)));
         } catch (com.aws.greengrass.authorization.exceptions.AuthorizationException e) {
             logger.atError("initialize-cda-service-authorization-error", e)
                     .log("Failed to initialize the client device auth service with the Authorization module.");
@@ -279,50 +275,29 @@ public class ClientDevicesAuthService extends PluginService {
         }
     }
 
-    private void updateCAType(Topic topic) {
+    private void updateCAType() {
+        // NOTE: This entire method will be moved out of here and will become part of a workflow.
+        String thingName = Coerce.toString(deviceConfiguration.getThingName());
         try {
-            List<String> caTypeList = Coerce.toStringList(topic);
-            logger.atDebug().kv("CA type", caTypeList).log("CA type list updated");
+            certificateManager.update(runtimeConfiguration.getCaPassphrase());
+            // NOTE: uploadCoreDeviceCAs should not block execution.
+            certificateManager.uploadCoreDeviceCAs(thingName);
 
-            if (Utils.isEmpty(caTypeList)) {
-                logger.atDebug().log("CA type list null or empty. Defaulting to RSA");
-                certificateManager.update(getPassphrase(), CertificateStore.CAType.RSA_2048);
-            } else {
-                if (caTypeList.size() > 1) {
-                    logger.atWarn().log("Only one CA type is supported. Ignoring subsequent CAs in the list.");
-                }
-                String caType = caTypeList.get(0);
-                certificateManager.update(getPassphrase(), CertificateStore.CAType.valueOf(caType));
-            }
-
-            List<String> caCerts = certificateManager.getCACertificates();
-            uploadCoreDeviceCAs(caCerts);
-            updateCACertificateConfig(caCerts);
-            updateCaPassphraseConfig(certificateManager.getCaPassPhrase());
+            runtimeConfiguration.updateCACertificates(certificateManager.getCACertificates());
+            runtimeConfiguration.updateCAPassphrase(certificateManager.getCaPassPhrase());
         } catch (CloudServiceInteractionException e) {
             logger.atError().cause(e)
-                    .kv("coreThingName", deviceConfiguration.getThingName())
+                    .kv("coreThingName", thingName)
                     .log("Unable to upload core CA certificates to the cloud");
-        } catch (KeyStoreException | IOException | CertificateEncodingException | IllegalArgumentException
-                e) {
+        } catch (KeyStoreException | IOException | CertificateEncodingException | IllegalArgumentException e) {
             serviceErrored(e);
         }
     }
 
     void updateCACertificateConfig(List<String> caCerts) {
-        Topic caCertsTopic = getRuntimeConfig().lookup(CERTIFICATES_KEY, AUTHORITIES_TOPIC);
-        caCertsTopic.withValue(caCerts);
-    }
-
-    void updateCaPassphraseConfig(String passphrase) {
-        Topic caPassphrase = getRuntimeConfig().lookup(CA_PASSPHRASE);
-        // TODO: This passphrase needs to be encrypted prior to storing in TLOG
-        caPassphrase.withValue(passphrase);
-    }
-
-    private String getPassphrase() {
-        Topic caPassphrase = getRuntimeConfig().lookup(CA_PASSPHRASE).dflt("");
-        return Coerce.toString(caPassphrase);
+        // NOTE: This shouldn't exist - This is just being exposed for test shouldn't be
+        // public API
+        runtimeConfiguration.updateCACertificates(caCerts);
     }
 
     @Override
@@ -331,31 +306,5 @@ public class ClientDevicesAuthService extends PluginService {
         // and injected in the constructor and we won't be able to restart it after it stops.
         cloudCallThreadPool.shutdown();
         return super.close(waitForDependers);
-    }
-
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
-    private void uploadCoreDeviceCAs(List<String> certificatePemList) {
-        String thingName = Coerce.toString(deviceConfiguration.getThingName());
-        PutCertificateAuthoritiesRequest request =
-                PutCertificateAuthoritiesRequest.builder().coreDeviceThingName(thingName)
-                        .coreDeviceCertificates(certificatePemList).build();
-        try {
-            RetryUtils.runWithRetry(SERVICE_EXCEPTION_RETRY_CONFIG,
-                    () -> clientFactory.getGreengrassV2DataClient().putCertificateAuthorities(request),
-                    "put-core-ca-certificate", logger);
-        } catch (InterruptedException e) {
-            logger.atError().cause(e).log("Put core CA certificates got interrupted");
-            // interrupt the current thread so that higher-level interrupt handlers can take care of it
-            Thread.currentThread().interrupt();
-        } catch (Exception e) {
-            throw new CloudServiceInteractionException("Failed to put core CA certificates to cloud. Check that the "
-                    + "core device's IoT policy grants the greengrass:PutCertificateAuthorities permission.",e);
-        }
-    }
-
-    private static List<Class> uploadCARetryExceptions() {
-        return Arrays.asList(ThrottlingException.class,
-                InternalServerException.class,
-                AccessDeniedException.class);
     }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfiguration.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfiguration.java
@@ -5,41 +5,112 @@
 
 package com.aws.greengrass.clientdevices.auth.configuration;
 
+import com.aws.greengrass.clientdevices.auth.certificate.CertificateStore;
+import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.util.Coerce;
-import lombok.Getter;
 
+import java.util.Collections;
 import java.util.List;
 
-import static com.aws.greengrass.clientdevices.auth.ClientDevicesAuthService.CA_PASSPHRASE;
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
-import static com.aws.greengrass.lifecyclemanager.GreengrassService.RUNTIME_STORE_NAMESPACE_TOPIC;
 
-@Getter
-@SuppressWarnings("PMD.DataClass")
+/**
+ * Represents the certificateAuthority and ca_type part of the component configuration. Acts as an adapter
+ * from the GG Topics to the domain.
+ * <p>
+ * |---- configuration
+ * |    |---- certificateAuthority:
+ * |          |---- privateKeyUri: "..."
+ * |          |---- certificateUri: "..."
+ * |          |---- ca_type: [...]
+ * </p>
+ */
 public class CAConfiguration {
-    public static final String CERTIFICATE_AUTHORITY_TOPIC = "certificateAuthority";
     public static final String CA_CERTIFICATE_URI = "certificateUri";
     public static final String CA_PRIVATE_KEY_URI = "privateKeyUri";
-    public static final String CA_TYPE_TOPIC = "ca_type";
-    private final String caPrivateKeyUri;
-    private final String caCertificateUri;
-    private final List<String> caTypeList;
-    private final String caPassphrase;
+    public static final String DEPRECATED_CA_TYPE_KEY = "ca_type";
+    public static final String CA_TYPE_KEY = "caType";
+    public static final String CERTIFICATE_AUTHORITY_TOPIC = "certificateAuthority";
+    private static final Logger logger = LogManager.getLogger(CAConfiguration.class);
+    private final Topics config;
 
     /**
-     * Creates CA configuration object with the latest CDA config.
+     * Update the CA configuration with the latest CDA config.
      *
-     * @param cdaConfigTopics CDA service configuration topics
+     * @param config CA configuration object
      */
-    public CAConfiguration(Topics cdaConfigTopics) {
-        Topics certificateAuthorityTopics = cdaConfigTopics.lookupTopics(CONFIGURATION_CONFIG_KEY,
-                CERTIFICATE_AUTHORITY_TOPIC);
-        caPrivateKeyUri = Coerce.toString(certificateAuthorityTopics.find(CA_PRIVATE_KEY_URI));
-        caCertificateUri = Coerce.toString(certificateAuthorityTopics.find(CA_CERTIFICATE_URI));
-        caTypeList = Coerce.toStringList(certificateAuthorityTopics.find(CA_TYPE_TOPIC));
+    public CAConfiguration(Topics config) {
+        // NOTE: Validate topics schema upon initialization. Better to fail fast if there is
+        // something wrong
+        this.config = config;
+    }
 
-        Topics cdaRuntimeTopics = cdaConfigTopics.lookupTopics(RUNTIME_STORE_NAMESPACE_TOPIC);
-        caPassphrase = Coerce.toString(cdaRuntimeTopics.find(CA_PASSPHRASE));
+    private Topics getCAConfigTopics() {
+        return config.lookupTopics(CONFIGURATION_CONFIG_KEY, CERTIFICATE_AUTHORITY_TOPIC);
+    }
+
+    /**
+     * Returns the configuration value for ca_type.
+     */
+    public List<String> getCaTypeList() {
+        // NOTE: This should be a list of CertificateStore.CAType and not any random Strings
+        Topic caTypeTopic = getCAConfigTopics().lookup(CA_TYPE_KEY);
+        if (caTypeTopic.getOnce() != null) {
+            return Coerce.toStringList(caTypeTopic.getOnce());
+        }
+
+        // NOTE: Ensure backwards compat with v.2.2.2 we are moving the ca_type key to be under
+        // certificateAuthority and changing its name to caType. (ONLY REMOVE AFTER IT IS SAFE)
+        Topic deprecatedCaTypeTopic = config.lookup(CONFIGURATION_CONFIG_KEY, DEPRECATED_CA_TYPE_KEY);
+        if (deprecatedCaTypeTopic.getOnce() != null) {
+            return Coerce.toStringList(deprecatedCaTypeTopic.getOnce());
+        }
+
+        return Collections.emptyList();
+    }
+
+    /**
+     * Returns the certificate type based on the ca_types configuration. If it is empty the type will
+     * default to RSA_2048, otherwise it will use the first value of that list.
+     */
+    public CertificateStore.CAType getCaType() {
+        List<String> caTypeList = getCaTypeList();
+        logger.atDebug().kv("CA type", caTypeList).log("CA type list updated");
+
+        if (caTypeList.isEmpty()) {
+            logger.atDebug().log("CA type list null or empty. Defaulting to RSA");
+            return  CertificateStore.CAType.RSA_2048;
+        }
+
+        if (caTypeList.size() > 1) {
+            logger.atWarn().log("Only one CA type is supported. Ignoring subsequent CAs in the list.");
+        }
+
+        String caType = caTypeList.get(0);
+        return CertificateStore.CAType.valueOf(caType);
+    }
+
+
+    /**
+     * Returns the privateKeyUri value from the configuration.
+     */
+    public String getCaPrivateKeyUri() {
+        // NOTE: Parse the key to ensure it is a valid URI
+        //  before returning it
+        Topic privateKeyUriTopic = getCAConfigTopics().find(CA_PRIVATE_KEY_URI);
+        return Coerce.toString(privateKeyUriTopic);
+    }
+
+    /**
+     * Returns the certificateUri from the configuration.
+     */
+    public String getCaCertificateUri() {
+        // NOTE: Parse the key to ensure it is a valid URI
+        //  before returning it
+        Topic privateKeyUriTopic = getCAConfigTopics().find(CA_CERTIFICATE_URI);
+        return Coerce.toString(privateKeyUriTopic);
     }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfiguration.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfiguration.java
@@ -25,7 +25,7 @@ import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURA
  * |    |---- certificateAuthority:
  * |          |---- privateKeyUri: "..."
  * |          |---- certificateUri: "..."
- * |          |---- ca_type: [...]
+ * |          |---- caType: [...]
  * </p>
  */
 public class CAConfiguration {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/RuntimeConfiguration.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/RuntimeConfiguration.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.configuration;
+
+import com.aws.greengrass.config.Topic;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.util.Coerce;
+
+import java.util.List;
+
+/**
+ * Manages the runtime configuration for the plugin. It allows to read and write
+ * to topics under the runtime key. Acts as an adapter from the GG Runtime Topics to the domain.
+ * <p>
+ * |---- runtime
+ * |    |---- ca_passphrase: "..."
+ * |    |---- certificates:
+ * |         |---- authorities: [...]
+ * |
+ * </p>
+ */
+public final class RuntimeConfiguration {
+    public static final String CA_PASSPHRASE_KEY = "ca_passphrase";
+    private static final String AUTHORITIES_KEY = "authorities";
+    private static final String CERTIFICATES_KEY = "certificates";
+    private final Topics config;
+
+
+    public RuntimeConfiguration(Topics config) {
+        this.config = config;
+    }
+
+    /**
+     * Returns the runtime configuration value for the ca_passphrase.
+     */
+    public String getCaPassphrase() {
+        Topic caPassphrase = config.lookup(CA_PASSPHRASE_KEY).dflt("");
+        return Coerce.toString(caPassphrase);
+    }
+
+    /**
+     * Updates the configuration value for certificates.
+     *
+     * @param caCerts list of caCerts
+     */
+    public void updateCACertificates(List<String> caCerts) {
+        Topic caCertsTopic = config.lookup(CERTIFICATES_KEY, AUTHORITIES_KEY);
+        caCertsTopic.withValue(caCerts);
+    }
+
+    /**
+     * Updates the runtime configuration value for ca_passphrase.
+     *
+     * @param passphrase new passphrase
+     */
+    public void updateCAPassphrase(String passphrase) {
+        Topic caPassphrase = config.lookup(CA_PASSPHRASE_KEY);
+        // TODO: This passphrase needs to be encrypted prior to storing in TLOG
+        caPassphrase.withValue(passphrase);
+    }
+
+}

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/CertificateManagerTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/CertificateManagerTest.java
@@ -12,6 +12,7 @@ import com.aws.greengrass.clientdevices.auth.certificate.CISShadowMonitor;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateExpiryMonitor;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateStore;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificatesConfig;
+import com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration;
 import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationException;
 import com.aws.greengrass.clientdevices.auth.iot.ConnectivityInfoProvider;
 import com.aws.greengrass.componentmanager.KernelConfigResolver;
@@ -19,6 +20,7 @@ import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.TestUtils;
+import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import com.aws.greengrass.util.Pair;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,19 +59,28 @@ public class CertificateManagerTest {
     @Mock
     CISShadowMonitor mockShadowMonitor;
 
+    @Mock
+    GreengrassServiceClientFactory clientFactory;
+
+
     @TempDir
     Path tmpPath;
 
     private CertificateManager certificateManager;
 
     @BeforeEach
-    void beforeEach() throws KeyStoreException {
+    void beforeEach() throws KeyStoreException, CertificateEncodingException, IOException {
         certificateManager = new CertificateManager(new CertificateStore(tmpPath), mockConnectivityInfoProvider,
-                mockCertExpiryMonitor, mockShadowMonitor, Clock.systemUTC());
-        certificateManager.update("", CertificateStore.CAType.RSA_2048);
+                mockCertExpiryMonitor, mockShadowMonitor, Clock.systemUTC(), clientFactory);
+
         CertificatesConfig certificatesConfig = new CertificatesConfig(
                 Topics.of(new Context(), KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null));
+        CAConfiguration caConfiguration = new CAConfiguration(
+                Topics.of(new Context(), KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null));
+
         certificateManager.updateCertificatesConfiguration(certificatesConfig);
+        certificateManager.updateCAConfiguration(caConfiguration);
+        certificateManager.update("");
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/CertificateManagerTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/CertificateManagerTest.java
@@ -75,7 +75,7 @@ public class CertificateManagerTest {
 
         CertificatesConfig certificatesConfig = new CertificatesConfig(
                 Topics.of(new Context(), KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null));
-        CAConfiguration caConfiguration = new CAConfiguration(
+        CAConfiguration caConfiguration = CAConfiguration.from(
                 Topics.of(new Context(), KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null));
 
         certificateManager.updateCertificatesConfiguration(certificatesConfig);

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfigurationTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfigurationTest.java
@@ -45,50 +45,51 @@ public class CAConfigurationTest {
 
     @Test
     public void GIVEN_cdaDefaultConfiguration_WHEN_getCATypeList_THEN_returnsEmptyList() {
-        CAConfiguration caConfiguration = new CAConfiguration(configurationTopics);
+        CAConfiguration caConfiguration = CAConfiguration.from(configurationTopics);
         assertThat(caConfiguration.getCaTypeList(), is(Collections.emptyList()));
     }
 
     @Test
     public void GIVEN_cdaDefaultConfiguration_WHEN_getCAKeyUri_THEN_returnsNull() {
-        CAConfiguration caConfiguration = new CAConfiguration(configurationTopics);
-        assertThat(caConfiguration.getCaPrivateKeyUri(), is(nullValue()));
+        CAConfiguration caConfiguration = CAConfiguration.from(configurationTopics);
+        assertThat(caConfiguration.getPrivateKeyUri(), is(nullValue()));
     }
 
     @Test
     public void GIVEN_cdaDefaultConfiguration_WHEN_getCACertUri_THEN_returnsNull() {
-        CAConfiguration caConfiguration = new CAConfiguration(configurationTopics);
-        assertThat(caConfiguration.getCaCertificateUri(), is(nullValue()));
+        CAConfiguration caConfiguration = CAConfiguration.from(configurationTopics);
+        assertThat(caConfiguration.getCertificateUri(), is(nullValue()));
     }
 
     @Test
     public void GIVEN_cdaConfiguration_WHEN_getCACertUri_THEN_returnsCACertUri() {
-        CAConfiguration caConfiguration = new CAConfiguration(configurationTopics);
-        assertThat(caConfiguration.getCaCertificateUri(), is(nullValue()));
+        CAConfiguration caConfiguration = CAConfiguration.from(configurationTopics);
+        assertThat(caConfiguration.getCertificateUri(), is(nullValue()));
         configurationTopics.lookup(CONFIGURATION_CONFIG_KEY, CERTIFICATE_AUTHORITY_TOPIC, CA_CERTIFICATE_URI)
                 .withValue("file:///cert-uri");
-        caConfiguration = new CAConfiguration(configurationTopics);
-        assertThat(caConfiguration.getCaCertificateUri(), is("file:///cert-uri"));
+        caConfiguration = CAConfiguration.from(configurationTopics);
+        assertThat(caConfiguration.getCertificateUri(), is("file:///cert-uri"));
     }
 
     @Test
     public void GIVEN_cdaConfiguration_WHEN_getCAKeyUri_THEN_returnsCACertUri() {
-        CAConfiguration caConfiguration = new CAConfiguration(configurationTopics);
-        assertThat(caConfiguration.getCaPrivateKeyUri(), is(nullValue()));
+        CAConfiguration caConfiguration = CAConfiguration.from(configurationTopics);
+        assertThat(caConfiguration.getPrivateKeyUri(), is(nullValue()));
         configurationTopics.lookup(CONFIGURATION_CONFIG_KEY, CERTIFICATE_AUTHORITY_TOPIC, CA_PRIVATE_KEY_URI)
                 .withValue("file:///key-uri");
-        caConfiguration = new CAConfiguration(configurationTopics);
-        assertThat(caConfiguration.getCaPrivateKeyUri(), is("file:///key-uri"));
+        caConfiguration = CAConfiguration.from(configurationTopics);
+        assertThat(caConfiguration.getPrivateKeyUri(), is("file:///key-uri"));
     }
 
     @Test
     public void GIVEN_cdaConfiguration_WHEN_getCATypeList_THEN_returnsCATypeList() {
-        CAConfiguration caConfiguration = new CAConfiguration(configurationTopics);
-        assertThat(caConfiguration.getCaTypeList(), is(Collections.emptyList()));
         configurationTopics.lookup(CONFIGURATION_CONFIG_KEY, CERTIFICATE_AUTHORITY_TOPIC, CA_TYPE_KEY)
                 .withValue(Arrays.asList("RSA_2048","ECDSA_P256"));
-        caConfiguration = new CAConfiguration(configurationTopics);
+        CAConfiguration caConfiguration = CAConfiguration.from(configurationTopics);
+        caConfiguration = CAConfiguration.from(configurationTopics);
+        assertThat(caConfiguration.getCaType(), is(CertificateStore.CAType.RSA_2048));
         assertThat(caConfiguration.getCaTypeList(), is(Arrays.asList("RSA_2048","ECDSA_P256")));
+
     }
 
     @Test
@@ -97,9 +98,10 @@ public class CAConfigurationTest {
         // we are changing how/where ca_type is stored
         configurationTopics.lookup(CONFIGURATION_CONFIG_KEY, DEPRECATED_CA_TYPE_KEY)
                 .withValue(Arrays.asList("ECDSA_P256"));
-        CAConfiguration caConfiguration = new CAConfiguration(configurationTopics);
+        CAConfiguration caConfiguration = CAConfiguration.from(configurationTopics);
         assertThat(caConfiguration.getCaType(), is(CertificateStore.CAType.ECDSA_P256));
         assertThat(caConfiguration.getCaTypeList(), is(Arrays.asList("ECDSA_P256")));
+
     }
 
     @Test
@@ -110,8 +112,9 @@ public class CAConfigurationTest {
         // New path - post v.2.2.2
         configurationTopics.lookup(CONFIGURATION_CONFIG_KEY, CERTIFICATE_AUTHORITY_TOPIC, CA_TYPE_KEY)
                 .withValue(Arrays.asList("RSA_2048"));
-        CAConfiguration caConfiguration = new CAConfiguration(configurationTopics);
+        CAConfiguration caConfiguration = CAConfiguration.from(configurationTopics);
         assertThat(caConfiguration.getCaType(), is(CertificateStore.CAType.RSA_2048));
         assertThat(caConfiguration.getCaTypeList(), is(Arrays.asList("RSA_2048")));
+
     }
 }

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfigurationTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfigurationTest.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.clientdevices.auth.configuration;
 
+import com.aws.greengrass.clientdevices.auth.certificate.CertificateStore;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
@@ -18,13 +19,12 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 
-import static com.aws.greengrass.clientdevices.auth.ClientDevicesAuthService.CA_PASSPHRASE;
-import static com.aws.greengrass.clientdevices.auth.ClientDevicesAuthService.CA_TYPE_TOPIC;
 import static com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration.CA_CERTIFICATE_URI;
 import static com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration.CA_PRIVATE_KEY_URI;
+import static com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration.CA_TYPE_KEY;
 import static com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration.CERTIFICATE_AUTHORITY_TOPIC;
+import static com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration.DEPRECATED_CA_TYPE_KEY;
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
-import static com.aws.greengrass.lifecyclemanager.GreengrassService.RUNTIME_STORE_NAMESPACE_TOPIC;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -32,12 +32,10 @@ import static org.hamcrest.Matchers.nullValue;
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 public class CAConfigurationTest {
     private Topics configurationTopics;
-    private CAConfiguration caConfiguration;
 
     @BeforeEach
     void beforeEach() {
         configurationTopics = Topics.of(new Context(), CONFIGURATION_CONFIG_KEY, null);
-        caConfiguration = new CAConfiguration(configurationTopics);
     }
 
     @AfterEach
@@ -47,53 +45,73 @@ public class CAConfigurationTest {
 
     @Test
     public void GIVEN_cdaDefaultConfiguration_WHEN_getCATypeList_THEN_returnsEmptyList() {
+        CAConfiguration caConfiguration = new CAConfiguration(configurationTopics);
         assertThat(caConfiguration.getCaTypeList(), is(Collections.emptyList()));
     }
 
     @Test
     public void GIVEN_cdaDefaultConfiguration_WHEN_getCAKeyUri_THEN_returnsNull() {
+        CAConfiguration caConfiguration = new CAConfiguration(configurationTopics);
         assertThat(caConfiguration.getCaPrivateKeyUri(), is(nullValue()));
     }
 
     @Test
     public void GIVEN_cdaDefaultConfiguration_WHEN_getCACertUri_THEN_returnsNull() {
+        CAConfiguration caConfiguration = new CAConfiguration(configurationTopics);
         assertThat(caConfiguration.getCaCertificateUri(), is(nullValue()));
     }
 
     @Test
     public void GIVEN_cdaConfiguration_WHEN_getCACertUri_THEN_returnsCACertUri() {
+        CAConfiguration caConfiguration = new CAConfiguration(configurationTopics);
+        assertThat(caConfiguration.getCaCertificateUri(), is(nullValue()));
         configurationTopics.lookup(CONFIGURATION_CONFIG_KEY, CERTIFICATE_AUTHORITY_TOPIC, CA_CERTIFICATE_URI)
                 .withValue("file:///cert-uri");
-        assertThat(caConfiguration.getCaCertificateUri(), is(nullValue()));
         caConfiguration = new CAConfiguration(configurationTopics);
         assertThat(caConfiguration.getCaCertificateUri(), is("file:///cert-uri"));
     }
 
     @Test
     public void GIVEN_cdaConfiguration_WHEN_getCAKeyUri_THEN_returnsCACertUri() {
+        CAConfiguration caConfiguration = new CAConfiguration(configurationTopics);
+        assertThat(caConfiguration.getCaPrivateKeyUri(), is(nullValue()));
         configurationTopics.lookup(CONFIGURATION_CONFIG_KEY, CERTIFICATE_AUTHORITY_TOPIC, CA_PRIVATE_KEY_URI)
                 .withValue("file:///key-uri");
-        assertThat(caConfiguration.getCaPrivateKeyUri(), is(nullValue()));
         caConfiguration = new CAConfiguration(configurationTopics);
         assertThat(caConfiguration.getCaPrivateKeyUri(), is("file:///key-uri"));
     }
 
     @Test
     public void GIVEN_cdaConfiguration_WHEN_getCATypeList_THEN_returnsCATypeList() {
-        configurationTopics.lookup(CONFIGURATION_CONFIG_KEY, CERTIFICATE_AUTHORITY_TOPIC, CA_TYPE_TOPIC)
-                .withValue(Arrays.asList("RSA_2048","EC_DSA"));
+        CAConfiguration caConfiguration = new CAConfiguration(configurationTopics);
         assertThat(caConfiguration.getCaTypeList(), is(Collections.emptyList()));
+        configurationTopics.lookup(CONFIGURATION_CONFIG_KEY, CERTIFICATE_AUTHORITY_TOPIC, CA_TYPE_KEY)
+                .withValue(Arrays.asList("RSA_2048","ECDSA_P256"));
         caConfiguration = new CAConfiguration(configurationTopics);
-        assertThat(caConfiguration.getCaTypeList(), is(Arrays.asList("RSA_2048","EC_DSA")));
+        assertThat(caConfiguration.getCaTypeList(), is(Arrays.asList("RSA_2048","ECDSA_P256")));
     }
 
     @Test
-    public void GIVEN_cdaConfiguration_WHEN_getCaPassphrase_THEN_returnsCAPassphrase() {
-        configurationTopics.lookup(RUNTIME_STORE_NAMESPACE_TOPIC, CA_PASSPHRASE)
-                .withValue("passphrase");
-        assertThat(caConfiguration.getCaPassphrase(), is(nullValue()));
-        caConfiguration = new CAConfiguration(configurationTopics);
-        assertThat(caConfiguration.getCaPassphrase(), is("passphrase"));
+    public void GIVEN_oldCdaConfiguration_WHEN_reading_ca_type_THEN_returns_ca_type() {
+        // NOTE: This test is to ensure we are backwards compatible with the v.2.2.2
+        // we are changing how/where ca_type is stored
+        configurationTopics.lookup(CONFIGURATION_CONFIG_KEY, DEPRECATED_CA_TYPE_KEY)
+                .withValue(Arrays.asList("ECDSA_P256"));
+        CAConfiguration caConfiguration = new CAConfiguration(configurationTopics);
+        assertThat(caConfiguration.getCaType(), is(CertificateStore.CAType.ECDSA_P256));
+        assertThat(caConfiguration.getCaTypeList(), is(Arrays.asList("ECDSA_P256")));
     }
 
+    @Test
+    public void GIVEN_oldCdaConfiguration_and_newCdaConfiguration_WHEN_reading_caType_THEN_newValueRead() {
+        // Old path - pre v.2.2.2
+        configurationTopics.lookup(CONFIGURATION_CONFIG_KEY, DEPRECATED_CA_TYPE_KEY)
+                .withValue(Arrays.asList("ECDSA_P256"));
+        // New path - post v.2.2.2
+        configurationTopics.lookup(CONFIGURATION_CONFIG_KEY, CERTIFICATE_AUTHORITY_TOPIC, CA_TYPE_KEY)
+                .withValue(Arrays.asList("RSA_2048"));
+        CAConfiguration caConfiguration = new CAConfiguration(configurationTopics);
+        assertThat(caConfiguration.getCaType(), is(CertificateStore.CAType.RSA_2048));
+        assertThat(caConfiguration.getCaTypeList(), is(Arrays.asList("RSA_2048")));
+    }
 }

--- a/src/test/resources/com/aws/greengrass/clientdevices/auth/config_with_ec_ca.yaml
+++ b/src/test/resources/com/aws/greengrass/clientdevices/auth/config_with_ec_ca.yaml
@@ -3,7 +3,7 @@ services:
   aws.greengrass.clientdevices.Auth:
     configuration:
       certificateAuthority:
-        ca_type: ["ECDSA_P256"]
+        caType: ["ECDSA_P256"]
   main:
     lifecycle:
       install: ""


### PR DESCRIPTION
**Description of changes:**
This PR refactors the `ClientDeviceAuthService` by extracting some of its existing functionality to separate classes. Here is an overview of what changed:

* Moved CA configuration related code to `CAConfiguration` which will be responsible for interfacing with topics and extracting the CA configuration values from the topics. (Basically acting as an Adapter)
* Moved runtime related configuration to `RuntimeConfiguration`
* Moved the `uploadCoreDeviceCAs` method to the Certificate manager
* Splitted the handler method from the subscription method on the `ClientAuthService`

**Why is this change necessary:**
The `ClientDeviceAuthService` should be only be responsible for the plugin lifecycle and logic regarding how to access, update configuration and upload CAs to the cloud is not the responsibility of the `ClientDeviceAuthService`. This will hopefully make things a bit easier to reason about and maintain.

**How was this change tested:**
Ensure old test are still passing since I just moved classes around and wrote new tests to cover the few tweaks made to ensure we are backwards compatible with the changes being introduced to `ca_type`

