### PR TITLE
refactor: create session using attribute providers

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactory.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactory.java
@@ -46,7 +46,7 @@ public class MqttSessionFactory implements SessionFactory {
 
         boolean isGreengrassComponent = deviceAuthClient.isGreengrassComponent(mqttCredential.certificatePem);
         if (isGreengrassComponent) {
-            return createGreengrassComponentSession(mqttCredential);
+            return createGreengrassComponentSession();
         }
 
         return createIotThingSession(mqttCredential);
@@ -64,19 +64,14 @@ public class MqttSessionFactory implements SessionFactory {
             if (!thingRegistry.isThingAttachedToCertificate(thing, cert)) {
                 throw new AuthenticationException("unable to authenticate device");
             }
-            Session session = new SessionImpl(cert);
-            session.putAttributeProvider(Thing.NAMESPACE, thing);
-            return session;
+            return new SessionImpl(cert, thing);
         } catch (CloudServiceInteractionException e) {
             throw new AuthenticationException("Failed to verify certificate with cloud", e);
         }
     }
 
-    private Session createGreengrassComponentSession(MqttCredential mqttCredential) {
-        Certificate cert = new Certificate(mqttCredential.clientId);
-        Session session = new SessionImpl(cert);
-        session.putAttributeProvider(Component.NAMESPACE, new Component());
-        return session;
+    private Session createGreengrassComponentSession() {
+        return new SessionImpl(new Component());
     }
 
     private static class MqttCredential {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/session/Session.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/session/Session.java
@@ -8,8 +8,6 @@ package com.aws.greengrass.clientdevices.auth.session;
 import com.aws.greengrass.clientdevices.auth.session.attribute.AttributeProvider;
 import com.aws.greengrass.clientdevices.auth.session.attribute.DeviceAttribute;
 
-import java.util.function.Function;
-
 public interface Session {
 
     /**
@@ -19,26 +17,6 @@ public interface Session {
      * @return Attribute provider
      */
     AttributeProvider getAttributeProvider(String attributeProviderNameSpace);
-
-    /**
-     * Put attribute provider to the namespace.
-     *
-     * @param attributeProviderNameSpace Attribute namespace
-     * @param attributeProvider          Attribute provider
-     * @return Attribute provider put to the session
-     */
-    AttributeProvider putAttributeProvider(String attributeProviderNameSpace, AttributeProvider attributeProvider);
-
-    /**
-     * Compute and put attribute provider if the namespace is not occupied.
-     *
-     * @param attributeProviderNameSpace Attribute namespace
-     * @param mappingFunction            Mapping function to compute attribute provider
-     * @return Attribute provider put to the session
-     */
-    AttributeProvider computeAttributeProviderIfAbsent(String attributeProviderNameSpace,
-                                                       Function<? super String, ? extends AttributeProvider>
-                                                               mappingFunction);
 
     /**
      * Get session attribute.

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/session/SessionImpl.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/session/SessionImpl.java
@@ -5,41 +5,29 @@
 
 package com.aws.greengrass.clientdevices.auth.session;
 
-import com.aws.greengrass.clientdevices.auth.iot.Certificate;
 import com.aws.greengrass.clientdevices.auth.session.attribute.AttributeProvider;
 import com.aws.greengrass.clientdevices.auth.session.attribute.DeviceAttribute;
 
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
 
 public class SessionImpl extends ConcurrentHashMap<String, AttributeProvider> implements Session {
 
     static final long serialVersionUID = -1L;
 
-    // TODO: Replace this with Principal abstraction
-    // so that a session can be instantiated using something else
-    // e.g. username/password
-    public SessionImpl(Certificate certificate) {
+    /**
+     * Create a Session from a list of attribute providers.
+     * @param providers list of attribute providers
+     */
+    public SessionImpl(AttributeProvider...providers) {
         super();
-        this.put(certificate.getNamespace(), certificate);
+        for (AttributeProvider provider : providers) {
+            this.put(provider.getNamespace(), provider);
+        }
     }
 
     @Override
     public AttributeProvider getAttributeProvider(String attributeProviderNameSpace) {
         return this.get(attributeProviderNameSpace);
-    }
-
-    @Override
-    public AttributeProvider putAttributeProvider(String attributeProviderNameSpace,
-                                                  AttributeProvider attributeProvider) {
-        return this.put(attributeProviderNameSpace, attributeProvider);
-    }
-
-    @Override
-    public AttributeProvider computeAttributeProviderIfAbsent(String attributeProviderNameSpace,
-                                                              Function<? super String, ? extends AttributeProvider>
-                                                                      mappingFunction) {
-        return computeIfAbsent(attributeProviderNameSpace, mappingFunction);
     }
 
     /**

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/DeviceAuthClientTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/DeviceAuthClientTest.java
@@ -97,8 +97,7 @@ public class DeviceAuthClientTest {
 
     @Test
     void GIVEN_internalClientSession_WHEN_canDevicePerform_THEN_authorizationReturnTrue() throws Exception {
-        Session session = new SessionImpl(new Certificate("certificateId"));
-        session.putAttributeProvider(Component.NAMESPACE, new Component());
+        Session session = new SessionImpl(new Certificate("certificateId"), new Component());
         when(sessionManager.findSession("sessionId")).thenReturn(session);
 
         boolean authorized = authClient.canDevicePerform(constructAuthorizationRequest());

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/configuration/GroupManagerTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/configuration/GroupManagerTest.java
@@ -102,9 +102,7 @@ public class GroupManagerTest {
 
     private Session getSessionFromThing(String thingName) {
         Thing thing = Thing.of(thingName);
-        Session session = new SessionImpl(new Certificate("FAKE_CERT_ID"));
-        session.putAttributeProvider(thing.getNamespace(), thing);
-        return session;
+        return new SessionImpl(new Certificate("FAKE_CERT_ID"), thing);
     }
 
     private GroupDefinition getGroupDefinition(String thingName, String policyName) throws ParseException {

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/session/SessionImplTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/session/SessionImplTest.java
@@ -20,8 +20,7 @@ public class SessionImplTest {
     public void GIVEN_sessionWithThingAndCert_WHEN_getSessionAttributes_THEN_attributesAreReturned() {
         Certificate cert = new Certificate("FAKE_CERT_ID");
         Thing thing = Thing.of("MyThing");
-        Session session = new SessionImpl(cert);
-        session.putAttributeProvider(thing.getNamespace(), thing);
+        Session session = new SessionImpl(cert, thing);
 
         Assertions.assertEquals(session.getSessionAttribute("Certificate", "CertificateId").toString(),
                 cert.getDeviceAttributes().get("CertificateId").toString());


### PR DESCRIPTION
This change also removes interface methods that result in updating sessions, which results in sessions becoming immutable by contract instead of by convention (technically the underlying attribute providers can still change so this isn't 100% true)

It's TBD on whether this is actually the behavior we want. But for now this allows us to delete unused code.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
