### PR TITLE
feat: upload the ca with the highest trust level from the ca chain

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/certificateauthority/CustomCaConfigurationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/certificateauthority/CustomCaConfigurationTest.java
@@ -6,27 +6,23 @@
 package com.aws.greengrass.integrationtests.certificateauthority;
 
 import com.aws.greengrass.clientdevices.auth.CertificateManager;
-import com.aws.greengrass.clientdevices.auth.DeviceAuthClient;
+import com.aws.greengrass.clientdevices.auth.ClientDevicesAuthService;
 import com.aws.greengrass.clientdevices.auth.api.CertificateUpdateEvent;
 import com.aws.greengrass.clientdevices.auth.api.ClientDevicesAuthServiceApi;
-import com.aws.greengrass.clientdevices.auth.api.DomainEvents;
 import com.aws.greengrass.clientdevices.auth.api.GetCertificateRequest;
 import com.aws.greengrass.clientdevices.auth.api.GetCertificateRequestOptions;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateExpiryMonitor;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateHelper;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateStore;
-import com.aws.greengrass.clientdevices.auth.certificate.CertificatesConfig;
-import com.aws.greengrass.clientdevices.auth.configuration.CDAConfiguration;
 import com.aws.greengrass.clientdevices.auth.configuration.GroupManager;
-import com.aws.greengrass.clientdevices.auth.connectivity.CISShadowMonitor;
-import com.aws.greengrass.clientdevices.auth.connectivity.ConnectivityInformation;
 import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationException;
-import com.aws.greengrass.clientdevices.auth.exception.InvalidConfigurationException;
 import com.aws.greengrass.clientdevices.auth.helpers.CertificateTestHelpers;
-import com.aws.greengrass.clientdevices.auth.iot.registry.CertificateRegistry;
-import com.aws.greengrass.clientdevices.auth.session.SessionManager;
 import com.aws.greengrass.config.Topics;
-import com.aws.greengrass.dependency.Context;
+import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
+import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
+import com.aws.greengrass.mqttclient.spool.SpoolerStoreException;
 import com.aws.greengrass.security.SecurityService;
 import com.aws.greengrass.security.exceptions.CertificateChainLoadingException;
 import com.aws.greengrass.security.exceptions.KeyLoadingException;
@@ -36,117 +32,137 @@ import com.aws.greengrass.testcommons.testutilities.TestUtils;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import com.aws.greengrass.util.Pair;
 import org.apache.commons.lang3.ArrayUtils;
-import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.cert.CertIOException;
 import org.bouncycastle.operator.OperatorCreationException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.greengrassv2data.GreengrassV2DataClient;
