### PR TITLE
refactor: simplify CDA service entry

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -51,33 +51,23 @@ import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.GET
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.SUBSCRIBE_TO_CERTIFICATE_UPDATES;
 import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCService.VERIFY_CLIENT_DEVICE_IDENTITY;
 
-@SuppressWarnings("PMD.DataClass")
 @ImplementsService(name = ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME)
 public class ClientDevicesAuthService extends PluginService {
     public static final String CLIENT_DEVICES_AUTH_SERVICE_NAME = "aws.greengrass.clientdevices.Auth";
+
+    // TODO: Move configuration related constants to appropriate configuration class
     public static final String DEVICE_GROUPS_TOPICS = "deviceGroups";
     public static final String PERFORMANCE_TOPIC = "performance";
     public static final String MAX_ACTIVE_AUTH_TOKENS_TOPIC = "maxActiveAuthTokens";
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-            .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS, MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES);
     public static final String CLOUD_REQUEST_QUEUE_SIZE_TOPIC = "cloudRequestQueueSize";
     public static final String MAX_CONCURRENT_CLOUD_REQUESTS_TOPIC = "maxConcurrentCloudRequests";
-
-    private final GroupManager groupManager;
-
-    private final CertificateManager certificateManager;
-
-
-    private final ClientDevicesAuthServiceApi clientDevicesAuthServiceApi;
-    private final AuthorizationHandler authorizationHandler;
-    private final GreengrassCoreIPCService greengrassCoreIPCService;
     // Limit the queue size before we start rejecting requests
     private static final int DEFAULT_CLOUD_CALL_QUEUE_SIZE = 100;
     private static final int DEFAULT_THREAD_POOL_SIZE = 1;
     public static final int DEFAULT_MAX_ACTIVE_AUTH_TOKENS = 2500;
+
     // Create a threadpool for calling the cloud. Single thread will be used by default.
-    private final ThreadPoolExecutor cloudCallThreadPool;
-    private final UseCases useCases;
+    private ThreadPoolExecutor cloudCallThreadPool;
     private int cloudCallQueueSize;
     private CDAConfiguration cdaConfiguration;
 
