### PR TITLE
feat: call configure ca every time the certificateAuthority config changes

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -86,7 +86,7 @@ public class ClientDevicesAuthService extends PluginService {
      *
      * @param topics                      Root Configuration topic for this service
      * @param groupManager                Group configuration management
-     * @param certificateManager           Certificate management
+     * @param certificateManager          Certificate management
      * @param authorizationHandler        authorization handler for IPC calls
      * @param greengrassCoreIPCService    core IPC service
      * @param mqttSessionFactory          session factory to handling mqtt credentials

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -199,7 +199,7 @@ public class ClientDevicesAuthService extends PluginService {
                 useCases.get(ConfigureCertificateAuthorityUseCase.class).apply(null);
             } else if (node.childOf(DEVICE_GROUPS_TOPICS)) {
                 updateDeviceGroups(whatHappened, deviceGroupTopics);
-            } else if (cdaConfiguration.certificateAuthorityChanged(prevCdaConfiguration)) {
+            } else if (cdaConfiguration.hasCAConfigurationChanged(prevCdaConfiguration)) {
                 useCases.get(ConfigureCertificateAuthorityUseCase.class).apply(null);
             }
         } catch (UseCaseException e) {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -43,8 +43,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 
-import static com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration.CA_TYPE_KEY;
-import static com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration.DEPRECATED_CA_TYPE_KEY;
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.AUTHORIZE_CLIENT_DEVICE_ACTION;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.GET_CLIENT_DEVICE_AUTH_TOKEN;
@@ -77,7 +75,9 @@ public class ClientDevicesAuthService extends PluginService {
     public static final int DEFAULT_MAX_ACTIVE_AUTH_TOKENS = 2500;
     // Create a threadpool for calling the cloud. Single thread will be used by default.
     private final ThreadPoolExecutor cloudCallThreadPool;
+    private final UseCases useCases;
     private int cloudCallQueueSize;
+    private CDAConfiguration prevCdaConfiguration;
     private CDAConfiguration cdaConfiguration;
 
 
@@ -86,12 +86,13 @@ public class ClientDevicesAuthService extends PluginService {
      *
      * @param topics                      Root Configuration topic for this service
      * @param groupManager                Group configuration management
-     * @param certificateManager          Certificate management
+     * @param certificateManager           Certificate management
      * @param authorizationHandler        authorization handler for IPC calls
      * @param greengrassCoreIPCService    core IPC service
      * @param mqttSessionFactory          session factory to handling mqtt credentials
      * @param sessionManager              session manager
      * @param clientDevicesAuthServiceApi client devices service api handle
+     * @param useCases                    UseCases service
      */
     @SuppressWarnings("PMD.ExcessiveParameterList")
     @Inject
@@ -101,7 +102,8 @@ public class ClientDevicesAuthService extends PluginService {
                                     GreengrassCoreIPCService greengrassCoreIPCService,
                                     MqttSessionFactory mqttSessionFactory,
                                     SessionManager sessionManager,
-                                    ClientDevicesAuthServiceApi clientDevicesAuthServiceApi) {
+                                    ClientDevicesAuthServiceApi clientDevicesAuthServiceApi,
+                                    UseCases useCases) {
         super(topics);
         cloudCallQueueSize = DEFAULT_CLOUD_CALL_QUEUE_SIZE;
         cloudCallQueueSize = getValidCloudCallQueueSize(topics);
@@ -119,7 +121,8 @@ public class ClientDevicesAuthService extends PluginService {
         sessionManager.setSessionConfig(new SessionConfig(getConfig()));
 
         // Initialize the use cases, so we can use them anywhere in the app
-        UseCases.init(getContext());
+        this.useCases = useCases;
+        this.useCases.init(getContext());
     }
 
 
@@ -148,9 +151,13 @@ public class ClientDevicesAuthService extends PluginService {
     }
 
     private void onConfigurationChanged() {
+        if (cdaConfiguration != null) {
+            prevCdaConfiguration = cdaConfiguration;
+        }
+
         try {
             cdaConfiguration = CDAConfiguration.from(getConfig());
-            UseCases.provide(CDAConfiguration.class, cdaConfiguration);
+            useCases.provide(CDAConfiguration.class, cdaConfiguration);
         } catch (URISyntaxException e) {
             serviceErrored(e);
         }
@@ -189,14 +196,11 @@ public class ClientDevicesAuthService extends PluginService {
         try {
             if (whatHappened == WhatHappened.initialized || node == null) {
                 updateDeviceGroups(whatHappened, deviceGroupTopics);
-                UseCases.get(ConfigureCertificateAuthorityUseCase.class).apply(null);
+                useCases.get(ConfigureCertificateAuthorityUseCase.class).apply(null);
             } else if (node.childOf(DEVICE_GROUPS_TOPICS)) {
                 updateDeviceGroups(whatHappened, deviceGroupTopics);
-            } else if (
-                    (node.childOf(CA_TYPE_KEY) || node.childOf(DEPRECATED_CA_TYPE_KEY))
-                            && cdaConfiguration.isCaTypesProvided()
-            ) {
-                UseCases.get(ConfigureCertificateAuthorityUseCase.class).apply(null);
+            } else if (cdaConfiguration.certificateAuthorityChanged(prevCdaConfiguration)) {
+                useCases.get(ConfigureCertificateAuthorityUseCase.class).apply(null);
             }
         } catch (UseCaseException e) {
             serviceErrored(e);

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/api/UseCases.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/api/UseCases.java
@@ -6,26 +6,26 @@
 package com.aws.greengrass.clientdevices.auth.api;
 
 import com.aws.greengrass.dependency.Context;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.util.CrashableFunction;
 
 
 public class UseCases {
-    private final Context context;
-    private static UseCases instance;
+    private Context context;
+    public static final Logger logger = LogManager.getLogger(UseCases.class);
 
     // Delegates to CrashableFunction but provides a domain rich alias
     public interface UseCase<R, D, E extends Exception> extends CrashableFunction<D, R, E> {}
 
-    private UseCases(Context context) {
+    public void init(Context context) {
         this.context = context;
     }
 
-    public static void init(Context context) {
-       instance = new UseCases(context);
-    }
 
-    private static void checkCanRun() {
-        if (instance == null) {
+
+    private void checkCanRun() {
+        if (context == null) {
             throw new RuntimeException("No UseCases instance found, make sure you initialize them first");
         }
     }
@@ -37,10 +37,10 @@ public class UseCases {
      * @param ob Concrete instance of the class
      * @param <T> instance type
      */
-    public static <T> UseCases provide(Class<T> clazz, T ob) {
+    public <T> UseCases provide(Class<T> clazz, T ob) {
         checkCanRun();
-        instance.context.put(clazz, ob);
-        return instance;
+        context.put(clazz, ob);
+        return this;
     }
 
     /**
@@ -50,8 +50,8 @@ public class UseCases {
      * @param clazz Use Case class to be built
      * @param <C>   Use Case concrete class
      */
-    public static <C extends UseCase> C get(Class<C> clazz) {
+    public <C extends UseCase> C get(Class<C> clazz) {
         checkCanRun();
-        return instance.context.newInstance(clazz);
+        return context.newInstance(clazz);
     }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/api/UseCases.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/api/UseCases.java
@@ -6,14 +6,11 @@
 package com.aws.greengrass.clientdevices.auth.api;
 
 import com.aws.greengrass.dependency.Context;
-import com.aws.greengrass.logging.api.Logger;
-import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.util.CrashableFunction;
 
 
 public class UseCases {
     private Context context;
-    public static final Logger logger = LogManager.getLogger(UseCases.class);
 
     // Delegates to CrashableFunction but provides a domain rich alias
     public interface UseCase<R, D, E extends Exception> extends CrashableFunction<D, R, E> {}
@@ -21,8 +18,6 @@ public class UseCases {
     public void init(Context context) {
         this.context = context;
     }
-
-
 
     private void checkCanRun() {
         if (context == null) {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/CertificateStore.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/CertificateStore.java
@@ -103,11 +103,12 @@ public class CertificateStore {
     public void update(String passphrase, CAType caType) throws KeyStoreException {
         this.passphrase = passphrase.toCharArray();
         try {
+            logger.info("Loading Greengrass managed certificate authority");
             keyStore = loadDefaultKeyStore(caType);
             logger.atDebug().log("successfully loaded existing CA keystore");
         } catch (KeyStoreException | IOException | CertificateException | NoSuchAlgorithmException
                  | UnrecoverableKeyException e) {
-            logger.atDebug().cause(e).log("failed to load existing CA keystore");
+            logger.atDebug().cause(e).log("Failed to load existing CA keystore, creating Greengrass managed CA");
             createAndStoreDefaultKeyStore(caType);
             logger.atDebug().log("successfully created new CA keystore");
         }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/usecases/ConfigureCertificateAuthorityUseCase.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/usecases/ConfigureCertificateAuthorityUseCase.java
@@ -19,19 +19,23 @@ import javax.inject.Inject;
 public class ConfigureCertificateAuthorityUseCase implements UseCases.UseCase<Void, Void, UseCaseException> {
     private final CertificateManager certificateManager;
     private final CDAConfiguration cdaConfiguration;
+    private final UseCases useCases;
 
 
     /**
      * Configure core certificate authority.
      * @param certificateManager  Certificate manager.
      * @param cdaConfiguration    Client device auth configuration wrapper.
+     * @param useCases           UseCases service
      */
     @Inject
     public ConfigureCertificateAuthorityUseCase(
             CertificateManager certificateManager,
-            CDAConfiguration cdaConfiguration) {
+            CDAConfiguration cdaConfiguration,
+            UseCases useCases) {
         this.certificateManager = certificateManager;
         this.cdaConfiguration = cdaConfiguration;
+        this.useCases = useCases;
     }
 
     @Override
@@ -40,8 +44,10 @@ public class ConfigureCertificateAuthorityUseCase implements UseCases.UseCase<Vo
         //  the ClientDeviceAuthService first.
         try {
             if (cdaConfiguration.isUsingCustomCA()) {
+                UseCases.logger.info("Configuration custom certificate authority");
                 certificateManager.configureCustomCA(cdaConfiguration);
             } else {
+                UseCases.logger.info("Creating a Certificate Authority");
                 certificateManager.generateCA(cdaConfiguration.getCaPassphrase(), cdaConfiguration.getCaType());
                 cdaConfiguration.updateCAPassphrase(certificateManager.getCaPassPhrase());
             }
@@ -52,7 +58,7 @@ public class ConfigureCertificateAuthorityUseCase implements UseCases.UseCase<Vo
         }
 
         // Register new certificate authority
-        UseCases.get(RegisterCertificateAuthorityUseCase.class).apply(null);
+        useCases.get(RegisterCertificateAuthorityUseCase.class).apply(null);
 
         return null;
     }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/usecases/ConfigureCertificateAuthorityUseCase.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/usecases/ConfigureCertificateAuthorityUseCase.java
@@ -10,6 +10,8 @@ import com.aws.greengrass.clientdevices.auth.api.UseCases;
 import com.aws.greengrass.clientdevices.auth.configuration.CDAConfiguration;
 import com.aws.greengrass.clientdevices.auth.exception.InvalidConfigurationException;
 import com.aws.greengrass.clientdevices.auth.exception.UseCaseException;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
 
 import java.io.IOException;
 import java.security.KeyStoreException;
@@ -20,6 +22,8 @@ public class ConfigureCertificateAuthorityUseCase implements UseCases.UseCase<Vo
     private final CertificateManager certificateManager;
     private final CDAConfiguration cdaConfiguration;
     private final UseCases useCases;
+    private static final Logger logger = LogManager.getLogger(ConfigureCertificateAuthorityUseCase.class);
+
 
 
     /**
@@ -44,10 +48,10 @@ public class ConfigureCertificateAuthorityUseCase implements UseCases.UseCase<Vo
         //  the ClientDeviceAuthService first.
         try {
             if (cdaConfiguration.isUsingCustomCA()) {
-                UseCases.logger.info("Configuration custom certificate authority");
+                logger.info("Configuration custom certificate authority");
                 certificateManager.configureCustomCA(cdaConfiguration);
             } else {
-                UseCases.logger.info("Creating a Certificate Authority");
+                logger.info("Creating a Certificate Authority");
                 certificateManager.generateCA(cdaConfiguration.getCaPassphrase(), cdaConfiguration.getCaType());
                 cdaConfiguration.updateCAPassphrase(certificateManager.getCaPassPhrase());
             }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/usecases/ConfigureCertificateAuthorityUseCase.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/usecases/ConfigureCertificateAuthorityUseCase.java
@@ -48,10 +48,9 @@ public class ConfigureCertificateAuthorityUseCase implements UseCases.UseCase<Vo
         //  the ClientDeviceAuthService first.
         try {
             if (cdaConfiguration.isUsingCustomCA()) {
-                logger.info("Configuration custom certificate authority");
+                logger.info("Configuring custom certificate authority");
                 certificateManager.configureCustomCA(cdaConfiguration);
             } else {
-                logger.info("Creating a Certificate Authority");
                 certificateManager.generateCA(cdaConfiguration.getCaPassphrase(), cdaConfiguration.getCaType());
                 cdaConfiguration.updateCAPassphrase(certificateManager.getCaPassPhrase());
             }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/CDAConfiguration.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/CDAConfiguration.java
@@ -98,4 +98,20 @@ public final class CDAConfiguration {
     public Optional<URI> getCertificateUri() {
         return ca.getCertificateUri();
     }
+
+    /**
+     * Verifies if the configuration for the certificateAuthority has changed, given a previous
+     * configuration.
+     *
+     * @param config  CDAConfiguration
+     */
+    public boolean certificateAuthorityChanged(CDAConfiguration config) {
+        if (config == null) {
+            return true;
+        }
+
+        return !config.getCertificateUri().equals(getCertificateUri())
+                || !config.getPrivateKeyUri().equals(getPrivateKeyUri())
+                || !config.getCaType().equals(getCaType());
+    }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/CDAConfiguration.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/CDAConfiguration.java
@@ -11,6 +11,7 @@ import com.aws.greengrass.config.Topics;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
@@ -110,8 +111,8 @@ public final class CDAConfiguration {
             return true;
         }
 
-        return !config.getCertificateUri().equals(getCertificateUri())
-                || !config.getPrivateKeyUri().equals(getPrivateKeyUri())
-                || !config.getCaType().equals(getCaType());
+        return !Objects.equals(config.getCertificateUri(), getCertificateUri())
+                || !Objects.equals(config.getPrivateKeyUri(), getPrivateKeyUri())
+                || !Objects.equals(config.getCaType(), getCaType());
     }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/CDAConfiguration.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/CDAConfiguration.java
@@ -106,7 +106,7 @@ public final class CDAConfiguration {
      *
      * @param config  CDAConfiguration
      */
-    public boolean certificateAuthorityChanged(CDAConfiguration config) {
+    public boolean hasCAConfigurationChanged(CDAConfiguration config) {
         if (config == null) {
             return true;
         }

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/UseCasesTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/UseCasesTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 public class UseCasesTest {
     private Topics topics;
+    private UseCases useCases;
 
     static class TestDependency {
         private final String name;
@@ -86,27 +87,28 @@ public class UseCasesTest {
     @BeforeEach
     void beforeEach() {
         topics = Topics.of(new Context(), CLIENT_DEVICES_AUTH_SERVICE_NAME, null);
-        UseCases.init(topics.getContext());
+        this.useCases = new UseCases();
+        this.useCases.init(topics.getContext());
     }
 
     @Test
     void GIVEN_aUseCaseWithDependencies_WHEN_ran_THEN_itExecutesWithNoExceptions() {
         TestDependency aTestDependency = new TestDependency("Something");
-        UseCases.provide(TestDependency.class, aTestDependency);
+        useCases.provide(TestDependency.class, aTestDependency);
 
-        UseCaseWithDependencies useCase = UseCases.get(UseCaseWithDependencies.class);
+        UseCaseWithDependencies useCase = useCases.get(UseCaseWithDependencies.class);
         assertEquals(useCase.apply(null), aTestDependency.name);
     }
 
     @Test
     void GIVEN_aUseCaseWithExceptions_WHEN_ran_THEN_itThrowsAnException() {
-        UseCaseWithExceptions useCase = UseCases.get(UseCaseWithExceptions.class);
+        UseCaseWithExceptions useCase = useCases.get(UseCaseWithExceptions.class);
         assertThrows(InvalidConfigurationException.class, () -> { useCase.apply(null); });
     }
 
     @Test
     void GIVEN_aUseCaseWithParameters_WHEN_ran_itAcceptsTheParamsAndReturnsThem() {
-        UseCaseWithParameters useCase = UseCases.get(UseCaseWithParameters.class);
+        UseCaseWithParameters useCase = useCases.get(UseCaseWithParameters.class);
         assertEquals(useCase.apply("hello"), "hello");
     }
 
@@ -117,8 +119,8 @@ public class UseCasesTest {
                 .withValue("file:///cert-uri");
 
         // Then
-        UseCases.provide(CDAConfiguration.class, CDAConfiguration.from(topics));
-        UseCaseUpdatingDependency useCase = UseCases.get(UseCaseUpdatingDependency.class);
+        useCases.provide(CDAConfiguration.class, CDAConfiguration.from(topics));
+        UseCaseUpdatingDependency useCase = useCases.get(UseCaseUpdatingDependency.class);
         assertEquals(useCase.apply(null), "file:///cert-uri");
 
         // When
@@ -126,8 +128,8 @@ public class UseCasesTest {
                 .withValue("file:///cert-changed-uri");
 
         // Then
-        UseCases.provide(CDAConfiguration.class, CDAConfiguration.from(topics));
-        useCase = UseCases.get(UseCaseUpdatingDependency.class);
+        useCases.provide(CDAConfiguration.class, CDAConfiguration.from(topics));
+        useCase = useCases.get(UseCaseUpdatingDependency.class);
         assertEquals(useCase.apply(null), "file:///cert-changed-uri");
     }
 }

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/usecases/ConnectivityInformationUseCasesTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/usecases/ConnectivityInformationUseCasesTest.java
@@ -45,6 +45,7 @@ public class ConnectivityInformationUseCasesTest {
     private static final Set<HostAddress> connectivityInfoSuperset = Stream.of("localhost", "127.0.0.1", "127.0.0.2")
             .map(HostAddress::of)
             .collect(Collectors.toSet());
+    private UseCases useCases;
 
     @BeforeEach
     public void setup() {
@@ -55,20 +56,21 @@ public class ConnectivityInformationUseCasesTest {
         context.put(GreengrassServiceClientFactory.class, Mockito.mock(GreengrassServiceClientFactory.class));
 
         Topics topics = Topics.of(context, CONFIGURATION_CONFIG_KEY, null);
-        UseCases.init(topics.getContext());
+        this.useCases = new UseCases();
+        this.useCases.init(topics.getContext());
     }
 
     @Test
     void GIVEN_emptyConnectivityInfo_WHEN_getConnectivityInformation_THEN_returnEmptySet() {
-        GetConnectivityInformationUseCase useCase = UseCases.get(GetConnectivityInformationUseCase.class);
+        GetConnectivityInformationUseCase useCase = useCases.get(GetConnectivityInformationUseCase.class);
         Set<HostAddress> connectivityInfo = useCase.apply(null);
         assertThat(connectivityInfo, is(empty()));
     }
 
     @Test
     void GIVEN_connectivityInfo_WHEN_recordChangesUseCase_THEN_connectivityInfoIsAdded() {
-        GetConnectivityInformationUseCase getUseCase = UseCases.get(GetConnectivityInformationUseCase.class);
-        RecordConnectivityChangesUseCase recordChangeUseCase = UseCases.get(RecordConnectivityChangesUseCase.class);
+        GetConnectivityInformationUseCase getUseCase = useCases.get(GetConnectivityInformationUseCase.class);
+        RecordConnectivityChangesUseCase recordChangeUseCase = useCases.get(RecordConnectivityChangesUseCase.class);
 
         RecordConnectivityChangesRequest request =
                 new RecordConnectivityChangesRequest(defaultSource, sourceConnectivityInfo);
@@ -83,7 +85,7 @@ public class ConnectivityInformationUseCasesTest {
 
     @Test
     void GIVEN_duplicateConnectivityInfo_WHEN_recordChangesUseCase_THEN_noChange() {
-        RecordConnectivityChangesUseCase recordChangeUseCase = UseCases.get(RecordConnectivityChangesUseCase.class);
+        RecordConnectivityChangesUseCase recordChangeUseCase = useCases.get(RecordConnectivityChangesUseCase.class);
 
         RecordConnectivityChangesRequest request =
                 new RecordConnectivityChangesRequest(defaultSource, sourceConnectivityInfo);
@@ -99,7 +101,7 @@ public class ConnectivityInformationUseCasesTest {
 
     @Test
     void GIVEN_connectivityInformationSuperset_WHEN_recordChangesUseCase_THEN_onlyConnectivityDeltaChanges() {
-        RecordConnectivityChangesUseCase recordChangeUseCase = UseCases.get(RecordConnectivityChangesUseCase.class);
+        RecordConnectivityChangesUseCase recordChangeUseCase = useCases.get(RecordConnectivityChangesUseCase.class);
 
         RecordConnectivityChangesRequest request =
                 new RecordConnectivityChangesRequest(defaultSource, sourceConnectivityInfo);
@@ -117,7 +119,7 @@ public class ConnectivityInformationUseCasesTest {
 
     @Test
     void GIVEN_connectivityInformationSubset_WHEN_recordChangesUseCase_THEN_onlyConnectivityDeltaChanges() {
-        RecordConnectivityChangesUseCase recordChangeUseCase = UseCases.get(RecordConnectivityChangesUseCase.class);
+        RecordConnectivityChangesUseCase recordChangeUseCase = useCases.get(RecordConnectivityChangesUseCase.class);
 
         RecordConnectivityChangesRequest request =
                 new RecordConnectivityChangesRequest(defaultSource, connectivityInfoSuperset);
@@ -135,7 +137,7 @@ public class ConnectivityInformationUseCasesTest {
 
     @Test
     void GIVEN_secondSourceWithConnectivityInformationSubset_WHEN_recordChangesUseCase_THEN_noChange() {
-        RecordConnectivityChangesUseCase recordChangeUseCase = UseCases.get(RecordConnectivityChangesUseCase.class);
+        RecordConnectivityChangesUseCase recordChangeUseCase = useCases.get(RecordConnectivityChangesUseCase.class);
 
         RecordConnectivityChangesRequest request =
                 new RecordConnectivityChangesRequest(defaultSource, connectivityInfoSuperset);
@@ -153,7 +155,7 @@ public class ConnectivityInformationUseCasesTest {
 
     @Test
     void GIVEN_emptySetAfterRecordingConnectivityChanges_WHEN_recordChangesUseCase_THEN_connectivityInfoRemoved() {
-        RecordConnectivityChangesUseCase recordChangeUseCase = UseCases.get(RecordConnectivityChangesUseCase.class);
+        RecordConnectivityChangesUseCase recordChangeUseCase = useCases.get(RecordConnectivityChangesUseCase.class);
 
         RecordConnectivityChangesRequest request =
                 new RecordConnectivityChangesRequest(defaultSource, sourceConnectivityInfo);


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Ensure we are calling the use case to configure the certificate authority every time there is a change on the CDA configuration for the `certificateAuthority`.

Additional changes:
* Made the UseCases injectable instead of a singleton due to the fact it make them easier to test by allowing us to mock provided values of use cases in case we want to do simple unit tests.

**Why is this change necessary:**
We need to make sure we are updating the CAs when any value under the certificateAuthority configuration changes

**How was this change tested:**
Wrote a unit test.