### PR TITLE
refactor: split upload CA into separate use case

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/AuthorizeClientDeviceActionTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/AuthorizeClientDeviceActionTest.java
@@ -10,6 +10,7 @@ import com.aws.greengrass.clientdevices.auth.AuthorizationRequest;
 import com.aws.greengrass.clientdevices.auth.ClientDevicesAuthService;
 import com.aws.greengrass.clientdevices.auth.DeviceAuthClient;
 import com.aws.greengrass.clientdevices.auth.exception.InvalidSessionException;
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
@@ -80,7 +81,7 @@ class AuthorizeClientDeviceActionTest {
     }
 
     @BeforeEach
-    void beforeEach(ExtensionContext context) {
+    void beforeEach(ExtensionContext context) throws DeviceConfigurationException {
         ignoreExceptionOfType(context, SpoolerStoreException.class);
 
         // Set this property for kernel to scan its own classpath to find plugins
@@ -88,7 +89,7 @@ class AuthorizeClientDeviceActionTest {
         kernel = new Kernel();
         kernel.getContext().put(GreengrassServiceClientFactory.class, clientFactory);
 
-        when(clientFactory.getGreengrassV2DataClient()).thenReturn(v2DataClient);
+        when(clientFactory.fetchGreengrassV2DataClient()).thenReturn(v2DataClient);
 
     }
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/GetClientDeviceAuthTokenTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/GetClientDeviceAuthTokenTest.java
@@ -10,6 +10,7 @@ import com.aws.greengrass.clientdevices.auth.ClientDevicesAuthService;
 import com.aws.greengrass.clientdevices.auth.exception.AuthenticationException;
 import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
 import com.aws.greengrass.clientdevices.auth.session.SessionManager;
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
@@ -85,7 +86,7 @@ class GetClientDeviceAuthTokenTest {
     }
 
     @BeforeEach
-    void beforeEach(ExtensionContext context) {
+    void beforeEach(ExtensionContext context) throws DeviceConfigurationException {
         ignoreExceptionOfType(context, SpoolerStoreException.class);
 
         // Set this property for kernel to scan its own classpath to find plugins
@@ -93,7 +94,7 @@ class GetClientDeviceAuthTokenTest {
         kernel = new Kernel();
         kernel.getContext().put(GreengrassServiceClientFactory.class, clientFactory);
 
-        when(clientFactory.getGreengrassV2DataClient()).thenReturn(client);
+        when(clientFactory.fetchGreengrassV2DataClient()).thenReturn(client);
 
     }
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/SubscribeToCertificateUpdatesTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/SubscribeToCertificateUpdatesTest.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.integrationtests.ipc;
 
 import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.clientdevices.auth.ClientDevicesAuthService;
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
@@ -99,14 +100,14 @@ class SubscribeToCertificateUpdatesTest {
     }
 
     @BeforeEach
-    void beforeEach(ExtensionContext context) {
+    void beforeEach(ExtensionContext context) throws DeviceConfigurationException {
         ignoreExceptionOfType(context, SpoolerStoreException.class);
 
         // Set this property for kernel to scan its own classpath to find plugins
         System.setProperty("aws.greengrass.scanSelfClasspath", "true");
         kernel = new Kernel();
         kernel.getContext().put(GreengrassServiceClientFactory.class, clientFactory);
-        lenient().when(clientFactory.getGreengrassV2DataClient()).thenReturn(client);
+        lenient().when(clientFactory.fetchGreengrassV2DataClient()).thenReturn(client);
     }
 
     private void startNucleusWithConfig(String configFileName) throws InterruptedException {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -150,6 +150,7 @@ public class ClientDevicesAuthService extends PluginService {
     private void onConfigurationChanged() {
         try {
             cdaConfiguration = CDAConfiguration.from(getConfig());
+            UseCases.provide(CDAConfiguration.class, cdaConfiguration);
         } catch (URISyntaxException e) {
             serviceErrored(e);
         }
@@ -188,14 +189,14 @@ public class ClientDevicesAuthService extends PluginService {
         try {
             if (whatHappened == WhatHappened.initialized || node == null) {
                 updateDeviceGroups(whatHappened, deviceGroupTopics);
-                UseCases.get(ConfigureCertificateAuthorityUseCase.class).apply(cdaConfiguration);
+                UseCases.get(ConfigureCertificateAuthorityUseCase.class).apply(null);
             } else if (node.childOf(DEVICE_GROUPS_TOPICS)) {
                 updateDeviceGroups(whatHappened, deviceGroupTopics);
             } else if (
                     (node.childOf(CA_TYPE_KEY) || node.childOf(DEPRECATED_CA_TYPE_KEY))
                             && cdaConfiguration.isCaTypesProvided()
             ) {
-                UseCases.get(ConfigureCertificateAuthorityUseCase.class).apply(cdaConfiguration);
+                UseCases.get(ConfigureCertificateAuthorityUseCase.class).apply(null);
             }
         } catch (UseCaseException e) {
             serviceErrored(e);

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/usecases/ConfigureCertificateAuthorityUseCase.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/usecases/ConfigureCertificateAuthorityUseCase.java
@@ -8,58 +8,51 @@ package com.aws.greengrass.clientdevices.auth.certificate.usecases;
 import com.aws.greengrass.clientdevices.auth.CertificateManager;
 import com.aws.greengrass.clientdevices.auth.api.UseCases;
 import com.aws.greengrass.clientdevices.auth.configuration.CDAConfiguration;
-import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
 import com.aws.greengrass.clientdevices.auth.exception.InvalidConfigurationException;
 import com.aws.greengrass.clientdevices.auth.exception.UseCaseException;
-import com.aws.greengrass.deployment.DeviceConfiguration;
-import com.aws.greengrass.logging.api.Logger;
-import com.aws.greengrass.logging.impl.LogManager;
-import com.aws.greengrass.util.Coerce;
 
 import java.io.IOException;
 import java.security.KeyStoreException;
 import java.security.cert.CertificateEncodingException;
 import javax.inject.Inject;
 
-public class ConfigureCertificateAuthorityUseCase
-        implements UseCases.UseCase<Void, CDAConfiguration, UseCaseException> {
+public class ConfigureCertificateAuthorityUseCase implements UseCases.UseCase<Void, Void, UseCaseException> {
     private final CertificateManager certificateManager;
-    private final DeviceConfiguration deviceConfiguration;
-    private static final Logger logger = LogManager.getLogger(ConfigureCertificateAuthorityUseCase.class);
+    private final CDAConfiguration cdaConfiguration;
 
 
+    /**
+     * Configure core certificate authority.
+     * @param certificateManager  Certificate manager.
+     * @param cdaConfiguration    Client device auth configuration wrapper.
+     */
     @Inject
     public ConfigureCertificateAuthorityUseCase(
             CertificateManager certificateManager,
-            DeviceConfiguration deviceConfiguration) {
+            CDAConfiguration cdaConfiguration) {
         this.certificateManager = certificateManager;
-        this.deviceConfiguration = deviceConfiguration;
+        this.cdaConfiguration = cdaConfiguration;
     }
 
     @Override
-    public Void apply(CDAConfiguration configuration) throws UseCaseException {
+    public Void apply(Void unused) throws UseCaseException {
         // NOTE: This is not the final shape of this useCase we are just taking the logic out from
         //  the ClientDeviceAuthService first.
-        String thingName = Coerce.toString(deviceConfiguration.getThingName());
-
         try {
-            if (configuration.isUsingCustomCA()) {
-                certificateManager.configureCustomCA(configuration);
+            if (cdaConfiguration.isUsingCustomCA()) {
+                certificateManager.configureCustomCA(cdaConfiguration);
             } else {
-                certificateManager.generateCA(configuration.getCaPassphrase(), configuration.getCaType());
-                configuration.updateCAPassphrase(certificateManager.getCaPassPhrase());
+                certificateManager.generateCA(cdaConfiguration.getCaPassphrase(), cdaConfiguration.getCaType());
+                cdaConfiguration.updateCAPassphrase(certificateManager.getCaPassPhrase());
             }
 
-            // Upload the generated or provided CA certificates to the GG cloud and update config
-            // NOTE: uploadCoreDeviceCAs should not block execution.
-            certificateManager.uploadCoreDeviceCAs(thingName);
-            configuration.updateCACertificates(certificateManager.getCACertificates());
-        } catch (CloudServiceInteractionException e) {
-            logger.atError().cause(e).kv("coreThingName", thingName)
-                    .log("Unable to upload core CA certificates to the cloud");
-        } catch (CertificateEncodingException | KeyStoreException | IOException | InvalidConfigurationException   e) {
+            cdaConfiguration.updateCACertificates(certificateManager.getCACertificates());
+        } catch (KeyStoreException | InvalidConfigurationException | IOException | CertificateEncodingException e) {
             throw new UseCaseException(e);
         }
+
+        // Register new certificate authority
+        UseCases.get(RegisterCertificateAuthorityUseCase.class).apply(null);
 
         return null;
     }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/usecases/RegisterCertificateAuthorityUseCase.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/usecases/RegisterCertificateAuthorityUseCase.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.certificate.usecases;
+
+import com.aws.greengrass.clientdevices.auth.CertificateManager;
+import com.aws.greengrass.clientdevices.auth.api.UseCases;
+import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
+import com.aws.greengrass.clientdevices.auth.exception.UseCaseException;
+import com.aws.greengrass.deployment.DeviceConfiguration;
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.util.Coerce;
+
+import java.io.IOException;
+import java.security.KeyStoreException;
+import java.security.cert.CertificateEncodingException;
+import javax.inject.Inject;
+
+public class RegisterCertificateAuthorityUseCase
+        implements UseCases.UseCase<Void, Void, UseCaseException> {
+    private static final Logger logger = LogManager.getLogger(RegisterCertificateAuthorityUseCase.class);
+
+    private final CertificateManager certificateManager;
+    private final DeviceConfiguration deviceConfiguration;
+
+
+    /**
+     * Register core certificate authority with Greengrass cloud.
+     * @param certificateManager  Certificate manager.
+     * @param deviceConfiguration Greengrass device configuration.
+     */
+    @Inject
+    public RegisterCertificateAuthorityUseCase(
+            CertificateManager certificateManager,
+            DeviceConfiguration deviceConfiguration) {
+        this.certificateManager = certificateManager;
+        this.deviceConfiguration = deviceConfiguration;
+    }
+
+    @Override
+    public Void apply(Void unused) throws UseCaseException {
+        // NOTE: This is not the final shape of this useCase we are just taking the logic out from
+        //  the ClientDeviceAuthService first.
+        String thingName = Coerce.toString(deviceConfiguration.getThingName());
+
+        try {
+            // Upload the generated or provided CA certificates to the GG cloud and update config
+            // NOTE: uploadCoreDeviceCAs should not block execution.
+            certificateManager.uploadCoreDeviceCAs(thingName);
+        } catch (CloudServiceInteractionException e) {
+            logger.atError().cause(e).kv("coreThingName", thingName)
+                    .log("Unable to upload core CA certificates to the cloud");
+        } catch (DeviceConfigurationException e) {
+            // TODO: This should be retried, but the customer likely needs to make configuration changes first
+            // For now, we will log and give up. But eventually this can be added to a DLQ and retried when
+            // DeviceConfiguration is updated.
+            logger.atError().cause(e)
+                    .log("Unable to upload core CA due to bad DeviceConfiguration. "
+                            + "Please correct configuration problem and restart Greengrass. "
+                            + "Failure to upload core CA may result in client devices being unable to "
+                            + "authenticate Greengrass.");
+            throw new UseCaseException(e);
+        } catch (CertificateEncodingException | KeyStoreException | IOException e) {
+            throw new UseCaseException(e);
+        }
+
+        return null;
+    }
+}

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthServiceTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthServiceTest.java
@@ -18,6 +18,7 @@ import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionEx
 import com.aws.greengrass.componentmanager.KernelConfigResolver;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
 import com.aws.greengrass.mqttclient.spool.SpoolerStoreException;
@@ -108,7 +109,7 @@ class ClientDevicesAuthServiceTest {
 
 
     @BeforeEach
-    void setup(ExtensionContext context) {
+    void setup(ExtensionContext context) throws DeviceConfigurationException {
         ignoreExceptionOfType(context, SpoolerStoreException.class);
 
         // Set this property for kernel to scan its own classpath to find plugins
@@ -118,7 +119,7 @@ class ClientDevicesAuthServiceTest {
         kernel.getContext().put(CertificateExpiryMonitor.class, certExpiryMonitor);
         kernel.getContext().put(GreengrassServiceClientFactory.class, clientFactory);
 
-        lenient().when(clientFactory.getGreengrassV2DataClient()).thenReturn(client);
+        lenient().when(clientFactory.fetchGreengrassV2DataClient()).thenReturn(client);
     }
 
     @AfterEach


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Splits CA upload into a separate use case so that it can be independently retried. For now this use case is called from within the original configure CA use case, but eventually it may be called independently (for example, if the network is down when we start).

Additionally, this also uses the new Nucleus API for retrieving the data client. This new API throws a checked exception for invalid DeviceConfiguration rather than an NPE, which will allow us to do something more intelligent later.

**Why is this change necessary:**

**How was this change tested:**
Unit tests.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