@@ -85,47 +75,23 @@ public class ClientDevicesAuthService extends PluginService {
     /**
      * Constructor.
      *
-     * @param topics                      Root Configuration topic for this service
-     * @param groupManager                Group configuration management
-     * @param certificateManager          Certificate management
-     * @param authorizationHandler        authorization handler for IPC calls
-     * @param greengrassCoreIPCService    core IPC service
-     * @param mqttSessionFactory          session factory to handling mqtt credentials
-     * @param sessionManager              session manager
-     * @param clientDevicesAuthServiceApi client devices service api handle
-     * @param useCases                    UseCases service
+     * @param topics Root Configuration topic for this service
      */
-    @SuppressWarnings("PMD.ExcessiveParameterList")
     @Inject
-    public ClientDevicesAuthService(Topics topics, GroupManager groupManager,
-                                    CertificateManager certificateManager,
-                                    AuthorizationHandler authorizationHandler,
-                                    GreengrassCoreIPCService greengrassCoreIPCService,
-                                    MqttSessionFactory mqttSessionFactory,
-                                    SessionManager sessionManager,
-                                    ClientDevicesAuthServiceApi clientDevicesAuthServiceApi,
-                                    UseCases useCases) {
+    public ClientDevicesAuthService(Topics topics) {
         super(topics);
-        cloudCallQueueSize = DEFAULT_CLOUD_CALL_QUEUE_SIZE;
-        cloudCallQueueSize = getValidCloudCallQueueSize(topics);
-        cloudCallThreadPool = new ThreadPoolExecutor(1,
-                DEFAULT_THREAD_POOL_SIZE, 60, TimeUnit.SECONDS,
-                new ResizableLinkedBlockingQueue<>(cloudCallQueueSize));
-        cloudCallThreadPool.allowCoreThreadTimeOut(true); // act as a cached threadpool
-        this.clientDevicesAuthServiceApi = clientDevicesAuthServiceApi;
-        this.groupManager = groupManager;
-        this.certificateManager = certificateManager;
-        this.authorizationHandler = authorizationHandler;
-        this.greengrassCoreIPCService = greengrassCoreIPCService;
-        SessionCreator.registerSessionFactory("mqtt", mqttSessionFactory);
-        certificateManager.updateCertificatesConfiguration(new CertificatesConfig(getConfig()));
-        sessionManager.setSessionConfig(new SessionConfig(getConfig()));
-
-        // Initialize the use cases, so we can use them anywhere in the app
-        this.useCases = useCases;
-        this.useCases.init(getContext());
     }
 
+    @Override
+    protected void install() throws InterruptedException {
+        super.install();
+
+        context.get(UseCases.class).init(context);
+        context.get(CertificateManager.class).updateCertificatesConfiguration(new CertificatesConfig(getConfig()));
+        initializeInfrastructure();
+        initializeHandlers();
+        subscribeToConfigChanges();
+    }
 
     private int getValidCloudCallQueueSize(Topics topics) {
         int newSize = Coerce.toInt(
@@ -139,15 +105,20 @@ public class ClientDevicesAuthService extends PluginService {
         return newSize;
     }
 
-
-    @Override
-    protected void install() throws InterruptedException {
-        super.install();
-        initializeHandlers();
-        subscribeToConfigChanges();
+    private void initializeInfrastructure() {
+        cloudCallQueueSize = DEFAULT_CLOUD_CALL_QUEUE_SIZE;
+        cloudCallQueueSize = getValidCloudCallQueueSize(config);
+        cloudCallThreadPool = new ThreadPoolExecutor(1,
+                DEFAULT_THREAD_POOL_SIZE, 60, TimeUnit.SECONDS,
+                new ResizableLinkedBlockingQueue<>(cloudCallQueueSize));
+        cloudCallThreadPool.allowCoreThreadTimeOut(true); // act as a cached threadpool
     }
 
     private void initializeHandlers() {
+        // Register auth session handlers
+        context.get(SessionManager.class).setSessionConfig(new SessionConfig(getConfig()));
+        SessionCreator.registerSessionFactory("mqtt", context.get(MqttSessionFactory.class));
+
         // Register domain event handlers
         context.get(CACertificateChainChangedHandler.class).listen();
         context.get(CAConfigurationChangedHandler.class).listen();
@@ -208,19 +179,20 @@ public class ClientDevicesAuthService extends PluginService {
 
     @Override
     protected void startup() throws InterruptedException {
-        certificateManager.startMonitors();
+        context.get(CertificateManager.class).startMonitors();
         super.startup();
     }
 
     @Override
     protected void shutdown() throws InterruptedException {
         super.shutdown();
-        certificateManager.stopMonitors();
+        context.get(CertificateManager.class).stopMonitors();
     }
 
     @Override
     public void postInject() {
         super.postInject();
+        AuthorizationHandler authorizationHandler = context.get(AuthorizationHandler.class);
         try {
             authorizationHandler.registerComponent(this.getName(),
                     new HashSet<>(Arrays.asList(SUBSCRIBE_TO_CERTIFICATE_UPDATES,
@@ -231,27 +203,35 @@ public class ClientDevicesAuthService extends PluginService {
             logger.atError("initialize-cda-service-authorization-error", e)
                     .log("Failed to initialize the client device auth service with the Authorization module.");
         }
+
+        GreengrassCoreIPCService greengrassCoreIPCService = context.get(GreengrassCoreIPCService.class);
+        ClientDevicesAuthServiceApi serviceApi = context.get(ClientDevicesAuthServiceApi.class);
+        CertificateManager certificateManager = context.get(CertificateManager.class);
+
         greengrassCoreIPCService.setSubscribeToCertificateUpdatesHandler(context ->
                 new SubscribeToCertificateUpdatesOperationHandler(context, certificateManager, authorizationHandler));
         greengrassCoreIPCService.setVerifyClientDeviceIdentityHandler(context ->
-                new VerifyClientDeviceIdentityOperationHandler(context, clientDevicesAuthServiceApi,
+                new VerifyClientDeviceIdentityOperationHandler(context, serviceApi,
                         authorizationHandler, cloudCallThreadPool));
         greengrassCoreIPCService.setGetClientDeviceAuthTokenHandler(context ->
-                new GetClientDeviceAuthTokenOperationHandler(context, clientDevicesAuthServiceApi, authorizationHandler,
+                new GetClientDeviceAuthTokenOperationHandler(context, serviceApi, authorizationHandler,
                         cloudCallThreadPool));
         greengrassCoreIPCService.setAuthorizeClientDeviceActionHandler(context ->
-                new AuthorizeClientDeviceActionOperationHandler(context, clientDevicesAuthServiceApi,
+                new AuthorizeClientDeviceActionOperationHandler(context, serviceApi,
                         authorizationHandler));
     }
 
     public CertificateManager getCertificateManager() {
-        return certificateManager;
+        return context.get(CertificateManager.class);
     }
 
     private void updateDeviceGroups(WhatHappened whatHappened, Topics deviceGroupsTopics) {
+        final ObjectMapper objectMapper = new ObjectMapper()
+                .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS, MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES);
+
         try {
-            groupManager.setGroupConfiguration(
-                    OBJECT_MAPPER.convertValue(deviceGroupsTopics.toPOJO(), GroupConfiguration.class));
+            context.get(GroupManager.class).setGroupConfiguration(
+                    objectMapper.convertValue(deviceGroupsTopics.toPOJO(), GroupConfiguration.class));
         } catch (IllegalArgumentException e) {
             logger.atError().kv("event", whatHappened)
                     .kv("node", deviceGroupsTopics.getFullName())


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Stop injecting everything into CDA and just grab it from the context when it's needed.

More of this will eventually go away once we introduce more UseCases. Infrastructure init will also move, along with configuration.

**Why is this change necessary:**
It's not. Just cleans things up a bit.

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