+import software.amazon.awssdk.services.greengrassv2data.model.PutCertificateAuthoritiesRequest;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.KeyPair;
+import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.time.Clock;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import static com.aws.greengrass.clientdevices.auth.ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME;
 import static com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration.CA_CERTIFICATE_URI;
 import static com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration.CA_PRIVATE_KEY_URI;
 import static com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration.CERTIFICATE_AUTHORITY_TOPIC;
 import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURATION_CONFIG_KEY;
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 public class CustomCaConfigurationTest {
     @Mock
-    private SessionManager sessionManagerMock;
-
-    @Mock
-    private GroupManager groupManagerMock;
-
-    @Mock private CertificateRegistry certificateRegistryMock;
-
-    @Mock
-    ConnectivityInformation mockConnectivityInformation;
-
-    @Mock
-    CertificateExpiryMonitor mockCertExpiryMonitor;
-
-    @Mock
-    CISShadowMonitor mockShadowMonitor;
-
-    @Mock
-    GreengrassServiceClientFactory clientFactoryMock;
-    @Mock
     SecurityService securityServiceMock;
+    @Mock
+    private GreengrassServiceClientFactory clientFactory;
+    @Mock
+    private GroupManager groupManager;
+    @Mock
+    CertificateExpiryMonitor certExpiryMonitor;
+    @Mock
+    private GreengrassV2DataClient client;
     @TempDir
-    Path tmpPath;
-
-    private CertificateManager certificateManager;
-    private CertificateStore certificateStore;
+    Path rootDir;
+    private Kernel kernel;
 
 
     @BeforeEach
-    void beforeEach() {
-        DomainEvents events = new DomainEvents();
-        certificateStore = new CertificateStore(tmpPath, events);
+    void setup(ExtensionContext context) throws DeviceConfigurationException {
+        ignoreExceptionOfType(context, SpoolerStoreException.class);
 
-        certificateManager = new CertificateManager(
-                certificateStore, mockConnectivityInformation,
-                mockCertExpiryMonitor, mockShadowMonitor, Clock.systemUTC(), clientFactoryMock, securityServiceMock);
+        // Set this property for kernel to scan its own classpath to find plugins
+        System.setProperty("aws.greengrass.scanSelfClasspath", "true");
+        kernel = new Kernel();
+        kernel.getContext().put(GroupManager.class, groupManager);
+        kernel.getContext().put(SecurityService.class, securityServiceMock);
+        kernel.getContext().put(CertificateExpiryMonitor.class, certExpiryMonitor);
+        kernel.getContext().put(GreengrassServiceClientFactory.class, clientFactory);
 
+        lenient().when(clientFactory.fetchGreengrassV2DataClient()).thenReturn(client);
+    }
+
+    @AfterEach
+    void cleanup() {
+        kernel.shutdown();
+    }
+
+    // TODO: Consolidate this test helpers with ClientDevicesAuthServiceTest
+    private void startNucleus() throws InterruptedException {
+        CountDownLatch authServiceRunning = new CountDownLatch(1);
+        Path resourceDirectory = Paths.get(
+                "src", "test", "resources", "com", "aws", "greengrass", "clientdevices", "auth", "config.yaml");
+        Path testPath = rootDir.toAbsolutePath();
+        kernel.parseArgs("-r", testPath.toString(), "-i", resourceDirectory.toFile().getAbsolutePath());
+        kernel.getContext().addGlobalStateChangeListener((service, was, newState) -> {
+            if (ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME.equals(service.getName()) && service.getState()
+                    .equals(State.RUNNING)) {
+                authServiceRunning.countDown();
+            }
+        });
+        kernel.launch();
+        assertThat(authServiceRunning.await(30L, TimeUnit.SECONDS), is(true));
+    }
+
+    private static Pair<X509Certificate[], KeyPair[]> arrangeCredentials() throws NoSuchAlgorithmException,
+            CertificateException,
+            OperatorCreationException, CertIOException {
+        KeyPair rootKeyPair = CertificateStore.newRSAKeyPair(2048);
+        X509Certificate rootCA = CertificateTestHelpers.createRootCertificateAuthority("root", rootKeyPair);
+
+        KeyPair intermediateKeyPair = CertificateStore.newRSAKeyPair(2048);
+        X509Certificate intermediateCA = CertificateTestHelpers.createIntermediateCertificateAuthority(
+                rootCA, "intermediate", intermediateKeyPair.getPublic(), rootKeyPair.getPrivate());
+
+        return new Pair<>(
+                new X509Certificate[]{intermediateCA, rootCA},
+                new KeyPair[]{intermediateKeyPair, rootKeyPair}
+        );
     }
 
     /**
      * Simulates an external party configuring their custom CA.
      */
-    private X509Certificate[] arrangeCustomCertificateAuthority() throws NoSuchAlgorithmException, CertificateException,
-            OperatorCreationException, CertIOException, URISyntaxException, KeyLoadingException,
-            ServiceUnavailableException, CertificateChainLoadingException, InvalidConfigurationException {
-        // Generate custom certificates
-        KeyPair rootKeyPair = CertificateStore.newRSAKeyPair(2048);
-        X509Certificate rootCA = CertificateTestHelpers.issueCertificate(
-                new X500Name("CN=root"), new X500Name("CN=root"), rootKeyPair, rootKeyPair, true);
-
-        KeyPair intermediateKeyPair = CertificateStore.newRSAKeyPair(2048);
-        X509Certificate intermediateCA = CertificateTestHelpers.issueCertificate(
-                new X500Name("CN=root"), new X500Name("CN=intermediate"), intermediateKeyPair, rootKeyPair, true);
-
+    private void arrangeCDAWithCustomCertificateAuthority(URI privateKeyUri, URI certificateUri) throws
+            ServiceLoadException {
         // Service Configuration
-        URI privateKeyUri = new URI("file:///private.key");
-        URI certificateUri = new URI("file:///certificate.pem");
-
-        Topics configurationTopics = Topics.of(new Context(), CLIENT_DEVICES_AUTH_SERVICE_NAME, null);
-        configurationTopics.lookup(CONFIGURATION_CONFIG_KEY, CERTIFICATE_AUTHORITY_TOPIC, CA_PRIVATE_KEY_URI)
+        Topics topics = kernel.locate(ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME).getConfig();
+        topics.lookup(CONFIGURATION_CONFIG_KEY, CERTIFICATE_AUTHORITY_TOPIC, CA_PRIVATE_KEY_URI)
                 .withValue(privateKeyUri.toString());
-        configurationTopics.lookup(CONFIGURATION_CONFIG_KEY, CERTIFICATE_AUTHORITY_TOPIC, CA_CERTIFICATE_URI)
+        topics.lookup(CONFIGURATION_CONFIG_KEY, CERTIFICATE_AUTHORITY_TOPIC, CA_CERTIFICATE_URI)
                 .withValue(certificateUri.toString());
 
-        CDAConfiguration cdaConfiguration = CDAConfiguration.from(configurationTopics);
-        CertificatesConfig certsConfig = new CertificatesConfig(configurationTopics);
-        certificateManager.updateCertificatesConfiguration(certsConfig);
-
-        // Configure Custom CA
-        when(securityServiceMock.getKeyPair(privateKeyUri, certificateUri)).thenReturn(intermediateKeyPair);
-        when(securityServiceMock.getCertificateChain(privateKeyUri, certificateUri))
-                .thenReturn(new X509Certificate[]{intermediateCA, rootCA});
-        certificateManager.configureCustomCA(cdaConfiguration);
-
-        return new X509Certificate[]{intermediateCA, rootCA};
+        kernel.getContext().waitForPublishQueueToClear();
     }
 
 
@@ -166,7 +182,8 @@ public class CustomCaConfigurationTest {
         GetCertificateRequest certificateRequest =
                 new GetCertificateRequest("com.aws.clients.Plugin", requestOptions, asyncCall.getRight());
 
-        certificateManager.subscribeToCertificateUpdates(certificateRequest);
+        CertificateManager manager = kernel.getContext().get(CertificateManager.class);
+        manager.subscribeToCertificateUpdates(certificateRequest);
         asyncCall.getLeft().get(1, TimeUnit.SECONDS);
 
         // Arrange the certificate chain leaf comes first, root comes last
@@ -177,30 +194,76 @@ public class CustomCaConfigurationTest {
 
     @Test
     void Given_CustomCAConfiguration_WHEN_issuingAClientCertificate_THEN_itsSignedByCustomCA() throws
-            CertificateChainLoadingException, KeyLoadingException, CertificateException, NoSuchAlgorithmException,
-            URISyntaxException, ServiceUnavailableException, OperatorCreationException, CertIOException,
-            InvalidConfigurationException, CertificateGenerationException, ExecutionException, InterruptedException,
-            TimeoutException {
-        X509Certificate[] caCertificates = arrangeCustomCertificateAuthority();
-        X509Certificate[] clientCertificateChain = arrangeClientComponentCertificateChain();
+            CertificateException, URISyntaxException, CertificateGenerationException, ExecutionException,
+            InterruptedException, TimeoutException, ServiceLoadException, NoSuchAlgorithmException,
+            OperatorCreationException, CertIOException, KeyLoadingException, ServiceUnavailableException,
+            CertificateChainLoadingException {
+        Pair<X509Certificate[], KeyPair[]> credentials = arrangeCredentials();
+        X509Certificate[] chain = credentials.getLeft();
+        KeyPair[] certificateKeys = credentials.getRight();
+        KeyPair intermediateKeyPair = certificateKeys[0];
 
-        assertTrue(CertificateTestHelpers.wasCertificateIssuedBy(caCertificates[0], clientCertificateChain[0]));
+        URI privateKeyUri = new URI("file:///private.key");
+        URI certificateUri = new URI("file:///certificate.pem");
+        when(securityServiceMock.getKeyPair(privateKeyUri, certificateUri)).thenReturn(intermediateKeyPair);
+        when(securityServiceMock.getCertificateChain(privateKeyUri, certificateUri)).thenReturn(chain);
+
+        startNucleus();
+        arrangeCDAWithCustomCertificateAuthority(privateKeyUri, certificateUri);
+
+        X509Certificate[] clientCertificateChain = arrangeClientComponentCertificateChain();
+        assertTrue(CertificateTestHelpers.wasCertificateIssuedBy(chain[0], clientCertificateChain[0]));
     }
 
     @Test
     void GIVEN_CustomCAConfiguration_WHEN_whenGeneratingClientCerts_THEN_GGComponentIsVerified() throws
             NoSuchAlgorithmException, CertificateException, OperatorCreationException, IOException,
-            URISyntaxException, InvalidConfigurationException, KeyLoadingException, ServiceUnavailableException,
+            URISyntaxException, KeyLoadingException, ServiceUnavailableException,
             CertificateChainLoadingException, CertificateGenerationException, ExecutionException, InterruptedException,
-            TimeoutException {
-        this.arrangeCustomCertificateAuthority();
-        X509Certificate[] clientCertificateChain = arrangeClientComponentCertificateChain();
+            TimeoutException, ServiceLoadException {
+        Pair<X509Certificate[], KeyPair[]> credentials = arrangeCredentials();
+        X509Certificate[] chain = credentials.getLeft();
+        KeyPair[] certificateKeys = credentials.getRight();
+        KeyPair intermediateKeyPair = certificateKeys[0];
 
-        DeviceAuthClient deviceAuth = new DeviceAuthClient(sessionManagerMock, groupManagerMock, certificateStore);
-        ClientDevicesAuthServiceApi api = new ClientDevicesAuthServiceApi(
-                certificateRegistryMock, sessionManagerMock, deviceAuth, certificateManager);
-        assertTrue(api.verifyClientDeviceIdentity(CertificateHelper.toPem(clientCertificateChain)));
+        URI privateKeyUri = new URI("file:///private.key");
+        URI certificateUri = new URI("file:///certificate.pem");
+        when(securityServiceMock.getKeyPair(privateKeyUri, certificateUri)).thenReturn(intermediateKeyPair);
+        when(securityServiceMock.getCertificateChain(privateKeyUri, certificateUri)).thenReturn(chain);
+
+        startNucleus();
+        arrangeCDAWithCustomCertificateAuthority(privateKeyUri, certificateUri);
+
+        X509Certificate[] clientCertChain = arrangeClientComponentCertificateChain();
+        ClientDevicesAuthServiceApi api = kernel.getContext().get(ClientDevicesAuthServiceApi.class);
+        assertTrue(api.verifyClientDeviceIdentity(CertificateHelper.toPem(clientCertChain)));
     }
 
+    @Test
+    void GIVEN_customCAConfigurationWithACAChain_WHEN_registeringCAWithIotCore_THEN_highestTrustCAUploaded() throws
+            CertificateChainLoadingException, KeyLoadingException, CertificateException, NoSuchAlgorithmException,
+            URISyntaxException, ServiceUnavailableException, OperatorCreationException, IOException,
+            ServiceLoadException, InterruptedException, DeviceConfigurationException, KeyStoreException {
+        Pair<X509Certificate[], KeyPair[]> credentials = arrangeCredentials();
+        X509Certificate[] chain = credentials.getLeft();
+        KeyPair[] certificateKeys = credentials.getRight();
+        KeyPair intermediateKeyPair = certificateKeys[0];
+
+        URI privateKeyUri = new URI("file:///private.key");
+        URI certificateUri = new URI("file:///certificate.pem");
+        when(securityServiceMock.getKeyPair(privateKeyUri, certificateUri)).thenReturn(intermediateKeyPair);
+        when(securityServiceMock.getCertificateChain(privateKeyUri, certificateUri)).thenReturn(chain);
+
+        startNucleus();
+        arrangeCDAWithCustomCertificateAuthority(privateKeyUri, certificateUri);
+
+        ArgumentCaptor<PutCertificateAuthoritiesRequest> requestCaptor =
+                ArgumentCaptor.forClass(PutCertificateAuthoritiesRequest.class);
+        verify(client, atLeastOnce()).putCertificateAuthorities(requestCaptor.capture());
+
+        List<String> expectedPem = Collections.singletonList(CertificateHelper.toPem(chain[chain.length - 1]));
+        PutCertificateAuthoritiesRequest lastRequest = requestCaptor.getValue();
+        assertEquals(lastRequest.coreDeviceCertificates(), expectedPem);
+    }
 
 }

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/certificateauthority/config.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/certificateauthority/config.yaml
@@ -1,0 +1,36 @@
+---
+services:
+  main:
+    lifecycle:
+      install:
+        all: echo All installed
+    dependencies:
+      - aws.greengrass.clientdevices.Auth
+
+  aws.greengrass.clientdevices.Auth:
+    configuration:
+      deviceGroups:
+        formatVersion: "2021-03-05"
+        definitions:
+          myTemperatureSensors:
+            selectionRule: "thingName:mySensor1 OR thingName:mySensor2"
+            policyName: "sensorAccessPolicy"
+          myHumiditySensors:
+            selectionRule: "thingName:mySensor3 OR thingName:mySensor4"
+            policyName: "sensorAccessPolicy"
+        policies:
+          sensorAccessPolicy:
+            policyStatement1:
+              statementDescription: "mqtt connect"
+              effect: ALLOW
+              operations:
+                - "mqtt:connect"
+              resources:
+                - "mqtt:clientId:foo"
+            policyStatement2:
+              statementDescription: "mqtt publish"
+              operations:
+                - "mqtt:publish"
+              resources:
+                - "mqtt:topic:temperature"
+                - "mqtt:topic:humidity"

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/api/Result.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/api/Result.java
@@ -35,11 +35,20 @@ public final class Result<T> {
         return new Result<>(Status.WARNING, value);
     }
 
+    public static <V> Result<V> warning() {
+        return new Result<>(Status.WARNING, null);
+    }
+
+
     public T get() {
         return value;
     }
 
     public boolean isError() {
         return status == Status.ERROR;
+    }
+
+    public boolean isOk() {
+        return status == Status.OK;
     }
 }

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/helpers/CertificateTestHelpers.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/helpers/CertificateTestHelpers.java
@@ -129,7 +129,8 @@ public final class CertificateTestHelpers {
         if (type == CertificateTypes.ROOT_CA) {
             builder
                     .addExtension(Extension.authorityKeyIdentifier, false,
-                            extUtils.createAuthorityKeyIdentifier(publicKey));
+                            extUtils.createAuthorityKeyIdentifier(publicKey))
+                    .addExtension(Extension.basicConstraints, true, new BasicConstraints(true));
         }
 
         if (type == CertificateTypes.INTERMEDIATE_CA) {

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/helpers/CertificateTestHelpers.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/helpers/CertificateTestHelpers.java
@@ -5,28 +5,40 @@
 
 package com.aws.greengrass.clientdevices.auth.helpers;
 
+import com.aws.greengrass.util.Pair;
 import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x500.X500NameBuilder;
+import org.bouncycastle.asn1.x500.style.BCStyle;
 import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
 import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.KeyPurposeId;
 import org.bouncycastle.cert.CertIOException;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.X509KeyUsage;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import software.amazon.awssdk.utils.ImmutableMap;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.Security;
 import java.security.cert.CertPath;
 import java.security.cert.CertPathValidator;
 import java.security.cert.CertPathValidatorException;
+import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.PKIXParameters;
@@ -39,9 +51,15 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 
-import static com.aws.greengrass.clientdevices.auth.certificate.CertificateHelper.CERTIFICATE_SIGNING_ALGORITHM;
 
 public final class CertificateTestHelpers {
+    private static final int DEFAULT_TEST_CA_DURATION_SECONDS = 10;
+    public static final String KEY_TYPE_RSA = "RSA";
+    public static final String RSA_SIGNING_ALGORITHM = "SHA256withRSA";
+    public static final String KEY_TYPE_EC = "EC";
+    public static final String ECDSA_SIGNING_ALGORITHM = "SHA256withECDSA";
+    public static final ImmutableMap<String, String> CERTIFICATE_SIGNING_ALGORITHM =
+            ImmutableMap.of(KEY_TYPE_RSA, RSA_SIGNING_ALGORITHM, KEY_TYPE_EC, ECDSA_SIGNING_ALGORITHM);
 
     private CertificateTestHelpers() {
     }
@@ -51,45 +69,111 @@ public final class CertificateTestHelpers {
         Security.addProvider(new BouncyCastleProvider());
     }
 
+    private enum CertificateTypes {
+        ROOT_CA, INTERMEDIATE_CA, SERVER_CERTIFICATE
+    }
 
+    public static X509Certificate createRootCertificateAuthority(String commonName, KeyPair kp)
+            throws CertificateException, OperatorCreationException, CertIOException, NoSuchAlgorithmException {
+        return createCertificate(null, commonName, kp.getPublic(), kp.getPrivate(), CertificateTypes.ROOT_CA);
+    }
 
-    /**
-     * Generates X509 certificates that could be CAs or leaf certs. This is intended to be used for testing in scenarios
-     * where we want to create intermediate CAs
-     *
-     * @param issuer             Issuer of the  certificate
-     * @param subject            Subject for the certificate
-     * @param certificateKeyPair Pair of keys for the certificates. The public key of this pair will get added to the
-     *                           certificate
-     * @param issuerKeyPair      Keypair of the issuer (or who signs) the certificate. The private key from this pair
-     *                           will be
-     *                           used to sign the certificate.
-     * @param isCA               Whether the cert can be used as a CA to sign more certificates
-     *
-     */
-    public static X509Certificate issueCertificate(X500Name issuer, X500Name subject, KeyPair certificateKeyPair,
-                                                   KeyPair issuerKeyPair, Boolean isCA)
-            throws CertificateException, OperatorCreationException, CertIOException {
-        String signingAlgorithm = CERTIFICATE_SIGNING_ALGORITHM.get(certificateKeyPair.getPrivate().getAlgorithm());
-        Instant now = Instant.now();
+    public static X509Certificate createIntermediateCertificateAuthority(
+            X509Certificate caCert, String commonName, PublicKey publicKey, PrivateKey caPrivateKey) throws
+            NoSuchAlgorithmException,
+            CertificateException, CertIOException, OperatorCreationException {
+        return createCertificate(caCert, commonName, publicKey, caPrivateKey, CertificateTypes.INTERMEDIATE_CA);
+    }
 
-        X509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
-                issuer,
-                new BigInteger(160, new SecureRandom()),
-                Date.from(now),
-                Date.from(now.plusSeconds(10)),
-                subject,
-                certificateKeyPair.getPublic()
-        );
+    static X509Certificate createServerCertificate(X509Certificate caCert, String commonName, PublicKey publicKey,
+                                                  PrivateKey caPrivateKey)
+            throws NoSuchAlgorithmException, CertificateException, IOException, OperatorCreationException {
+        return createCertificate(caCert, commonName, publicKey, caPrivateKey, CertificateTypes.SERVER_CERTIFICATE);
+    }
 
-        if (isCA) {
-            builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(true));
+    private static X509Certificate createCertificate(X509Certificate caCert, String commonName, PublicKey publicKey,
+                                              PrivateKey caPrivateKey, CertificateTypes type) throws NoSuchAlgorithmException,
+            CertIOException, CertificateException, OperatorCreationException {
+        Pair<Date, Date> dateRange = getValidityDateRange();
+        X500Name subject = getX500Name(commonName);
+
+        X509v3CertificateBuilder builder;
+        if (type == CertificateTypes.ROOT_CA) {
+            builder = new JcaX509v3CertificateBuilder(
+                    subject, getSerialNumber(), dateRange.getLeft(), dateRange.getRight(), subject, publicKey);
+        } else {
+            builder = new JcaX509v3CertificateBuilder(
+                    caCert, getSerialNumber(), dateRange.getLeft(), dateRange.getRight(), subject, publicKey);
         }
 
-        ContentSigner signer = new JcaContentSignerBuilder(signingAlgorithm).build(issuerKeyPair.getPrivate());
-        X509CertificateHolder holder = builder.build(signer);
-        return new JcaX509CertificateConverter().getCertificate(holder);
+        buildCertificateExtensions(builder, caCert, publicKey, type);
+        X509CertificateHolder certHolder = signCertificate(builder, caPrivateKey);
+        return new JcaX509CertificateConverter().setProvider("BC").getCertificate(certHolder);
     }
+
+    private static X509CertificateHolder signCertificate(X509v3CertificateBuilder certBuilder, PrivateKey privateKey)
+            throws OperatorCreationException {
+        String signingAlgorithm = CERTIFICATE_SIGNING_ALGORITHM.get(privateKey.getAlgorithm());
+        final ContentSigner contentSigner = new JcaContentSignerBuilder(
+                signingAlgorithm).setProvider("BC").build(privateKey);
+
+        return certBuilder.build(contentSigner);
+    }
+
+    private static void buildCertificateExtensions(
+            X509v3CertificateBuilder builder, X509Certificate caCert, PublicKey publicKey, CertificateTypes type) throws
+            NoSuchAlgorithmException, CertificateEncodingException, CertIOException {
+        JcaX509ExtensionUtils extUtils = new JcaX509ExtensionUtils();
+        builder.addExtension(Extension.subjectKeyIdentifier, false, extUtils.createSubjectKeyIdentifier(publicKey));
+
+        if (type == CertificateTypes.ROOT_CA) {
+            builder
+                    .addExtension(Extension.authorityKeyIdentifier, false,
+                            extUtils.createAuthorityKeyIdentifier(publicKey));
+        }
+
+        if (type == CertificateTypes.INTERMEDIATE_CA) {
+            builder
+                    .addExtension(Extension.authorityKeyIdentifier, false,
+                            extUtils.createAuthorityKeyIdentifier(caCert))
+                    .addExtension(Extension.basicConstraints, true, new BasicConstraints(true))
+                    .addExtension(Extension.keyUsage, true, new X509KeyUsage(
+                            X509KeyUsage.digitalSignature | X509KeyUsage.keyCertSign | X509KeyUsage.cRLSign));
+        }
+
+        if (type == CertificateTypes.SERVER_CERTIFICATE) {
+            builder
+                    .addExtension(Extension.authorityKeyIdentifier, false,
+                            extUtils.createAuthorityKeyIdentifier(caCert))
+                    .addExtension(Extension.basicConstraints, true, new BasicConstraints(false))
+                    .addExtension(Extension.extendedKeyUsage, true,
+                            new ExtendedKeyUsage(KeyPurposeId.id_kp_serverAuth));
+        }
+    }
+
+    private static BigInteger getSerialNumber() {
+        return  new BigInteger(160, new SecureRandom());
+    }
+
+    private static Pair<Date, Date> getValidityDateRange() {
+        Instant now = Instant.now();
+        Date notBefore = Date.from(now);
+        Date notAfter = Date.from(now.plusSeconds(DEFAULT_TEST_CA_DURATION_SECONDS));
+        return new Pair(notBefore, notAfter);
+    }
+
+    private static X500Name getX500Name(String commonName) {
+        X500NameBuilder nameBuilder = new X500NameBuilder(X500Name.getDefaultStyle());
+        nameBuilder.addRDN(BCStyle.C, "US");
+        nameBuilder.addRDN(BCStyle.O, "Internet Widgits Pty Ltd");
+        nameBuilder.addRDN(BCStyle.OU, "Amazon Web Services");
+        nameBuilder.addRDN(BCStyle.ST, "Washington");
+        nameBuilder.addRDN(BCStyle.L, "Seattle");
+        nameBuilder.addRDN(BCStyle.CN, commonName);
+
+        return nameBuilder.build();
+    }
+
 
     /**
      * Verifies if one certificate was signed by another.


### PR DESCRIPTION
**Description of changes:**
This CR changes what CA is uploaded to Iot core so that validation of client devices work when providing a certificate chain. Customers having clients using V1 of the IoT device SDK must provide the full certificate chain to CDA in order to be successfully authenticated. V2 is a bit more lenient, it allow clients to be validated with partial chains (meaning not having a core CA present and using and intermediate as a Trust anchor) 

**Why is this change necessary:**
We need this change so that customers bringing their own CA with clients on V1 of the SDK can continue to successfully authenticate their devices using the CA returned from cloud discovery.

**How was this change tested:**
Manually tested and validate that authentication would work using openssl by creating a certificate chain using openssl, providing a full chain and ensure it validates it on v1 and v2 and providing a partial chain and ensure it can connect on v2.

I also wrote a UAT that simulates this scenarios and authentication succeeds.
