### PR TITLE
feat(wip): add thing registry domain and events

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Thing.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Thing.java
@@ -70,7 +70,7 @@ public final class Thing implements AttributeProvider, Cloneable {
         if (!Pattern.matches(thingNamePattern, thingName)) {
             throw new IllegalArgumentException("Invalid thing name. The thing name must match \"[a-zA-Z0-9\\-_:]+\".");
         }
-        return new Thing(version, thingName, new CopyOnWriteArrayList<>(certificateIds));
+        return new Thing(version, thingName, certificateIds);
     }
 
     @Override
@@ -109,13 +109,13 @@ public final class Thing implements AttributeProvider, Cloneable {
      * @return Certificate IDs
      */
     public List<String> getAttachedCertificateIds() {
-        return new CopyOnWriteArrayList<>(attachedCertificateIds);
+        return new ArrayList<>(attachedCertificateIds);
     }
 
-    private Thing(int version, String thingName, CopyOnWriteArrayList<String> certificateIds) {
+    private Thing(int version, String thingName, List<String> certificateIds) {
         this.version = version;
         this.thingName = thingName;
-        this.attachedCertificateIds = certificateIds;
+        this.attachedCertificateIds = new CopyOnWriteArrayList<>(certificateIds);
     }
 
     @Override

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Thing.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Thing.java
@@ -8,48 +8,143 @@ package com.aws.greengrass.clientdevices.auth.iot;
 import com.aws.greengrass.clientdevices.auth.session.attribute.AttributeProvider;
 import com.aws.greengrass.clientdevices.auth.session.attribute.DeviceAttribute;
 import com.aws.greengrass.clientdevices.auth.session.attribute.WildcardSuffixAttribute;
-import lombok.Value;
+import lombok.Getter;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 /**
- * This is a value object representing an IoT Thing at specific point in time.
- * It is **NOT** updated when the local Thing Registry is updated, or when
- * changes to this Thing are made in IoT Core.
+ * This is a versioned representation of an IoT Thing. It is **NOT** updated
+ * when the local Thing Registry is updated, or when changes to this Thing are
+ * made in IoT Core. Consider calling the ThingRegistry to retrieve Thing
+ * objects as they are needed rather than storing references long term.
  */
-@Value
-public class Thing implements AttributeProvider {
+@Getter
+public final class Thing implements AttributeProvider {
     public static final String NAMESPACE = "Thing";
     private static final String thingNamePattern = "[a-zA-Z0-9\\-_:]+";
 
-    String thingName;
-    List<String> attachedCertificateIds;
+    private final int version;
+    private final String thingName;
+    private final List<String> attachedCertificateIds;
+    private boolean modified = false;
 
     /**
-     * Create a Thing object with no attached certificates.
+     * Create a new Thing.
      *
      * @param thingName AWS IoT ThingName
+     * @throws IllegalArgumentException If the given ThingName contains illegal characters
      */
-    public Thing(String thingName) {
-        this(thingName, null);
+    public static Thing of(String thingName) {
+        return Thing.of(0, thingName);
     }
 
     /**
-     * Create a Thing object with the provided attached certificate IDs.
+     * Create a new Thing.
      *
+     * @param version        Thing version
      * @param thingName      AWS IoT ThingName
-     * @param certificateIds AWS IoT Certificate IDs
      * @throws IllegalArgumentException If the given ThingName contains illegal characters
      */
-    public Thing(String thingName, List<String> certificateIds) {
+    public static Thing of(int version, String thingName) {
+        return Thing.of(version, thingName, new ArrayList<>());
+    }
+
+    /**
+     * Create a new Thing.
+     *
+     * @param version        Thing version
+     * @param thingName      AWS IoT ThingName
+     * @param certificateIds Attached certificate IDs
+     * @throws IllegalArgumentException If the given ThingName contains illegal characters
+     */
+    public static Thing of(int version, String thingName, List<String> certificateIds) {
+        if (version < 0) {
+            throw new IllegalArgumentException("Invalid version. Version must not be < 0");
+        }
         if (!Pattern.matches(thingNamePattern, thingName)) {
             throw new IllegalArgumentException("Invalid thing name. The thing name must match \"[a-zA-Z0-9\\-_:]+\".");
         }
+        return new Thing(version, thingName, new ArrayList<>(certificateIds));
+    }
+
+    /**
+     * Create a copy of a Thing.
+     *
+     * @param other Thing to copy
+     */
+    public static Thing of(Thing other) {
+        return Thing.of(other.getVersion(), other.getThingName(), other.getAttachedCertificateIds());
+    }
+
+    /**
+     * Attach a certificate ID.
+     * @param certificateId Certificate ID to attach
+     */
+    public void attachCertificate(String certificateId) {
+        if (attachedCertificateIds.contains(certificateId)) {
+            return;
+        }
+        attachedCertificateIds.add(certificateId);
+        modified = true;
+    }
+
+    /**
+     * Detach a certificate ID.
+     * @param certificateId Certificate ID to detach
+     */
+    public void detachCertificate(String certificateId) {
+        if (!attachedCertificateIds.contains(certificateId)) {
+            return;
+        }
+        attachedCertificateIds.remove(certificateId);
+        modified = true;
+    }
+
+    /**
+     * Returns copy of attached certificate IDs.
+     * </p>
+     * This list cannot be modified directly. Refer to {@link #attachCertificate(String) attachCertificate} and
+     * {@link #detachCertificate(String) detachCertificate}
+     *
+     * @return Certificate IDs
+     */
+    public List<String> getAttachedCertificateIds() {
+        return new ArrayList<>(attachedCertificateIds);
+    }
+
+    private Thing(int version, String thingName, List<String> certificateIds) {
+        this.version = version;
         this.thingName = thingName;
         this.attachedCertificateIds = certificateIds;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof Thing)) {
+            return false;
+        }
+
+        Thing other = (Thing) o;
+        if (isModified() || other.isModified()) {
+            return false;
+        }
+
+        return version == other.version
+                && thingName.equals(other.thingName)
+                && attachedCertificateIds.equals(other.attachedCertificateIds);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(version, thingName, attachedCertificateIds);
     }
 
     @Override

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Thing.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Thing.java
@@ -11,26 +11,45 @@ import com.aws.greengrass.clientdevices.auth.session.attribute.WildcardSuffixAtt
 import lombok.Value;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+/**
+ * This is a value object representing an IoT Thing at specific point in time.
+ * It is **NOT** updated when the local Thing Registry is updated, or when
+ * changes to this Thing are made in IoT Core.
+ */
 @Value
 public class Thing implements AttributeProvider {
     public static final String NAMESPACE = "Thing";
     private static final String thingNamePattern = "[a-zA-Z0-9\\-_:]+";
 
     String thingName;
+    List<String> attachedCertificateIds;
 
     /**
-     * Constructor.
+     * Create a Thing object with no attached certificates.
+     *
      * @param thingName AWS IoT ThingName
-     * @throws IllegalArgumentException If the given ThingName contains illegal characters
      */
     public Thing(String thingName) {
+        this(thingName, null);
+    }
+
+    /**
+     * Create a Thing object with the provided attached certificate IDs.
+     *
+     * @param thingName      AWS IoT ThingName
+     * @param certificateIds AWS IoT Certificate IDs
+     * @throws IllegalArgumentException If the given ThingName contains illegal characters
+     */
+    public Thing(String thingName, List<String> certificateIds) {
         if (!Pattern.matches(thingNamePattern, thingName)) {
             throw new IllegalArgumentException("Invalid thing name. The thing name must match \"[a-zA-Z0-9\\-_:]+\".");
         }
         this.thingName = thingName;
+        this.attachedCertificateIds = certificateIds;
     }
 
     @Override

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/events/ThingEvent.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/events/ThingEvent.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.iot.events;
+
+import com.aws.greengrass.clientdevices.auth.api.DomainEvent;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@AllArgsConstructor
+public class ThingEvent implements DomainEvent {
+    @Getter
+    private ThingEventType eventType;
+    @Getter
+    private String thingName;
+    @Getter
+    private List<String> attachedCertificateIds;
+
+    public enum ThingEventType {
+        THING_UPDATED
+    }
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/events/ThingUpdated.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/events/ThingUpdated.java
@@ -9,12 +9,10 @@ import com.aws.greengrass.clientdevices.auth.api.DomainEvent;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.util.List;
-
 @AllArgsConstructor
 public class ThingUpdated implements DomainEvent {
     @Getter
     private String thingName;
     @Getter
-    private List<String> attachedCertificateIds;
+    private int thingVersion;
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/events/ThingUpdated.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/events/ThingUpdated.java
@@ -12,15 +12,9 @@ import lombok.Getter;
 import java.util.List;
 
 @AllArgsConstructor
-public class ThingEvent implements DomainEvent {
-    @Getter
-    private ThingEventType eventType;
+public class ThingUpdated implements DomainEvent {
     @Getter
     private String thingName;
     @Getter
     private List<String> attachedCertificateIds;
-
-    public enum ThingEventType {
-        THING_UPDATED
-    }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistry.java
@@ -5,22 +5,25 @@
 
 package com.aws.greengrass.clientdevices.auth.iot.registry;
 
+import com.aws.greengrass.clientdevices.auth.api.DomainEvents;
 import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
 import com.aws.greengrass.clientdevices.auth.iot.Certificate;
 import com.aws.greengrass.clientdevices.auth.iot.IotAuthClient;
 import com.aws.greengrass.clientdevices.auth.iot.Thing;
+import com.aws.greengrass.clientdevices.auth.iot.events.ThingEvent;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import javax.inject.Inject;
 
 public class ThingRegistry {
-    // holds mapping of thingName to IoT Certificate ID;
+    // holds mapping of thingName to IoT Certificate IDs;
     // size-bound by default cache size, evicts oldest written entry if the max size is reached
-    private final Map<String, String> registry = Collections.synchronizedMap(
-            new LinkedHashMap<String, String>(RegistryConfig.REGISTRY_CACHE_SIZE, 0.75f, false) {
+    private final Map<String, List<String>> registry = Collections.synchronizedMap(
+            new LinkedHashMap<String, List<String>>(RegistryConfig.REGISTRY_CACHE_SIZE, 0.75f, false) {
                 @Override
                 protected boolean removeEldestEntry(Map.Entry eldest) {
                     return size() > RegistryConfig.REGISTRY_CACHE_SIZE;
@@ -28,10 +31,75 @@ public class ThingRegistry {
             });
 
     private final IotAuthClient iotAuthClient;
+    private final DomainEvents domainEvents;
 
     @Inject
-    public ThingRegistry(IotAuthClient iotAuthClient) {
+    public ThingRegistry(IotAuthClient iotAuthClient, DomainEvents domainEvents) {
         this.iotAuthClient = iotAuthClient;
+        this.domainEvents = domainEvents;
+    }
+
+    /**
+     * Retrieve a Thing based on ThingName.
+     *
+     * @param thingName ThingName
+     * @return Thing domain object
+     */
+    public Thing getThing(String thingName) {
+        List<String> certificateIds = registry.get(thingName);
+        if (certificateIds != null) {
+            return new Thing(thingName, certificateIds);
+        }
+        return null;
+    }
+
+    /**
+     * Attach a certificate to Thing.
+     * </p>
+     * If the provided Thing does not exist, it will be created.
+     * @param thingName     ThingName.
+     * @param certificateId Certificate ID to attach.
+     */
+    public synchronized void attachCertificateToThing(String thingName, String certificateId) {
+        List<String> certificateIds = registry.get(thingName);
+
+        if (certificateIds != null && certificateIds.contains(certificateId)) {
+            // Nothing to do
+            return;
+        }
+
+        // Thing doesn't exist - create it
+        if (certificateIds == null) {
+            certificateIds = new ArrayList<>(Collections.singletonList(certificateId));
+            registry.put(thingName, certificateIds);
+        } else {
+            certificateIds.add(certificateId);
+        }
+
+        domainEvents.emit(
+                new ThingEvent(ThingEvent.ThingEventType.THING_UPDATED,
+                        thingName,
+                        new ArrayList<>(certificateIds)));
+    }
+
+    /**
+     * Detach a certificate from Thing.
+     * @param thingName     ThingName.
+     * @param certificateId Certificate ID to detach.
+     */
+    public synchronized void detachCertificateFromThing(String thingName, String certificateId) {
+        List<String> certificateIds = registry.get(thingName);
+
+        if (certificateIds == null || !certificateIds.contains(certificateId)) {
+            // Nothing to do
+            return;
+        }
+
+        certificateIds.remove(certificateId);
+        domainEvents.emit(
+                new ThingEvent(ThingEvent.ThingEventType.THING_UPDATED,
+                        thingName,
+                        new ArrayList<>(certificateIds)));
     }
 
     /**
@@ -53,7 +121,7 @@ public class ThingRegistry {
                 clearRegistryForThing(thing);
             }
         } catch (CloudServiceInteractionException e) {
-            if (isCertificateRegisteredForThing(thing, certificate)) {
+            if (isCertificateRegisteredForThing(thing.getThingName(), certificate.getIotCertificateId())) {
                 return true;
             }
             throw e;
@@ -62,16 +130,16 @@ public class ThingRegistry {
     }
 
     private void registerCertificateForThing(Thing thing, Certificate certificate) {
-        registry.put(thing.getThingName(), certificate.getIotCertificateId());
+        registry.put(thing.getThingName(),
+                new ArrayList<>(Collections.singletonList(certificate.getIotCertificateId())));
     }
 
     private void clearRegistryForThing(Thing thing) {
         registry.remove(thing.getThingName());
     }
 
-    private boolean isCertificateRegisteredForThing(Thing thing, Certificate certificate) {
-        return Optional.ofNullable(registry.get(thing.getThingName()))
-                .filter(certId -> certId.equals(certificate.getIotCertificateId()))
-                .isPresent();
+    private boolean isCertificateRegisteredForThing(String thingName, String certificateId) {
+        Thing newThing = getThing(thingName);
+        return newThing != null && newThing.getAttachedCertificateIds().contains(certificateId);
     }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistry.java
@@ -10,7 +10,7 @@ import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionEx
 import com.aws.greengrass.clientdevices.auth.iot.Certificate;
 import com.aws.greengrass.clientdevices.auth.iot.IotAuthClient;
 import com.aws.greengrass.clientdevices.auth.iot.Thing;
-import com.aws.greengrass.clientdevices.auth.iot.events.ThingEvent;
+import com.aws.greengrass.clientdevices.auth.iot.events.ThingUpdated;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -77,9 +77,7 @@ public class ThingRegistry {
         }
 
         domainEvents.emit(
-                new ThingEvent(ThingEvent.ThingEventType.THING_UPDATED,
-                        thingName,
-                        new ArrayList<>(certificateIds)));
+                new ThingUpdated(thingName, new ArrayList<>(certificateIds)));
     }
 
     /**
@@ -97,9 +95,7 @@ public class ThingRegistry {
 
         certificateIds.remove(certificateId);
         domainEvents.emit(
-                new ThingEvent(ThingEvent.ThingEventType.THING_UPDATED,
-                        thingName,
-                        new ArrayList<>(certificateIds)));
+                new ThingUpdated(thingName, new ArrayList<>(certificateIds)));
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistry.java
@@ -39,12 +39,27 @@ public class ThingRegistry {
     }
 
     /**
+     * Get or create a Thing.
+     * @param thingName ThingName
+     * @return Thing object
+     */
+    public Thing getOrCreateThing(String thingName) {
+        Thing thing = getThingInternal(thingName);
+        if (thing == null) {
+            thing = createThing(thingName);
+        }
+        return thing;
+    }
+
+    /**
      * Create a Thing.
      * @param thingName ThingName
      * @return Thing object
      */
     public Thing createThing(String thingName) {
-        return updateThing(Thing.of(thingName));
+        Thing newThing = Thing.of(1, thingName);
+        storeThing(newThing);
+        return newThing.clone();
     }
 
     /**
@@ -54,7 +69,11 @@ public class ThingRegistry {
      * @return Thing domain object, if it exists
      */
     public Thing getThing(String thingName) {
-        return Thing.of(getThingInternal(thingName));
+        Thing thing = getThingInternal(thingName);
+        if (thing != null) {
+            return thing.clone();
+        }
+        return null;
     }
 
     /**
@@ -63,16 +82,16 @@ public class ThingRegistry {
      * @return      New Thing version
      */
     public Thing updateThing(Thing thing) {
-        // TODO - need to throw exception if provided Thing is not the most recent version
+        // TODO: this method should throw exceptions instead of returning
+        //  null if the Thing doesn't exist, if the caller is attempting to
+        //  update an old version, or if the Thing hasn't been modified.
         Thing oldThing = getThingInternal(thing.getThingName());
 
         if (oldThing == null) {
-            storeThing(thing);
-            return thing;
+            return null;
         }
 
         if (thing.getVersion() != oldThing.getVersion()) {
-            // TODO: throw exception since caller is trying to update an old version
             return null;
         }
 

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactory.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactory.java
@@ -59,7 +59,7 @@ public class MqttSessionFactory implements SessionFactory {
             if (!certificateId.isPresent()) {
                 throw new AuthenticationException("Certificate isn't active");
             }
-            Thing thing = new Thing(mqttCredential.clientId);
+            Thing thing = Thing.of(mqttCredential.clientId);
             Certificate cert = new Certificate(certificateId.get());
             if (!thingRegistry.isThingAttachedToCertificate(thing, cert)) {
                 throw new AuthenticationException("unable to authenticate device");

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactory.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactory.java
@@ -59,7 +59,7 @@ public class MqttSessionFactory implements SessionFactory {
             if (!certificateId.isPresent()) {
                 throw new AuthenticationException("Certificate isn't active");
             }
-            Thing thing = Thing.of(mqttCredential.clientId);
+            Thing thing = thingRegistry.getOrCreateThing(mqttCredential.clientId);
             Certificate cert = new Certificate(certificateId.get());
             if (!thingRegistry.isThingAttachedToCertificate(thing, cert)) {
                 throw new AuthenticationException("unable to authenticate device");

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/configuration/GroupManagerTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/configuration/GroupManagerTest.java
@@ -101,7 +101,7 @@ public class GroupManagerTest {
     }
 
     private Session getSessionFromThing(String thingName) {
-        Thing thing = new Thing(thingName);
+        Thing thing = Thing.of(thingName);
         Session session = new SessionImpl(new Certificate("FAKE_CERT_ID"));
         session.putAttributeProvider(thing.getNamespace(), thing);
         return session;

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/ThingTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/ThingTest.java
@@ -11,31 +11,107 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 public class ThingTest {
     @Test
-    public void GIVEN_validThingName_WHEN_Thing_THEN_objectIsCreated() {
-        Assertions.assertDoesNotThrow(() -> new Thing("abcdefghijklmnopqrstuvwxyz:_-"));
-        Assertions.assertDoesNotThrow(() -> new Thing("ABCDEFGHIJKLMNOPQRSTUXWXYZ"));
-        Assertions.assertDoesNotThrow(() -> new Thing("0123456789"));
+    void GIVEN_validThingName_WHEN_Thing_THEN_objectIsCreated() {
+        Assertions.assertDoesNotThrow(() -> Thing.of("abcdefghijklmnopqrstuvwxyz:_-"));
+        Assertions.assertDoesNotThrow(() -> Thing.of("ABCDEFGHIJKLMNOPQRSTUXWXYZ"));
+        Assertions.assertDoesNotThrow(() -> Thing.of("0123456789"));
     }
 
     @Test
-    public void GIVEN_emptyThingName_WHEN_Thing_THEN_exceptionThrown() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new Thing(""));
+    void GIVEN_emptyThingName_WHEN_Thing_THEN_exceptionThrown() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Thing.of(""));
     }
 
     @Test
-    public void GIVEN_thingNameWithInvalidCharacters_WHEN_Thing_THEN_exceptionThrown() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new Thing("Thing!"));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new Thing("Thing@"));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new Thing("Thing#"));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new Thing("Thing$"));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new Thing("Thing%"));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new Thing("Thing^"));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new Thing("Thing&"));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new Thing("Thing*"));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new Thing("Thing("));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new Thing("Thing)"));
+    void GIVEN_thingNameWithInvalidCharacters_WHEN_Thing_THEN_exceptionThrown() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Thing.of("Thing!"));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Thing.of("Thing@"));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Thing.of("Thing#"));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Thing.of("Thing$"));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Thing.of("Thing%"));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Thing.of("Thing^"));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Thing.of("Thing&"));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Thing.of("Thing*"));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Thing.of("Thing("));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Thing.of("Thing)"));
+    }
+
+    @Test
+    void GIVEN_invalidVersion_WHEN_Thing_THEN_exceptionThrown() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Thing.of(-1, "Thing"));
+        Assertions.assertDoesNotThrow(() -> Thing.of(0, "Thing"));
+    }
+
+    @Test
+    void GIVEN_thing_WHEN_attachCertificate_THEN_certAttachedAndDirtyBitSet() {
+        Thing thing = Thing.of(0, "Thing");
+        thing.attachCertificate("cert-id");
+
+        assertThat(thing.isModified(), is(true));
+        List<String> certIds = thing.getAttachedCertificateIds();
+        assertThat(certIds, equalTo(Collections.singletonList("cert-id")));
+    }
+
+    @Test
+    void GIVEN_thingWithCertificate_WHEN_attachSameCertificate_THEN_noChange() {
+        Thing thing = Thing.of(0, "Thing", Collections.singletonList("cert-id"));
+        thing.attachCertificate("cert-id");
+
+        assertThat(thing.isModified(), is(false));
+        List<String> certIds = thing.getAttachedCertificateIds();
+        assertThat(certIds, equalTo(Collections.singletonList("cert-id")));
+    }
+
+    @Test
+    void GIVEN_thingWithoutCertificate_WHEN_detachCertificate_THEN_noChange() {
+        Thing thing = Thing.of(0, "Thing");
+        thing.detachCertificate("cert-id");
+
+        assertThat(thing.isModified(), is(false));
+        List<String> certIds = thing.getAttachedCertificateIds();
+        assertThat(certIds, equalTo(Collections.emptyList()));
+    }
+
+    @Test
+    void GIVEN_thingWithCertificate_WHEN_detachCertificate_THEN_certDetachedAndDirtyBitSet() {
+        Thing thing = Thing.of(0, "Thing", Collections.singletonList("cert-id"));
+        thing.detachCertificate("cert-id");
+
+        assertThat(thing.isModified(), is(true));
+        List<String> certIds = thing.getAttachedCertificateIds();
+        assertThat(certIds, equalTo(Collections.emptyList()));
+    }
+
+    @Test
+    void testEquals() {
+        Thing version0_Thing_NoList = Thing.of(0, "Thing");
+        Thing version0_Thing2_NoList = Thing.of(0, "Thing2", Collections.emptyList());
+        Thing version0_Thing_EmptyList = Thing.of(0, "Thing", Collections.emptyList());
+        Thing version1_Thing_SingleCert = Thing.of(1, "Thing", Collections.singletonList("certId"));
+        Thing version1_Thing_SingleCert_copy = Thing.of(1, "Thing", Collections.singletonList("certId"));
+        Thing version2_Thing_SingleCert = Thing.of(2, "Thing", Collections.singletonList("certId"));
+        Thing version3_Thing_CertA = Thing.of(3, "Thing", Collections.singletonList("CertA"));
+        Thing version3_Thing_CertB = Thing.of(3, "Thing", Collections.singletonList("CertB"));
+        Thing version4_Thing_MultiCert = Thing.of(4, "Thing", Arrays.asList("Cert1", "Cert2"));
+        Thing version4_Thing_MultiCert_copy = Thing.of(4, "Thing", Arrays.asList("Cert1", "Cert2"));
+
+        assertThat(version0_Thing_NoList, equalTo(version0_Thing_EmptyList));
+        assertThat(version0_Thing_NoList, not(equalTo(version0_Thing2_NoList)));
+        assertThat(version1_Thing_SingleCert, equalTo(version1_Thing_SingleCert_copy));
+        assertThat(version1_Thing_SingleCert, not(equalTo(version2_Thing_SingleCert)));
+        assertThat(version3_Thing_CertA, not(equalTo(version3_Thing_CertB)));
+        assertThat(version4_Thing_MultiCert, equalTo(version4_Thing_MultiCert_copy));
     }
 }

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistryTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistryTest.java
@@ -58,11 +58,12 @@ class ThingRegistryTest {
         Thing retrievedThing = registry.getThing(mockThingName);
 
         assertThat(createdThing.getThingName(), is(mockThingName));
-        assertThat(createdThing.getVersion(), is(0));
+        assertThat(createdThing.getVersion(), is(1));
         assertThat(createdThing.getAttachedCertificateIds(), equalTo(Collections.emptyList()));
 
         assertThat(createdThing, equalTo(retrievedThing));
-        assertThat(createdThing != retrievedThing, is(true)); // Ensure a copy was returned
+        // IMPORTANT! Ensure a copy is returned. It is incorrect to call the equals method for this
+        assertThat(createdThing != retrievedThing, is(true));
 
         // TODO: check ThingUpdated event
     }
