### PR TITLE
feat: rotate certificates when ca chain changes

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -11,6 +11,7 @@ import com.aws.greengrass.clientdevices.auth.api.UseCases;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificatesConfig;
 import com.aws.greengrass.clientdevices.auth.certificate.handlers.CACertificateChainChangedHandler;
 import com.aws.greengrass.clientdevices.auth.certificate.handlers.CAConfigurationChangedHandler;
+import com.aws.greengrass.clientdevices.auth.certificate.handlers.RotateCertificatesHandler;
 import com.aws.greengrass.clientdevices.auth.configuration.CDAConfiguration;
 import com.aws.greengrass.clientdevices.auth.configuration.GroupConfiguration;
 import com.aws.greengrass.clientdevices.auth.configuration.GroupManager;
@@ -122,6 +123,7 @@ public class ClientDevicesAuthService extends PluginService {
         // Register domain event handlers
         context.get(CACertificateChainChangedHandler.class).listen();
         context.get(CAConfigurationChangedHandler.class).listen();
+        context.get(RotateCertificatesHandler.class).listen();
 
         // Initialize infrastructure
         NetworkState networkState = context.get(NetworkState.class);

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/ClientCertificateGenerator.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/ClientCertificateGenerator.java
@@ -21,13 +21,13 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 public class ClientCertificateGenerator extends CertificateGenerator {
     private static final Logger logger = LogManager.getLogger(ClientCertificateGenerator.class);
 
-    private final Consumer<X509Certificate[]> callback;
+    private final BiConsumer<X509Certificate[], X509Certificate[]> callback;
 
     /**
      * Constructor.
@@ -41,7 +41,7 @@ public class ClientCertificateGenerator extends CertificateGenerator {
      */
     public ClientCertificateGenerator(X500Name subject,
                                       PublicKey publicKey,
-                                      Consumer<X509Certificate[]> callback,
+                                      BiConsumer<X509Certificate[], X509Certificate[]> callback,
                                       CertificateStore certificateStore,
                                       CertificatesConfig certificatesConfig,
                                       Clock clock) {
@@ -79,7 +79,8 @@ public class ClientCertificateGenerator extends CertificateGenerator {
 
             X509Certificate caCertificate = certificateStore.getCACertificate();
             X509Certificate[] chain = {certificate, caCertificate};
-            callback.accept(chain);
+            X509Certificate[] caChain = certificateStore.getCaCertificateChain();
+            callback.accept(chain, caChain);
         } catch (NoSuchAlgorithmException | OperatorCreationException | CertificateException | IOException
                 | KeyStoreException e) {
             throw new CertificateGenerationException(e);

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/ServerCertificateGenerator.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/ServerCertificateGenerator.java
@@ -22,12 +22,12 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 public class ServerCertificateGenerator extends CertificateGenerator {
     private static final Logger logger = LogManager.getLogger(ServerCertificateGenerator.class);
-    private final Consumer<X509Certificate> callback;
+    private final BiConsumer<X509Certificate, X509Certificate[]> callback;
 
     /**
      * Constructor.
@@ -41,7 +41,7 @@ public class ServerCertificateGenerator extends CertificateGenerator {
      */
     public ServerCertificateGenerator(X500Name subject,
                                       PublicKey publicKey,
-                                      Consumer<X509Certificate> callback,
+                                      BiConsumer<X509Certificate, X509Certificate[]> callback,
                                       CertificateStore certificateStore,
                                       CertificatesConfig certificatesConfig,
                                       Clock clock) {
@@ -91,6 +91,6 @@ public class ServerCertificateGenerator extends CertificateGenerator {
                 .kv("certExpiry", getExpiryTime())
                 .log("New server certificate generated");
 
-        callback.accept(certificate);
+        callback.accept(certificate, certificateStore.getCaCertificateChain());
     }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/handlers/RotateCertificatesHandler.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/handlers/RotateCertificatesHandler.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.certificate.handlers;
+
+import com.aws.greengrass.clientdevices.auth.api.DomainEvents;
+import com.aws.greengrass.clientdevices.auth.api.UseCases;
+import com.aws.greengrass.clientdevices.auth.certificate.events.CACertificateChainChanged;
+import com.aws.greengrass.clientdevices.auth.certificate.usecases.RotateCertificates;
+
+import java.util.function.Consumer;
+import javax.inject.Inject;
+
+public class RotateCertificatesHandler implements Consumer<CACertificateChainChanged> {
+    private final UseCases useCases;
+    private final DomainEvents domainEvents;
+
+
+    /**
+     * Register core certificate authority with Greengrass cloud.
+     * @param useCases     Use cases.
+     * @param domainEvents Domain event router.
+     */
+    @Inject
+    public RotateCertificatesHandler(UseCases useCases, DomainEvents domainEvents) {
+        this.useCases = useCases;
+        this.domainEvents = domainEvents;
+    }
+
+    /**
+     * Listen for certificate authority change events.
+     */
+    public void listen() {
+        domainEvents.registerListener(this, CACertificateChainChanged.class);
+    }
+
+    /**
+     * Trigger certificate authority registration use case.
+     *
+     * @param event Certificate authority change event
+     */
+    @Override
+    public void accept(CACertificateChainChanged event) {
+        useCases.get(RotateCertificates.class).apply("Certificate chain changed");
+    }
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/infra/CertificateGeneratorRegistry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/infra/CertificateGeneratorRegistry.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.certificate.infra;
+
+import com.aws.greengrass.clientdevices.auth.certificate.CertificateGenerator;
+import lombok.Getter;
+
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+/**
+ * Simple store for server certificate generators.
+ */
+public class CertificateGeneratorRegistry {
+    @Getter
+    private final Set<CertificateGenerator> certificateGenerators = new CopyOnWriteArraySet<>();
+
+
+    /**
+     * Stores generators for server certificates that can be called upon specific triggers.
+     * @param generator A certificate generator
+     */
+    public void registerGenerator(CertificateGenerator generator) {
+        certificateGenerators.add(generator);
+    }
+
+    /**
+     * Remove a generator from the registry.
+     * @param generator  A certificate generator
+     */
+    public void removeGenerator(CertificateGenerator generator) {
+        certificateGenerators.remove(generator);
+    }
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/usecases/RotateCertificates.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/usecases/RotateCertificates.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.certificate.usecases;
+
+import com.aws.greengrass.clientdevices.auth.api.Result;
+import com.aws.greengrass.clientdevices.auth.api.UseCases;
+import com.aws.greengrass.clientdevices.auth.certificate.CertificateGenerator;
+import com.aws.greengrass.clientdevices.auth.certificate.infra.CertificateGeneratorRegistry;
+import com.aws.greengrass.clientdevices.auth.connectivity.ConnectivityInformation;
+import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationException;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+
+import java.util.Set;
+import javax.inject.Inject;
+
+/**
+ * Rotates the Certificates for all the registered subscribers. Other plugin component can use the ClientDevicesAuthApi
+ * to subscribe to CA updates and get new certificates when those events happen. This use case just triggers the
+ * rotation for all the registered subscribers.
+ */
+public class RotateCertificates implements UseCases.UseCase<Void, String> {
+    private final CertificateGeneratorRegistry certificateGeneratorRegistry;
+    private static final Logger logger = LogManager.getLogger(RotateCertificates.class);
+    private final ConnectivityInformation connectivityInformation;
+
+
+    @Inject
+    public RotateCertificates(
+            CertificateGeneratorRegistry certificateGeneratorRegistry,
+            ConnectivityInformation connectivityInformation) {
+        this.certificateGeneratorRegistry = certificateGeneratorRegistry;
+        this.connectivityInformation = connectivityInformation;
+    }
+
+    @Override
+    public Result apply(String rotationReason) {
+        Set<CertificateGenerator> generators = certificateGeneratorRegistry.getCertificateGenerators();
+        Result result = Result.ok();
+
+        if (generators.isEmpty()) {
+            logger.info("Not certificates to rotate, skipping");
+            return result;
+        }
+
+        for (CertificateGenerator generator : generators) {
+            try {
+                generator.generateCertificate(connectivityInformation::getCachedHostAddresses, rotationReason);
+            } catch (CertificateGenerationException e) {
+               result = Result.warning(e);
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/CertificateManagerTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/CertificateManagerTest.java
@@ -13,6 +13,7 @@ import com.aws.greengrass.clientdevices.auth.certificate.CertificateExpiryMonito
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateHelper;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateStore;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificatesConfig;
+import com.aws.greengrass.clientdevices.auth.certificate.infra.CertificateGeneratorRegistry;
 import com.aws.greengrass.clientdevices.auth.configuration.CDAConfiguration;
 import com.aws.greengrass.clientdevices.auth.connectivity.CISShadowMonitor;
 import com.aws.greengrass.clientdevices.auth.connectivity.ConnectivityInformation;
@@ -89,9 +90,11 @@ public class CertificateManagerTest {
 
     @BeforeEach
     void beforeEach() throws KeyStoreException {
+        CertificateGeneratorRegistry certificateGeneratorRegistry = new CertificateGeneratorRegistry();
+
         certificateManager = new CertificateManager(new CertificateStore(tmpPath, new DomainEvents()),
                 mockConnectivityInformation, mockCertExpiryMonitor, mockShadowMonitor,
-                Clock.systemUTC(), clientFactoryMock, securityServiceMock);
+                Clock.systemUTC(), clientFactoryMock, securityServiceMock, certificateGeneratorRegistry);
 
         CertificatesConfig certificatesConfig = new CertificatesConfig(
                 Topics.of(new Context(), CONFIGURATION_CONFIG_KEY, null));

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/certificate/CertificateExpiryMonitorTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/certificate/CertificateExpiryMonitorTest.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.clientdevices.auth.certificate;
 
 import com.aws.greengrass.clientdevices.auth.api.DomainEvents;
+import com.aws.greengrass.clientdevices.auth.certificate.infra.CertificateGeneratorRegistry;
 import com.aws.greengrass.clientdevices.auth.connectivity.ConnectivityInformation;
 import com.aws.greengrass.componentmanager.KernelConfigResolver;
 import com.aws.greengrass.config.Topics;
@@ -61,7 +62,11 @@ public class CertificateExpiryMonitorTest {
         certificateStore = new CertificateStore(tmpPath, new DomainEvents());
         certificateStore.update(TEST_PASSPHRASE, CertificateStore.CAType.RSA_2048);
 
-        certExpiryMonitor = new CertificateExpiryMonitor(mock(ScheduledExecutorService.class), mock(ConnectivityInformation.class), Clock.systemUTC());
+        CertificateGeneratorRegistry certificateGeneratorRegistry = new CertificateGeneratorRegistry();
+
+        certExpiryMonitor = new CertificateExpiryMonitor(
+                mock(ScheduledExecutorService.class), mock(ConnectivityInformation.class), Clock.systemUTC(),
+                certificateGeneratorRegistry);
     }
 
     @AfterEach
@@ -183,7 +188,7 @@ public class CertificateExpiryMonitorTest {
     private CertificateGenerator monitorNewServerCert(Clock clock)
             throws NoSuchAlgorithmException, CertificateGenerationException {
         return monitorNewCert(key -> new ServerCertificateGenerator(
-                SUBJECT, key, cert -> {
+                SUBJECT, key, (cert, caChain) -> {
         }, certificateStore, certificatesConfig, clock));
     }
 
@@ -199,7 +204,7 @@ public class CertificateExpiryMonitorTest {
     private CertificateGenerator monitorNewClientCert(Clock clock)
             throws NoSuchAlgorithmException, CertificateGenerationException {
         return monitorNewCert(key -> new ClientCertificateGenerator(
-                SUBJECT, key, cert -> {
+                SUBJECT, key, (cert, caChain) -> {
         }, certificateStore, certificatesConfig, clock));
     }
 

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitorTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitorTest.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.clientdevices.auth.connectivity;
 
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateGenerator;
+import com.aws.greengrass.clientdevices.auth.certificate.infra.CertificateGeneratorRegistry;
 import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationException;
 import com.aws.greengrass.clientdevices.auth.infra.NetworkState;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
@@ -98,12 +99,14 @@ public class CISShadowMonitorTest {
 
     @BeforeEach
     void setup() {
+        CertificateGeneratorRegistry certificateGeneratorRegistry = new CertificateGeneratorRegistry();
         cisShadowMonitor = new CISShadowMonitor(
                 shadowClientConnection,
                 shadowClient,
                 executor,
                 SHADOW_NAME,
-                connectivityInfoProvider
+                connectivityInfoProvider,
+                certificateGeneratorRegistry
         );
     }
 

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/helpers/CertificateTestHelpers.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/helpers/CertificateTestHelpers.java
@@ -182,20 +182,19 @@ public final class CertificateTestHelpers {
      * @param issuerCA  X509Certificate issuer cert
      * @param certificate X509Certificate signed cert
      */
-    public static boolean wasCertificateIssuedBy(X509Certificate issuerCA, X509Certificate certificate) throws
-            CertificateException {
-        CertificateFactory cf = CertificateFactory.getInstance("X.509");
-        List<X509Certificate> leafCertificate = Arrays.asList(certificate);
-        CertPath leafCertPath = cf.generateCertPath(leafCertificate);
-
+    public static boolean wasCertificateIssuedBy(X509Certificate issuerCA, X509Certificate certificate) {
         try {
+            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            List<X509Certificate> leafCertificate = Arrays.asList(certificate);
+            CertPath leafCertPath = cf.generateCertPath(leafCertificate);
             CertPathValidator cpv = CertPathValidator.getInstance("PKIX");
             TrustAnchor trustAnchor = new TrustAnchor(issuerCA, null);
             PKIXParameters validationParams = new PKIXParameters(new HashSet<>(Collections.singletonList(trustAnchor)));
             validationParams.setRevocationEnabled(false);
             cpv.validate(leafCertPath, validationParams);
             return true;
-        } catch (CertPathValidatorException | InvalidAlgorithmParameterException | NoSuchAlgorithmException  e) {
+        } catch (CertPathValidatorException | InvalidAlgorithmParameterException | NoSuchAlgorithmException
+                 | CertificateException  e) {
             return false;
         }
     }


### PR DESCRIPTION
**Description of changes:**
This changes are required to properly rotate the certificates of components subscribed to CDA after the CDA configuration changes from managed to custom and vice-versa.

**Why is this change necessary:**
Without this changes, for customers running CDA, when updating the CA configuration their configuration certificates are not rotated and authentication would stop working. 

**How was this change tested:**
Wrote an integration test and there are UATs in place that surfaces this issue.