### PR TITLE
fix: present full cert chain

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/CertificateManager.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/CertificateManager.java
@@ -138,7 +138,7 @@ public class CertificateManager {
     }
 
     private X509Certificate[] getX509CACertificates() throws KeyStoreException {
-        return new X509Certificate[]{certificateStore.getCACertificate()};
+        return certificateStore.getCaCertificateChain();
     }
 
     public String getCaPassPhrase() {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/CertificateStore.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/CertificateStore.java
@@ -141,10 +141,17 @@ public class CertificateStore {
      * @throws KeyStoreException if unable to retrieve the certificate
      */
     public X509Certificate getCACertificate() throws KeyStoreException {
-        return getCaCertificateChain()[0];
+        X509Certificate[] certChain = getCaCertificateChain();
+        if (certChain == null) {
+            throw new KeyStoreException("No CA certificate configured");
+        }
+        return certChain[0];
     }
 
     private void setCaCertificateChain(Certificate... caCertificateChain) throws KeyStoreException {
+        if (caCertificateChain == null) {
+            throw new KeyStoreException("No certificate chain provided");
+        }
         for (Certificate cert : caCertificateChain) {
             if (!(cert instanceof X509Certificate)) {
                 throw new KeyStoreException("Unsupported certificate type");
@@ -157,8 +164,12 @@ public class CertificateStore {
      * Sets the CA certificate chain.
      *
      * @param caCertificateChain Array of CA certificates
+     * @throws KeyStoreException if unable to retrieve the certificate chain
      */
-    public void setCaCertificateChain(X509Certificate... caCertificateChain) {
+    public void setCaCertificateChain(X509Certificate... caCertificateChain) throws KeyStoreException {
+        if (caCertificateChain == null) {
+            throw new KeyStoreException("No certificate chain provided");
+        }
         this.caCertificateChain = caCertificateChain;
         eventEmitter.emit(new CACertificateChainChanged(caCertificateChain));
     }


### PR DESCRIPTION
This change adds support for returning the entire CA certificate chain to clients who subscribe to certificate updates. This change is required in order to support Greengrass using an intermediate CA to issue server certificates.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**
Unit tests. Manually testing with MQTT broker to ensure that the full certificate chain is returned as part of the SubscribeToCertificateUpdates operations.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
