### PR TITLE
Ensure latest CA are returned to subscribers when they change

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/ClientCertificateGenerator.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/ClientCertificateGenerator.java
@@ -21,13 +21,13 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 public class ClientCertificateGenerator extends CertificateGenerator {
     private static final Logger logger = LogManager.getLogger(ClientCertificateGenerator.class);
 
-    private final Consumer<X509Certificate[]> callback;
+    private final BiConsumer<X509Certificate, X509Certificate[]> callback;
 
     /**
      * Constructor.
@@ -41,7 +41,7 @@ public class ClientCertificateGenerator extends CertificateGenerator {
      */
     public ClientCertificateGenerator(X500Name subject,
                                       PublicKey publicKey,
-                                      Consumer<X509Certificate[]> callback,
+                                      BiConsumer<X509Certificate, X509Certificate[]> callback,
                                       CertificateStore certificateStore,
                                       CertificatesConfig certificatesConfig,
                                       Clock clock) {
@@ -77,9 +77,7 @@ public class ClientCertificateGenerator extends CertificateGenerator {
                     .kv("certExpiry", getExpiryTime())
                     .log("New client certificate generated");
 
-            X509Certificate caCertificate = certificateStore.getCACertificate();
-            X509Certificate[] chain = {certificate, caCertificate};
-            callback.accept(chain);
+            callback.accept(certificate, certificateStore.getCaCertificateChain());
         } catch (NoSuchAlgorithmException | OperatorCreationException | CertificateException | IOException
                 | KeyStoreException e) {
             throw new CertificateGenerationException(e);

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/ServerCertificateGenerator.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/ServerCertificateGenerator.java
@@ -22,12 +22,12 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 public class ServerCertificateGenerator extends CertificateGenerator {
     private static final Logger logger = LogManager.getLogger(ServerCertificateGenerator.class);
-    private final Consumer<X509Certificate> callback;
+    private final BiConsumer<X509Certificate, X509Certificate[]> callback;
 
     /**
      * Constructor.
@@ -41,7 +41,7 @@ public class ServerCertificateGenerator extends CertificateGenerator {
      */
     public ServerCertificateGenerator(X500Name subject,
                                       PublicKey publicKey,
-                                      Consumer<X509Certificate> callback,
+                                      BiConsumer<X509Certificate, X509Certificate[]> callback,
                                       CertificateStore certificateStore,
                                       CertificatesConfig certificatesConfig,
                                       Clock clock) {
@@ -91,6 +91,6 @@ public class ServerCertificateGenerator extends CertificateGenerator {
                 .kv("certExpiry", getExpiryTime())
                 .log("New server certificate generated");
 
-        callback.accept(certificate);
+        callback.accept(certificate, certificateStore.getCaCertificateChain());
     }
 }

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/certificate/CertificateExpiryMonitorTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/certificate/CertificateExpiryMonitorTest.java
@@ -183,7 +183,7 @@ public class CertificateExpiryMonitorTest {
     private CertificateGenerator monitorNewServerCert(Clock clock)
             throws NoSuchAlgorithmException, CertificateGenerationException {
         return monitorNewCert(key -> new ServerCertificateGenerator(
-                SUBJECT, key, cert -> {
+                SUBJECT, key, (cert, caChain) -> {
         }, certificateStore, certificatesConfig, clock));
     }
 
@@ -199,7 +199,7 @@ public class CertificateExpiryMonitorTest {
     private CertificateGenerator monitorNewClientCert(Clock clock)
             throws NoSuchAlgorithmException, CertificateGenerationException {
         return monitorNewCert(key -> new ClientCertificateGenerator(
-                SUBJECT, key, cert -> {
+                SUBJECT, key, (cert, caChain) -> {
         }, certificateStore, certificatesConfig, clock));
     }
 


### PR DESCRIPTION
**Description of changes:**
Fix issue where old CA's are getting returned if the ca chain changes

**Why is this change necessary:**
This is part of a larger fix to ensure that we are rotating the certificates when the CA configuration changes.  It is required so that client components get the latest CA values and can properly authenticate.

**How was this change tested:**
Wrote a test
