### PR TITLE
fix: avoid potential impossible states

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/certificateauthority/CustomCaConfigurationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/certificateauthority/CustomCaConfigurationTest.java
@@ -73,6 +73,8 @@ import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.lenient;
@@ -276,8 +278,7 @@ public class CustomCaConfigurationTest {
     void GIVEN_managedCAConfiguration_WHEN_updatedToCustomCAConfiguration_THEN_serverCertificatesAreRotated() throws
             InterruptedException, CertificateGenerationException, CertificateException, NoSuchAlgorithmException,
             OperatorCreationException, IOException, URISyntaxException, KeyLoadingException,
-            ServiceUnavailableException, CertificateChainLoadingException, ServiceLoadException, ExecutionException,
-            TimeoutException {
+            ServiceUnavailableException, CertificateChainLoadingException, ServiceLoadException {
         Pair<X509Certificate[], KeyPair[]> credentials = givenRootAndIntermediateCA();
         X509Certificate[] chain = credentials.getLeft();
         X509Certificate intermediateCA =  chain[0];
@@ -290,18 +291,19 @@ public class CustomCaConfigurationTest {
         when(securityServiceMock.getCertificateChain(privateKeyUri, certificateUri)).thenReturn(chain);
 
         AtomicReference<CertificateUpdateEvent> eventRef = new AtomicReference<>();
-        Pair<CompletableFuture<Void>, Consumer<CertificateUpdateEvent>> asyncCall =
-                TestUtils.asyncAssertOnConsumer(eventRef::set, 2);
         GetCertificateRequest request = buildCertificateUpdateRequest(
-                GetCertificateRequestOptions.CertificateType.SERVER, asyncCall.getRight());
+                GetCertificateRequestOptions.CertificateType.SERVER, eventRef::set);
 
         givenNucleusRunningWithConfig("config.yaml");
-        subscribeToCertificateUpdates(request);
-        givenCDAWithCustomCertificateAuthority(privateKeyUri, certificateUri);
 
-        // Called 2 times. 1 for initial manages CA and then after the config is changes to use custom CA
-        asyncCall.getLeft().get(2, TimeUnit.SECONDS);
-        CertificateUpdateEvent event = eventRef.get();
-        assertTrue(CertificateTestHelpers.wasCertificateIssuedBy(intermediateCA, event.getCertificate()));
+        // Begin with managed CA
+        subscribeToCertificateUpdates(request);
+        assertNotEquals(CertificateHelper.toPem(chain), CertificateHelper.toPem(eventRef.get().getCaCertificates()));
+        assertFalse(CertificateTestHelpers.wasCertificateIssuedBy(intermediateCA, eventRef.get().getCertificate()));
+
+        // Change to custom CA
+        givenCDAWithCustomCertificateAuthority(privateKeyUri, certificateUri);
+        assertEquals(CertificateHelper.toPem(chain), CertificateHelper.toPem(eventRef.get().getCaCertificates()));
+        assertTrue(CertificateTestHelpers.wasCertificateIssuedBy(intermediateCA, eventRef.get().getCertificate()));
     }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/CertificateManager.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/CertificateManager.java
@@ -291,7 +291,7 @@ public class CertificateManager {
                     () -> securityService.getCertificateChain(privateKeyUri, certificateUri),
                     "get-certificate-chain", logger);
 
-            certificateStore.setCaCertificateChain(keyPair.getPrivate(), certificateChain);
+            certificateStore.setCaKeyAndCertificateChain(keyPair.getPrivate(), certificateChain);
         } catch (Exception e) {
             throw new InvalidCertificateAuthorityException(String.format("Failed to configure CA: There was an error "
                     + "reading the provided private key %s or certificate chain %s", privateKeyUri, certificateUri), e);

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/CertificateManager.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/CertificateManager.java
@@ -291,8 +291,7 @@ public class CertificateManager {
                     () -> securityService.getCertificateChain(privateKeyUri, certificateUri),
                     "get-certificate-chain", logger);
 
-            certificateStore.setCaCertificateChain(certificateChain);
-            certificateStore.setCaPrivateKey(keyPair.getPrivate());
+            certificateStore.setCaCertificateChain(keyPair.getPrivate(), certificateChain);
         } catch (Exception e) {
             throw new InvalidCertificateAuthorityException(String.format("Failed to configure CA: There was an error "
                     + "reading the provided private key %s or certificate chain %s", privateKeyUri, certificateUri), e);

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/CAConfigurationMonitor.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/CAConfigurationMonitor.java
@@ -65,7 +65,7 @@ public class CAConfigurationMonitor {
                         connectivityInformation::getCachedHostAddresses,
                         "Certificate Configuration Changed");
             } catch (CertificateGenerationException e) {
-                result = Result.warning(e);
+                result = Result.error(e);
             }
         }
 

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/CertificateStore.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/CertificateStore.java
@@ -118,7 +118,7 @@ public class CertificateStore {
         }
 
         try {
-            setCaCertificateChain(keyStore.getKey(CA_KEY_ALIAS, getPassphrase()),
+            setCaKeyAndCertificateChain(keyStore.getKey(CA_KEY_ALIAS, getPassphrase()),
                     keyStore.getCertificateChain(CA_KEY_ALIAS));
         } catch (NoSuchAlgorithmException | UnrecoverableKeyException e) {
             throw new KeyStoreException("unable to retrieve CA private key", e);
@@ -159,7 +159,9 @@ public class CertificateStore {
      *
      * @throws KeyStoreException  if privateKey is not instance of PrivateKey or no ca chain provided
      */
-    public void setCaCertificateChain(Key privateKey, X509Certificate... caCertificateChain) throws KeyStoreException {
+     @SuppressWarnings("PMD.CommentsIndentation")
+     public synchronized void setCaKeyAndCertificateChain(Key privateKey, X509Certificate... caCertificateChain)
+            throws KeyStoreException {
         if (caCertificateChain == null) {
             throw new KeyStoreException("No certificate chain provided");
         }
@@ -175,7 +177,8 @@ public class CertificateStore {
     }
 
 
-    private void setCaCertificateChain(Key privateKey, Certificate... caCertificateChain) throws KeyStoreException {
+    private void setCaKeyAndCertificateChain(Key privateKey, Certificate... caCertificateChain)
+            throws KeyStoreException {
         if (caCertificateChain == null) {
             throw new KeyStoreException("No certificate chain provided");
         }
@@ -187,7 +190,7 @@ public class CertificateStore {
         }
 
         X509Certificate[] certificates = Arrays.stream(caCertificateChain).toArray(X509Certificate[]::new);
-        setCaCertificateChain(privateKey, certificates);
+        setCaKeyAndCertificateChain(privateKey, certificates);
     }
 
 

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/CertificateStore.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/CertificateStore.java
@@ -149,17 +149,16 @@ public class CertificateStore {
     }
 
 
-    /**
-     * Sets the CA chain and private key that are used to generate certificates. It combines setting both values
-     * at the same time to avoid invalid states where the caChain can be updated without updating the value of
-     * the private key required to sign generated certificates.
-     *
-     * @param privateKey  leaf CA private key
-     * @param caCertificateChain a CA chain
-     *
-     * @throws KeyStoreException  if privateKey is not instance of PrivateKey or no ca chain provided
-     */
-     @SuppressWarnings("PMD.CommentsIndentation")
+     /**
+      * Sets the CA chain and private key that are used to generate certificates. It combines setting both values
+      * at the same time to avoid invalid states where the caChain can be updated without updating the value of
+      * the private key required to sign generated certificates.
+      *
+      * @param privateKey  leaf CA private key
+      * @param caCertificateChain a CA chain
+      *
+      * @throws KeyStoreException  if privateKey is not instance of PrivateKey or no ca chain provided
+      */
      public synchronized void setCaKeyAndCertificateChain(Key privateKey, X509Certificate... caCertificateChain)
             throws KeyStoreException {
         if (caCertificateChain == null) {

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/CertificateManagerTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/CertificateManagerTest.java
@@ -270,7 +270,7 @@ public class CertificateManagerTest {
         X509Certificate caB = CertificateTestHelpers.createRootCertificateAuthority("Root B", caBKeys);
 
 
-        certificateStore.setCaCertificateChain(caAKeys.getPrivate(), caA);
+        certificateStore.setCaKeyAndCertificateChain(caAKeys.getPrivate(), caA);
         certificateManager.subscribeToCertificateUpdates(request);
 
         assertEquals(1, eventRef.get().getCaCertificates().length);
@@ -279,7 +279,7 @@ public class CertificateManagerTest {
         ArgumentCaptor<CertificateGenerator> generator = ArgumentCaptor.forClass(CertificateGenerator.class);
         verify(mockCertExpiryMonitor).addToMonitor(generator.capture());
 
-        certificateStore.setCaCertificateChain(caBKeys.getPrivate(), caB);
+        certificateStore.setCaKeyAndCertificateChain(caBKeys.getPrivate(), caB);
 
         // This part below just simulates the expiry monitor triggering expired certificates after the ca had changed
         generator.getValue().generateCertificate(ArrayList::new, "testing");

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/CertificateManagerTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/CertificateManagerTest.java
@@ -270,8 +270,7 @@ public class CertificateManagerTest {
         X509Certificate caB = CertificateTestHelpers.createRootCertificateAuthority("Root B", caBKeys);
 
 
-        certificateStore.setCaPrivateKey(caAKeys.getPrivate());
-        certificateStore.setCaCertificateChain(caA);
+        certificateStore.setCaCertificateChain(caAKeys.getPrivate(), caA);
         certificateManager.subscribeToCertificateUpdates(request);
 
         assertEquals(1, eventRef.get().getCaCertificates().length);
@@ -280,8 +279,7 @@ public class CertificateManagerTest {
         ArgumentCaptor<CertificateGenerator> generator = ArgumentCaptor.forClass(CertificateGenerator.class);
         verify(mockCertExpiryMonitor).addToMonitor(generator.capture());
 
-        certificateStore.setCaPrivateKey(caBKeys.getPrivate());
-        certificateStore.setCaCertificateChain(caB);
+        certificateStore.setCaCertificateChain(caBKeys.getPrivate(), caB);
 
         // This part below just simulates the expiry monitor triggering expired certificates after the ca had changed
         generator.getValue().generateCertificate(ArrayList::new, "testing");


### PR DESCRIPTION
**Description of changes:**
Update caChain and private key together to avoid leaving the door open for someone to update the caChain without changing the private key which would lead to generating invalid certificates.

**Why is this change necessary:**
If we don't do this, depending on how we hook the events it can happen that we generate certificates with an old private key.

**How was this change tested:**
This is a refactor, ensure all tests are passing.