### PR TITLE
feat: support configurable CA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,13 +73,13 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.7.0-SNAPSHOT</version>
+            <version>2.8.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.7.0-SNAPSHOT</version>
+            <version>2.8.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -73,13 +73,13 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.6.0-SNAPSHOT</version>
+            <version>2.7.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.6.0-SNAPSHOT</version>
+            <version>2.7.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -12,7 +12,6 @@ import com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration;
 import com.aws.greengrass.clientdevices.auth.configuration.GroupConfiguration;
 import com.aws.greengrass.clientdevices.auth.configuration.GroupManager;
 import com.aws.greengrass.clientdevices.auth.configuration.RuntimeConfiguration;
-import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
 import com.aws.greengrass.clientdevices.auth.session.MqttSessionFactory;
 import com.aws.greengrass.clientdevices.auth.session.SessionConfig;
 import com.aws.greengrass.clientdevices.auth.session.SessionCreator;
@@ -33,9 +32,7 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService;
 
-import java.io.IOException;
-import java.security.KeyStoreException;
-import java.security.cert.CertificateEncodingException;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -127,11 +124,7 @@ public class ClientDevicesAuthService extends PluginService {
         sessionManager.setSessionConfig(new SessionConfig(getConfig()));
     }
 
-    private void onConfigurationChanged() {
-        runtimeConfiguration = new RuntimeConfiguration(getRuntimeConfig());
-        caConfiguration = CAConfiguration.from(getConfig());
-        certificateManager.updateCAConfiguration(caConfiguration);
-    }
+
 
     private int getValidCloudCallQueueSize(Topics topics) {
         int newSize = Coerce.toInt(
@@ -177,6 +170,17 @@ public class ClientDevicesAuthService extends PluginService {
         config.lookupTopics(CONFIGURATION_CONFIG_KEY).subscribe(this::configChangeHandler);
     }
 
+    private void onConfigurationChanged() {
+        runtimeConfiguration = new RuntimeConfiguration(getRuntimeConfig());
+
+        try {
+            caConfiguration = CAConfiguration.from(getConfig());
+            certificateManager.updateCAConfiguration(caConfiguration);
+        } catch (URISyntaxException e) {
+            serviceErrored(e);
+        }
+    }
+
     private void configChangeHandler(WhatHappened whatHappened, Node node) {
         if (whatHappened == WhatHappened.timestampUpdated || whatHappened == WhatHappened.interiorAdded) {
             return;
@@ -209,14 +213,14 @@ public class ClientDevicesAuthService extends PluginService {
 
         if (whatHappened == WhatHappened.initialized || node == null) {
             updateDeviceGroups(whatHappened, deviceGroupTopics);
-            updateCAType();
+            updateCertificateAuthority();
         } else if (node.childOf(DEVICE_GROUPS_TOPICS)) {
             updateDeviceGroups(whatHappened, deviceGroupTopics);
         } else if (node.childOf(CA_TYPE_KEY) || node.childOf(DEPRECATED_CA_TYPE_KEY)) {
             if (caConfiguration.getCaTypeList().isEmpty()) {
                 return;
             }
-            updateCAType();
+            updateCertificateAuthority();
         }
     }
 
@@ -275,28 +279,30 @@ public class ClientDevicesAuthService extends PluginService {
         }
     }
 
-    private void updateCAType() {
-        // NOTE: This entire method will be moved out of here and will become part of a workflow.
-        String thingName = Coerce.toString(deviceConfiguration.getThingName());
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    private void updateCertificateAuthority() {
+        // NOTE: This entire method will be moved out of here and will become part of a workflow/usecase
         try {
-            certificateManager.update(runtimeConfiguration.getCaPassphrase());
-            // NOTE: uploadCoreDeviceCAs should not block execution.
-            certificateManager.uploadCoreDeviceCAs(thingName);
+            if (caConfiguration.isUsingCustomCA()) {
+                certificateManager.configureCustomCA();
+            } else {
+                certificateManager.generateCA(runtimeConfiguration.getCaPassphrase());
+                runtimeConfiguration.updateCAPassphrase(certificateManager.getCaPassPhrase());
+            }
 
+            // Upload the generated or provided CA certificates to the GG cloud and update config
+            // NOTE: uploadCoreDeviceCAs should not block execution.
+            String thingName = Coerce.toString(deviceConfiguration.getThingName());
+            certificateManager.uploadCoreDeviceCAs(thingName);
             runtimeConfiguration.updateCACertificates(certificateManager.getCACertificates());
-            runtimeConfiguration.updateCAPassphrase(certificateManager.getCaPassPhrase());
-        } catch (CloudServiceInteractionException e) {
-            logger.atError().cause(e)
-                    .kv("coreThingName", thingName)
-                    .log("Unable to upload core CA certificates to the cloud");
-        } catch (KeyStoreException | IOException | CertificateEncodingException | IllegalArgumentException e) {
+        }  catch (Exception e) {
+            logger.atError().cause(e).log("Failed to get the CA certificates");
             serviceErrored(e);
         }
     }
 
     void updateCACertificateConfig(List<String> caCerts) {
-        // NOTE: This shouldn't exist - This is just being exposed for test shouldn't be
-        // public API
+        // NOTE: This shouldn't exist - This is just being exposed for test shouldn't be public API
         runtimeConfiguration.updateCACertificates(caCerts);
     }
 

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/exception/InvalidCertificateAuthorityException.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/exception/InvalidCertificateAuthorityException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.exception;
+
+public class InvalidCertificateAuthorityException extends RuntimeException {
+    private static final long serialVersionUID = -1L;
+
+    public InvalidCertificateAuthorityException(String message) {
+        super(message);
+    }
+
+    public InvalidCertificateAuthorityException(Throwable e) {
+        super(e);
+    }
+
+    public InvalidCertificateAuthorityException(String message, Throwable e) {
+        super(message, e);
+    }
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/exception/InvalidConfigurationException.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/exception/InvalidConfigurationException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.exception;
+
+public class InvalidConfigurationException extends Exception {
+    private static final long serialVersionUID = -1L;
+
+    public InvalidConfigurationException(String message) {
+        super(message);
+    }
+
+    public InvalidConfigurationException(Throwable e) {
+        super(e);
+    }
+
+    public InvalidConfigurationException(String message, Throwable e) {
+        super(message, e);
+    }
+}

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/CertificateManagerTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/CertificateManagerTest.java
@@ -10,18 +10,20 @@ import com.aws.greengrass.clientdevices.auth.api.GetCertificateRequest;
 import com.aws.greengrass.clientdevices.auth.api.GetCertificateRequestOptions;
 import com.aws.greengrass.clientdevices.auth.certificate.CISShadowMonitor;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateExpiryMonitor;
+import com.aws.greengrass.clientdevices.auth.certificate.CertificateHelper;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateStore;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificatesConfig;
 import com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration;
 import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationException;
 import com.aws.greengrass.clientdevices.auth.iot.ConnectivityInfoProvider;
-import com.aws.greengrass.componentmanager.KernelConfigResolver;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.Context;
+import com.aws.greengrass.security.SecurityService;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.TestUtils;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import com.aws.greengrass.util.Pair;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,7 +33,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.security.KeyPair;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -39,7 +44,9 @@ import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.time.Clock;
+import java.time.Instant;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -47,6 +54,15 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+
+import static com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration.CA_CERTIFICATE_URI;
+import static com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration.CA_PRIVATE_KEY_URI;
+import static com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration.CERTIFICATE_AUTHORITY_TOPIC;
+import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 public class CertificateManagerTest {
@@ -60,7 +76,9 @@ public class CertificateManagerTest {
     CISShadowMonitor mockShadowMonitor;
 
     @Mock
-    GreengrassServiceClientFactory clientFactory;
+    GreengrassServiceClientFactory clientFactoryMock;
+    @Mock
+    SecurityService securityServiceMock;
 
 
     @TempDir
@@ -69,25 +87,88 @@ public class CertificateManagerTest {
     private CertificateManager certificateManager;
 
     @BeforeEach
-    void beforeEach() throws KeyStoreException, CertificateEncodingException, IOException {
+    void beforeEach() throws KeyStoreException, CertificateEncodingException, IOException, URISyntaxException {
         certificateManager = new CertificateManager(new CertificateStore(tmpPath), mockConnectivityInfoProvider,
-                mockCertExpiryMonitor, mockShadowMonitor, Clock.systemUTC(), clientFactory);
+                mockCertExpiryMonitor, mockShadowMonitor, Clock.systemUTC(), clientFactoryMock, securityServiceMock);
 
         CertificatesConfig certificatesConfig = new CertificatesConfig(
-                Topics.of(new Context(), KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null));
+                Topics.of(new Context(), CONFIGURATION_CONFIG_KEY, null));
         CAConfiguration caConfiguration = CAConfiguration.from(
-                Topics.of(new Context(), KernelConfigResolver.CONFIGURATION_CONFIG_KEY, null));
+                Topics.of(new Context(), CONFIGURATION_CONFIG_KEY, null));
 
         certificateManager.updateCertificatesConfiguration(certificatesConfig);
         certificateManager.updateCAConfiguration(caConfiguration);
-        certificateManager.update("");
+        certificateManager.generateCA("");
+    }
+
+    @AfterEach
+    void afterEach() {
+        reset(securityServiceMock);
+    }
+
+    @Test
+    void GIVEN_customCAConfiguration_WHEN_configureCustomCA_THEN_returnsCustomCA() throws Exception {
+        // Given
+        Instant now = Instant.now();
+        KeyPair keyPair = CertificateStore.newRSAKeyPair(2048);
+        X509Certificate caCertificate = CertificateHelper.createCACertificate(
+                keyPair, Date.from(now), Date.from(now.plusSeconds(10)), "Custom Core CA");
+
+        URI privateKeyUri = new URI("file:///private.key");
+        URI certificateUri = new URI("file:///certificate.pem");
+
+        Topics configuration = Topics.of(new Context(), CONFIGURATION_CONFIG_KEY, null);
+        configuration.lookup(CONFIGURATION_CONFIG_KEY, CERTIFICATE_AUTHORITY_TOPIC, CA_PRIVATE_KEY_URI)
+                .withValue(privateKeyUri.toString());
+        configuration.lookup(CONFIGURATION_CONFIG_KEY, CERTIFICATE_AUTHORITY_TOPIC, CA_CERTIFICATE_URI)
+                .withValue(certificateUri.toString());
+
+        CAConfiguration caConfiguration = CAConfiguration.from(configuration);
+        certificateManager.updateCAConfiguration(caConfiguration);
+
+        // TODO: Write the actual certificate to the file system and avoid mocking the security service. Doing
+        //  this is a bad given we are exposing implementation details on the test.
+        when(securityServiceMock.getKeyPair(privateKeyUri, certificateUri)).thenReturn(keyPair);
+        when(securityServiceMock.getCertificateChain(privateKeyUri, certificateUri))
+                .thenReturn(new X509Certificate[]{caCertificate});
+
+        // When
+        certificateManager.configureCustomCA();
+
+        // Then
+        List<String> caPemStrings = certificateManager.getCACertificates();
+        String caPem = caPemStrings.get(0);
+        assertEquals(caPem, CertificateHelper.toPem(caCertificate));
+    }
+
+    @Test
+    void Given_defaultCAConfiguration_THEN_returnsAutoGeneratedCA() throws Exception {
+        // Given
+        Instant now = Instant.now();
+        KeyPair keyPair = CertificateStore.newRSAKeyPair(2048);
+        X509Certificate caCertificate = CertificateHelper.createCACertificate(
+                keyPair, Date.from(now), Date.from(now.plusSeconds(10)), "Custom Core CA");
+
+        URI privateKeyUri = new URI("file:///private.key");
+        URI certificateUri = new URI("file:///certificate.pem");
+
+        // TODO: Write the actual certificate to the file system and avoid mocking the security service. Doing
+        //  this is a bad given we are exposing implementation details on the test.
+        when(securityServiceMock.getKeyPair(privateKeyUri, certificateUri)).thenReturn(keyPair);
+        when(securityServiceMock.getCertificateChain(privateKeyUri, certificateUri))
+                .thenReturn(new X509Certificate[]{caCertificate});
+
+        // Then
+        List<String> caPemStrings = certificateManager.getCACertificates();
+        String caPem = caPemStrings.get(0);
+        assertNotEquals(caPem, CertificateHelper.toPem(caCertificate));
     }
 
     @Test
     void GIVEN_defaultCertManager_WHEN_getCACertificates_THEN_singleCAReturned()
             throws CertificateEncodingException, KeyStoreException, IOException {
         List<String> caPemList = certificateManager.getCACertificates();
-        Assertions.assertEquals(1, caPemList.size(), "expected single CA certificate");
+        assertEquals(1, caPemList.size(), "expected single CA certificate");
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfigurationTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfigurationTest.java
@@ -16,6 +16,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -27,7 +29,7 @@ import static com.aws.greengrass.clientdevices.auth.configuration.CAConfiguratio
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 public class CAConfigurationTest {
@@ -44,56 +46,55 @@ public class CAConfigurationTest {
     }
 
     @Test
-    public void GIVEN_cdaDefaultConfiguration_WHEN_getCATypeList_THEN_returnsEmptyList() {
+    public void GIVEN_cdaDefaultConfiguration_WHEN_getCATypeList_THEN_returnsEmptyList() throws URISyntaxException {
         CAConfiguration caConfiguration = CAConfiguration.from(configurationTopics);
         assertThat(caConfiguration.getCaTypeList(), is(Collections.emptyList()));
     }
 
     @Test
-    public void GIVEN_cdaDefaultConfiguration_WHEN_getCAKeyUri_THEN_returnsNull() {
+    public void GIVEN_cdaDefaultConfiguration_WHEN_getCAKeyUri_THEN_returnsNull() throws URISyntaxException {
         CAConfiguration caConfiguration = CAConfiguration.from(configurationTopics);
-        assertThat(caConfiguration.getPrivateKeyUri(), is(nullValue()));
+        assertFalse(caConfiguration.getPrivateKeyUri().isPresent());
     }
 
     @Test
-    public void GIVEN_cdaDefaultConfiguration_WHEN_getCACertUri_THEN_returnsNull() {
+    public void GIVEN_cdaDefaultConfiguration_WHEN_getCACertUri_THEN_returnsNull() throws URISyntaxException {
         CAConfiguration caConfiguration = CAConfiguration.from(configurationTopics);
-        assertThat(caConfiguration.getCertificateUri(), is(nullValue()));
+        assertFalse(caConfiguration.getCertificateUri().isPresent());
     }
 
     @Test
-    public void GIVEN_cdaConfiguration_WHEN_getCACertUri_THEN_returnsCACertUri() {
+    public void GIVEN_cdaConfiguration_WHEN_getCACertUri_THEN_returnsCACertUri() throws URISyntaxException {
         CAConfiguration caConfiguration = CAConfiguration.from(configurationTopics);
-        assertThat(caConfiguration.getCertificateUri(), is(nullValue()));
+        assertFalse(caConfiguration.getCertificateUri().isPresent());
         configurationTopics.lookup(CONFIGURATION_CONFIG_KEY, CERTIFICATE_AUTHORITY_TOPIC, CA_CERTIFICATE_URI)
                 .withValue("file:///cert-uri");
         caConfiguration = CAConfiguration.from(configurationTopics);
-        assertThat(caConfiguration.getCertificateUri(), is("file:///cert-uri"));
+        assertThat(caConfiguration.getCertificateUri().get(), is(new URI("file:///cert-uri")));
     }
 
     @Test
-    public void GIVEN_cdaConfiguration_WHEN_getCAKeyUri_THEN_returnsCACertUri() {
+    public void GIVEN_cdaConfiguration_WHEN_getCAKeyUri_THEN_returnsCACertUri() throws URISyntaxException {
         CAConfiguration caConfiguration = CAConfiguration.from(configurationTopics);
-        assertThat(caConfiguration.getPrivateKeyUri(), is(nullValue()));
+        assertFalse(caConfiguration.getPrivateKeyUri().isPresent());
         configurationTopics.lookup(CONFIGURATION_CONFIG_KEY, CERTIFICATE_AUTHORITY_TOPIC, CA_PRIVATE_KEY_URI)
                 .withValue("file:///key-uri");
         caConfiguration = CAConfiguration.from(configurationTopics);
-        assertThat(caConfiguration.getPrivateKeyUri(), is("file:///key-uri"));
+        assertThat(caConfiguration.getPrivateKeyUri().get(), is(new URI("file:///key-uri")));
     }
 
     @Test
-    public void GIVEN_cdaConfiguration_WHEN_getCATypeList_THEN_returnsCATypeList() {
+    public void GIVEN_cdaConfiguration_WHEN_getCATypeList_THEN_returnsCATypeList() throws URISyntaxException {
         configurationTopics.lookup(CONFIGURATION_CONFIG_KEY, CERTIFICATE_AUTHORITY_TOPIC, CA_TYPE_KEY)
                 .withValue(Arrays.asList("RSA_2048","ECDSA_P256"));
         CAConfiguration caConfiguration = CAConfiguration.from(configurationTopics);
-        caConfiguration = CAConfiguration.from(configurationTopics);
         assertThat(caConfiguration.getCaType(), is(CertificateStore.CAType.RSA_2048));
         assertThat(caConfiguration.getCaTypeList(), is(Arrays.asList("RSA_2048","ECDSA_P256")));
 
     }
 
     @Test
-    public void GIVEN_oldCdaConfiguration_WHEN_reading_ca_type_THEN_returns_ca_type() {
+    public void GIVEN_oldCdaConfiguration_WHEN_reading_ca_type_THEN_returns_ca_type() throws URISyntaxException {
         // NOTE: This test is to ensure we are backwards compatible with the v.2.2.2
         // we are changing how/where ca_type is stored
         configurationTopics.lookup(CONFIGURATION_CONFIG_KEY, DEPRECATED_CA_TYPE_KEY)
@@ -105,7 +106,8 @@ public class CAConfigurationTest {
     }
 
     @Test
-    public void GIVEN_oldCdaConfiguration_and_newCdaConfiguration_WHEN_reading_caType_THEN_newValueRead() {
+    public void GIVEN_oldCdaConfiguration_and_newCdaConfiguration_WHEN_reading_caType_THEN_newValueRead() throws
+            URISyntaxException {
         // Old path - pre v.2.2.2
         configurationTopics.lookup(CONFIGURATION_CONFIG_KEY, DEPRECATED_CA_TYPE_KEY)
                 .withValue(Arrays.asList("ECDSA_P256"));


### PR DESCRIPTION
**Description of changes:**
This PR adds support for configuring custom certificates from the provided `certificateAuthority` configuration.

**Why is this change necessary:**
This introduces the ability for customers to provide their own CA instead of having the CDA generate it.

**How was this change tested:**
There are 2 new tests that ensure the appropriate certificate chain is set once it is provided.