@@ -76,15 +77,10 @@ class ThingRegistryTest {
         // TODO: no update event
     }
 
+    @Disabled
     @Test
     void GIVEN_staleThing_WHEN_updateThing_THEN_updateRejected() {
-        Thing thing = registry.createThing(mockThingName);
-        //Thing thingCopy = Thing.of(thing);
-
-        thing.attachCertificate("new-cert");
-
-        // TODO: Finish me
-        // TODO: no update event
+        // TODO
     }
 
     @Test
@@ -100,21 +96,19 @@ class ThingRegistryTest {
         assertFalse(registry.isThingAttachedToCertificate(mockThing, mockCertificate));
     }
 
-    // TODO: fix this
-    @Disabled
     @Test
     void GIVEN_unreachable_cloud_WHEN_isThingAttachedToCertificate_THEN_return_cached_result() {
         // cache result before going offline
         Thing thing = registry.createThing(mockThingName);
         thing.attachCertificate(mockCertificate.getIotCertificateId());
-        registry.updateThing(thing);
+        Thing updatedThing = registry.updateThing(thing);
 
         // go offline
         doThrow(CloudServiceInteractionException.class)
                 .when(mockIotAuthClient).isThingAttachedToCertificate(any(), any());
 
         // verify cached result
-        assertTrue(registry.isThingAttachedToCertificate(mockThing, mockCertificate));
+        assertTrue(registry.isThingAttachedToCertificate(updatedThing, mockCertificate));
         verify(mockIotAuthClient, times(1)).isThingAttachedToCertificate(any(), any());
     }
 

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistryTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistryTest.java
@@ -11,7 +11,7 @@ import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionEx
 import com.aws.greengrass.clientdevices.auth.iot.Certificate;
 import com.aws.greengrass.clientdevices.auth.iot.IotAuthClient;
 import com.aws.greengrass.clientdevices.auth.iot.Thing;
