### PR TITLE
refactor: add repository for registries

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/InMemoryRepository.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/InMemoryRepository.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.iot.registry;
+
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Mediates between the registry domain and the in-memory data storage.
+ *
+ * @param <K> Registry key type
+ * @param <V> Registry value type
+ */
+public class InMemoryRepository<K, V> implements Repository<K, V> {
+    // repository size bound by default registry cache size;
+    // it evicts oldest written entry if the max size is reached
+    private final Map<K, V> repository = Collections.synchronizedMap(
+            new LinkedHashMap<K, V>(RegistryConfig.REGISTRY_CACHE_SIZE, 0.75f, false) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry eldest) {
+                    return size() > RegistryConfig.REGISTRY_CACHE_SIZE;
+                }
+            });
+
+    @Override
+    public void put(K k, V v) {
+        repository.put(k, v);
+    }
+
+    @Override
+    public V get(K k) {
+        return repository.get(k);
+    }
+
+    @Override
+    public void remove(K k) {
+        repository.remove(k);
+    }
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/Repository.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/Repository.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.iot.registry;
+
+/**
+ * Mediates between the registry domain and data storage layer
+ * using a collection-like interface for accessing domain objects.
+ *
+ * @param <K> Registry key type
+ * @param <V> Registry value type
+ */
+public interface Repository<K, V> {
+    /**
+     * Puts a key-value pair into the repository.
+     *
+     * @param k Key object
+     * @param v Value object
+     */
+    void put(K k, V v);
+
+    /**
+     * Retrieves the value for the given key from the repository.
+     *
+     * @param k Key object
+     * @return associated value for the key
+     */
+    V get(K k);
+
+    /**
+     * Removes the entry for the given key from the repository.
+     *
+     * @param k Key object
+     */
+    void remove(K k);
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistry.java
@@ -12,30 +12,28 @@ import com.aws.greengrass.clientdevices.auth.iot.IotAuthClient;
 import com.aws.greengrass.clientdevices.auth.iot.Thing;
 import com.aws.greengrass.clientdevices.auth.iot.events.ThingUpdated;
 
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import javax.inject.Inject;
 
 public class ThingRegistry {
-    // holds mapping of thingName to IoT Certificate IDs;
-    // size-bound by default cache size, evicts oldest written entry if the max size is reached
-    private final Map<String, Thing> registry = Collections.synchronizedMap(
-            new LinkedHashMap<String, Thing>(RegistryConfig.REGISTRY_CACHE_SIZE, 0.75f, false) {
-                @Override
-                protected boolean removeEldestEntry(Map.Entry eldest) {
-                    return size() > RegistryConfig.REGISTRY_CACHE_SIZE;
-                }
-            });
-
     private final IotAuthClient iotAuthClient;
     private final DomainEvents domainEvents;
+    private final Repository<String, Thing> repository;
 
+    /**
+     * Constructor.
+     *
+     * @param iotAuthClient IoT Auth Client
+     * @param domainEvents  Domain Events
+     * @param repository    Repository for storage
+     */
     @Inject
-    public ThingRegistry(IotAuthClient iotAuthClient, DomainEvents domainEvents) {
+    public ThingRegistry(IotAuthClient iotAuthClient,
+                         DomainEvents domainEvents,
+                         InMemoryRepository<String, Thing> repository) {
         this.iotAuthClient = iotAuthClient;
         this.domainEvents = domainEvents;
+        this.repository = repository;
     }
 
     /**
@@ -105,11 +103,11 @@ public class ThingRegistry {
     }
 
     private Thing getThingInternal(String thingName) {
-        return registry.get(thingName);
+        return repository.get(thingName);
     }
 
     private Thing storeThing(Thing thing) {
-        registry.put(thing.getThingName(), thing);
+        repository.put(thing.getThingName(), thing);
         domainEvents.emit(new ThingUpdated(thing.getThingName(), thing.getVersion()));
         return thing;
     }

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/registry/CertificateRegistryTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/registry/CertificateRegistryTest.java
@@ -43,7 +43,7 @@ class CertificateRegistryTest {
 
     @BeforeEach
     void beforeEach() {
-        registry = new CertificateRegistry(mockIotAuthClient);
+        registry = new CertificateRegistry(mockIotAuthClient, new InMemoryRepository<>());
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistryTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistryTest.java
@@ -48,7 +48,7 @@ class ThingRegistryTest {
     @BeforeEach
     void beforeEach() {
         domainEvents = new DomainEvents();
-        registry = new ThingRegistry(mockIotAuthClient, domainEvents);
+        registry = new ThingRegistry(mockIotAuthClient, domainEvents, new InMemoryRepository<>());
     }
 
     @Test


### PR DESCRIPTION
**Description of changes:** adds `Repository` for the registries that mediates between the registry domain and the data storage layer. This Repository can be backed with in-memory as well as filesystem storage. This PR includes only the in-memory repository implementation.

**Why is this change necessary:** To be able to switch storage layer for registries.

**How was this change tested:** unit, integ tests (`mvn verify` , `mvn package`)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