-import com.aws.greengrass.clientdevices.auth.iot.events.ThingEvent;
+import com.aws.greengrass.clientdevices.auth.iot.events.ThingUpdated;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -102,16 +102,15 @@ class ThingRegistryTest {
 
     @Test
     void GIVEN_emptyRegistry_WHEN_attachCertificateToThing_THEN_thingEventEmitted() {
-        AtomicReference<ThingEvent> thingEvent = new AtomicReference();
-        Consumer<ThingEvent> eventListener = (event) -> thingEvent.set(event);
-        domainEvents.registerListener(eventListener, ThingEvent.class);
+        AtomicReference<ThingUpdated> thingEvent = new AtomicReference();
+        Consumer<ThingUpdated> eventListener = (event) -> thingEvent.set(event);
+        domainEvents.registerListener(eventListener, ThingUpdated.class);
 
         registry.attachCertificateToThing(mockThing.getThingName(), mockCertificate.getIotCertificateId());
 
         // ensure event contains the correct information
-        ThingEvent event = thingEvent.get();
+        ThingUpdated event = thingEvent.get();
         assertThat(event, is(notNullValue()));
-        assertThat(event.getEventType(), is(ThingEvent.ThingEventType.THING_UPDATED));
         assertThat(event.getThingName(), is(mockThing.getThingName()));
         assertThat(event.getAttachedCertificateIds(), is(notNullValue()));
         assertThat(event.getAttachedCertificateIds(), contains(mockCertificate.getIotCertificateId()));
@@ -119,18 +118,17 @@ class ThingRegistryTest {
 
     @Test
     void GIVEN_thingPresentInRegistry_WHEN_attachCertificateToThing_THEN_thingEventEmitted() {
-        AtomicReference<ThingEvent> thingEvent = new AtomicReference();
-        Consumer<ThingEvent> eventListener = (event) -> thingEvent.set(event);
-        domainEvents.registerListener(eventListener, ThingEvent.class);
+        AtomicReference<ThingUpdated> thingEvent = new AtomicReference();
+        Consumer<ThingUpdated> eventListener = (event) -> thingEvent.set(event);
+        domainEvents.registerListener(eventListener, ThingUpdated.class);
 
         // Initialize registry with Thing + Cert1 and then update
         registry.attachCertificateToThing(mockThing.getThingName(), mockCertificate.getIotCertificateId());
         registry.attachCertificateToThing(mockThing.getThingName(), mockCertificate2.getIotCertificateId());
 
         // ensure event contains the correct information
-        ThingEvent event = thingEvent.get();
+        ThingUpdated event = thingEvent.get();
         assertThat(event, is(notNullValue()));
-        assertThat(event.getEventType(), is(ThingEvent.ThingEventType.THING_UPDATED));
         assertThat(event.getThingName(), is(mockThing.getThingName()));
         assertThat(event.getAttachedCertificateIds(), is(notNullValue()));
         assertThat(event.getAttachedCertificateIds(),
@@ -140,9 +138,9 @@ class ThingRegistryTest {
 
     @Test
     void GIVEN_thingWithMultipleCertificates_WHEN_certificateDetached_THEN_thingEventEmitted() {
-        AtomicReference<ThingEvent> thingEvent = new AtomicReference();
-        Consumer<ThingEvent> eventListener = (event) -> thingEvent.set(event);
-        domainEvents.registerListener(eventListener, ThingEvent.class);
+        AtomicReference<ThingUpdated> thingEvent = new AtomicReference();
+        Consumer<ThingUpdated> eventListener = (event) -> thingEvent.set(event);
+        domainEvents.registerListener(eventListener, ThingUpdated.class);
 
         // Initialize registry with Thing with two certs, and then detach one
         registry.attachCertificateToThing(mockThing.getThingName(), mockCertificate.getIotCertificateId());
@@ -150,9 +148,8 @@ class ThingRegistryTest {
         registry.detachCertificateFromThing(mockThing.getThingName(), mockCertificate.getIotCertificateId());
 
         // ensure event contains the correct information
-        ThingEvent event = thingEvent.get();
+        ThingUpdated event = thingEvent.get();
         assertThat(event, is(notNullValue()));
-        assertThat(event.getEventType(), is(ThingEvent.ThingEventType.THING_UPDATED));
         assertThat(event.getThingName(), is(mockThing.getThingName()));
         assertThat(event.getAttachedCertificateIds(), is(notNullValue()));
         assertThat(event.getAttachedCertificateIds(), contains(mockCertificate2.getIotCertificateId()));
@@ -160,18 +157,17 @@ class ThingRegistryTest {
 
     @Test
     void GIVEN_thingPresentInRegistry_WHEN_certificateDetached_THEN_thingEventEmitted() {
-        AtomicReference<ThingEvent> thingEvent = new AtomicReference();
-        Consumer<ThingEvent> eventListener = (event) -> thingEvent.set(event);
-        domainEvents.registerListener(eventListener, ThingEvent.class);
+        AtomicReference<ThingUpdated> thingEvent = new AtomicReference();
+        Consumer<ThingUpdated> eventListener = (event) -> thingEvent.set(event);
+        domainEvents.registerListener(eventListener, ThingUpdated.class);
 
         // Initialize registry with Thing and then detach
         registry.attachCertificateToThing(mockThing.getThingName(), mockCertificate.getIotCertificateId());
         registry.detachCertificateFromThing(mockThing.getThingName(), mockCertificate.getIotCertificateId());
 
         // ensure event contains the correct information
-        ThingEvent event = thingEvent.get();
+        ThingUpdated event = thingEvent.get();
         assertThat(event, is(notNullValue()));
-        assertThat(event.getEventType(), is(ThingEvent.ThingEventType.THING_UPDATED));
         assertThat(event.getThingName(), is(mockThing.getThingName()));
         assertThat(event.getAttachedCertificateIds().size(), is(0));
     }

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactoryTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactoryTest.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.clientdevices.auth.session;
 import com.aws.greengrass.clientdevices.auth.DeviceAuthClient;
 import com.aws.greengrass.clientdevices.auth.exception.AuthenticationException;
 import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
+import com.aws.greengrass.clientdevices.auth.iot.Thing;
 import com.aws.greengrass.clientdevices.auth.iot.registry.CertificateRegistry;
 import com.aws.greengrass.clientdevices.auth.iot.Component;
 import com.aws.greengrass.clientdevices.auth.iot.registry.ThingRegistry;
@@ -55,6 +56,7 @@ public class MqttSessionFactoryTest {
     @Test
     void GIVEN_credentialsWithUnknownClientId_WHEN_createSession_THEN_throwsAuthenticationException() {
         when(mockCertificateRegistry.getIotCertificateIdForPem(any())).thenReturn(Optional.of("id"));
+        when(mockThingRegistry.getOrCreateThing(any())).thenReturn(Thing.of("clientId"));
         when(mockThingRegistry.isThingAttachedToCertificate(any(), any())).thenReturn(false);
 
         Assertions.assertThrows(AuthenticationException.class,
@@ -71,6 +73,7 @@ public class MqttSessionFactoryTest {
     @Test
     void GIVEN_credentialsWithCertificate_WHEN_createSession_AND_cloudError_THEN_throwsAuthenticationException() {
         when(mockCertificateRegistry.getIotCertificateIdForPem(any())).thenReturn(Optional.of("id"));
+        when(mockThingRegistry.getOrCreateThing(any())).thenReturn(Thing.of("clientId"));
         when(mockThingRegistry.isThingAttachedToCertificate(any(), any()))
                 .thenThrow(CloudServiceInteractionException.class);
         Assertions.assertThrows(AuthenticationException.class,
@@ -79,6 +82,7 @@ public class MqttSessionFactoryTest {
 
     @Test
     void GIVEN_credentialsWithValidClientId_WHEN_createSession_THEN_returnsSession() throws AuthenticationException {
+        when(mockThingRegistry.getOrCreateThing("clientId")).thenReturn(Thing.of("clientId"));
         when(mockCertificateRegistry.getIotCertificateIdForPem(any())).thenReturn(Optional.of("id"));
         when(mockThingRegistry.isThingAttachedToCertificate(any(), any())).thenReturn(true);
 

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/session/SessionImplTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/session/SessionImplTest.java
@@ -19,7 +19,7 @@ public class SessionImplTest {
     @Test
     public void GIVEN_sessionWithThingAndCert_WHEN_getSessionAttributes_THEN_attributesAreReturned() {
         Certificate cert = new Certificate("FAKE_CERT_ID");
-        Thing thing = new Thing("MyThing");
+        Thing thing = Thing.of("MyThing");
         Session session = new SessionImpl(cert);
         session.putAttributeProvider(thing.getNamespace(), thing);
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add new Thing Registry interface and emit events when Things are added/updated. This change is somewhat incomplete, as right now timestamps aren't included.

**Why is this change necessary:**
This will be a building block for follow-up PRs which introduce authentication use cases.

**How was this change tested:**
Unit tests

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
