### PR TITLE
feat: certificate registry

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Certificate.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Certificate.java
@@ -39,11 +39,7 @@ public class Certificate implements AttributeProvider {
     Instant lastUpdated;
 
 
-    /**
-     * TODO: Make this private.
-     * @param certificateId certificate ID
-     */
-    public Certificate(String certificateId) {
+    Certificate(String certificateId) {
         this.certificateId = certificateId;
         this.status = Status.UNKNOWN;
         this.lastUpdated = Instant.MIN;

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/CertificateRegistry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/CertificateRegistry.java
@@ -5,156 +5,67 @@
 
 package com.aws.greengrass.clientdevices.auth.iot.registry;
 
-import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
-import com.aws.greengrass.clientdevices.auth.iot.IotAuthClient;
-import com.aws.greengrass.logging.api.Logger;
-import com.aws.greengrass.logging.impl.LogManager;
-import com.aws.greengrass.util.Digest;
-import com.aws.greengrass.util.Utils;
+import com.aws.greengrass.clientdevices.auth.iot.Certificate;
+import com.aws.greengrass.clientdevices.auth.iot.InvalidCertificateException;
 
-import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
-import javax.inject.Inject;
 
 
 public class CertificateRegistry {
-    private static final Logger logger = LogManager.getLogger(CertificateRegistry.class);
-    // holds mapping of certificateHash (SHA-256 hash of certificatePem) to IoT Certificate Id;
-    // size-bound by default cache size, evicts oldest written entry if the max size is reached
-    private final Map<String, String> registry = Collections.synchronizedMap(
-            new LinkedHashMap<String, String>(RegistryConfig.REGISTRY_CACHE_SIZE, 0.75f, false) {
+    // holds certificate metadata -- this is a temporary implementation
+    // which will be replaced in subsequent PRs
+    private final Map<String, Certificate> registry = Collections.synchronizedMap(
+            new LinkedHashMap<String, Certificate>(RegistryConfig.REGISTRY_CACHE_SIZE, 0.75f, false) {
                 @Override
                 protected boolean removeEldestEntry(Map.Entry eldest) {
                     return size() > RegistryConfig.REGISTRY_CACHE_SIZE;
                 }
             });
 
-    private final IotAuthClient iotAuthClient;
-
     /**
-     * Constructor.
-     *
-     * @param iotAuthClient IoT Auth Client
+     * Retrieve certificate by certificate pem.
+     * @param certificatePem cert pem
+     * @return certificate object
+     * @throws InvalidCertificateException if certificate PEM is invalid
      */
-    @Inject
-    public CertificateRegistry(IotAuthClient iotAuthClient) {
-        this.iotAuthClient = iotAuthClient;
+    public Optional<Certificate> getCertificateFromPem(String certificatePem) throws InvalidCertificateException {
+        Certificate cert = Certificate.fromPem(certificatePem);
+        return getCertificateById(cert.getCertificateId());
+    }
+
+    public Certificate createCertificate(String certificatePem) throws InvalidCertificateException {
+        return Certificate.fromPem(certificatePem);
     }
 
     /**
-     * Returns whether the provided certificate is valid and active.
-     * Returns valid locally registered result when IoT Core cannot be reached.
-     *
-     * @param certificatePem Certificate PEM
-     * @return true if the certificate is valid and active.
-     * @throws CloudServiceInteractionException if the certificate cannot be validated
+     * Update certificate.
+     * @param certificate certificate object
      */
-    public boolean isCertificateValid(String certificatePem) {
-        try {
-            Optional<String> certId = fetchActiveCertificateId(certificatePem);
-            updateRegistryForCertificate(certificatePem, certId);
-            return certId.isPresent();
-        } catch (CloudServiceInteractionException e) {
-            return getAssociatedCertificateId(certificatePem)
-                    .map(certId -> true)
-                    .orElseThrow(() -> e);
-        }
+    public void updateCertificate(Certificate certificate) {
+        storeCertificateMetadata(certificate);
     }
 
     /**
-     * Get IoT Certificate ID for given certificate pem.
-     * Active IoT Certificate Ids are cached locally to avoid multiple cloud requests.
-     *
-     * @param certificatePem Certificate PEM
-     * @return IoT Certificate ID or empty Optional if certificate is inactive/invalid
-     * @throws IllegalArgumentException for empty certificate PEM
-     * @throws CloudServiceInteractionException if IoT certificate Id cannot be fetched
+     * Removes a certificate from the registry.
+     * @param certificate certificate to remove
      */
-    public Optional<String> getIotCertificateIdForPem(String certificatePem) {
-        if (Utils.isEmpty(certificatePem)) {
-            throw new IllegalArgumentException("Certificate PEM is empty");
-        }
-        try {
-            Optional<String> certId = getAssociatedCertificateId(certificatePem).map(Optional::of)
-                    .orElseGet(() -> fetchActiveCertificateId(certificatePem));
-            updateRegistryForCertificate(certificatePem, certId);
-            return certId;
-        } catch (CloudServiceInteractionException e) {
-            return getAssociatedCertificateId(certificatePem).map(Optional::of)
-                    .orElseThrow(() -> e);
-        }
+    public void removeCertificate(Certificate certificate) {
+        removeCertificateMetadata(certificate);
     }
 
-    /**
-     * Retrieves Certificate ID from IoT Core.
-     *
-     * @param certificatePem Certificate PEM
-     * @return IoT Certificate ID or empty Optional if certificate is inactive or invalid
-     */
-    private Optional<String> fetchActiveCertificateId(String certificatePem) {
-        return iotAuthClient.getActiveCertificateId(certificatePem);
+    private void storeCertificateMetadata(Certificate certificate) {
+        registry.put(certificate.getCertificateId(), certificate);
     }
 
-    /**
-     * Returns IoT Certificate ID associated locally for given certificate PEM.
-     *
-     * @param certificatePem Certificate PEM
-     * @return Certificate ID or empty optional
-     */
-    private Optional<String> getAssociatedCertificateId(String certificatePem) {
-        return Optional.ofNullable(getCertificateHash(certificatePem))
-                .map(registry::get);
+    private void removeCertificateMetadata(Certificate certificate) {
+        registry.remove(certificate.getCertificateId());
     }
 
-    /**
-     * Locally caches IoT Certificate ID mapping for Certificate PEM.
-     *
-     * @param certificateId IoT Certificate ID
-     * @param certificatePem Certificate PEM
-     */
-    private void registerCertificateIdForPem(String certificateId, String certificatePem) {
-        Optional.ofNullable(getCertificateHash(certificatePem))
-                .ifPresent(certHash -> registry.put(certHash, certificateId));
-    }
-
-    /**
-     * Updates certPem <-> IoT Certificate ID association in the registry.
-     *
-     * @param certificatePem Certificate PEM
-     * @param iotCertificateId Optional of IoT Certificate ID
-     */
-    private void updateRegistryForCertificate(String certificatePem, Optional<String> iotCertificateId) {
-        if (iotCertificateId.isPresent()) {
-            registerCertificateIdForPem(iotCertificateId.get(), certificatePem);
-        } else {
-            clearRegistryForPem(certificatePem);
-        }
-    }
-
-    /**
-     * Removes registry entry for Certificate PEM.
-     *
-     * @param certificatePem Certificate PEM
-     */
-    private void clearRegistryForPem(String certificatePem) {
-        Optional.ofNullable(getCertificateHash(certificatePem))
-                .ifPresent(registry::remove);
-    }
-
-    /**
-     * Returns SHA-256 hash of given CertificatePem.
-     * @param certificatePem certificate pem
-     * @return Certificate hash or null if hash could not be calculated
-     */
-    private String getCertificateHash(String certificatePem) {
-        try {
-            return Digest.calculate(certificatePem);
-        } catch (NoSuchAlgorithmException e) {
-            logger.atWarn().cause(e).log("CertificatePem to CertificateId mapping could not be cached");
-        }
-        return null;
+    private Optional<Certificate> getCertificateById(String certificateId) {
+        Certificate cert = registry.get(certificateId);
+        return Optional.ofNullable(cert);
     }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/CertificateRegistry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/CertificateRegistry.java
@@ -27,6 +27,7 @@ public class CertificateRegistry {
 
     /**
      * Retrieve certificate by certificate pem.
+     *
      * @param certificatePem cert pem
      * @return certificate object
      * @throws InvalidCertificateException if certificate PEM is invalid
@@ -36,12 +37,26 @@ public class CertificateRegistry {
         return getCertificateById(cert.getCertificateId());
     }
 
+    /**
+     * Create and store a new certificate.
+     * </p>
+     * Certificates are created with an initial UNKNOWN state. Callers
+     * are responsible for updating the appropriate metadata and then
+     * calling {@link #updateCertificate(Certificate)}
+     *
+     * @param certificatePem Certificate PEM
+     * @return certificate object
+     * @throws InvalidCertificateException if certificate PEM is invalid
+     */
     public Certificate createCertificate(String certificatePem) throws InvalidCertificateException {
-        return Certificate.fromPem(certificatePem);
+        Certificate newCert = Certificate.fromPem(certificatePem);
+        updateCertificate(newCert);
+        return newCert;
     }
 
     /**
      * Update certificate.
+     *
      * @param certificate certificate object
      */
     public void updateCertificate(Certificate certificate) {
@@ -50,6 +65,7 @@ public class CertificateRegistry {
 
     /**
      * Removes a certificate from the registry.
+     *
      * @param certificate certificate to remove
      */
     public void removeCertificate(Certificate certificate) {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/usecases/VerifyIotCertificate.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/usecases/VerifyIotCertificate.java
@@ -7,44 +7,64 @@ package com.aws.greengrass.clientdevices.auth.iot.usecases;
 
 import com.aws.greengrass.clientdevices.auth.api.Result;
 import com.aws.greengrass.clientdevices.auth.api.UseCases;
+import com.aws.greengrass.clientdevices.auth.iot.Certificate;
+import com.aws.greengrass.clientdevices.auth.iot.InvalidCertificateException;
+import com.aws.greengrass.clientdevices.auth.iot.IotAuthClient;
 import com.aws.greengrass.clientdevices.auth.iot.registry.CertificateRegistry;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
 
+import java.util.Optional;
 import javax.inject.Inject;
 
 public class VerifyIotCertificate implements UseCases.UseCase<Boolean, String> {
+    private static final Logger logger = LogManager.getLogger(VerifyIotCertificate.class);
+
+    private final IotAuthClient iotAuthClient;
     private final CertificateRegistry certificateRegistry;
 
 
     /**
-     * Register core certificate authority with Greengrass cloud.
+     * Verify a certificate with IoT Core.
      *
+     * @param iotAuthClient       IoT auth client
      * @param certificateRegistry Certificate Registry
      */
     @Inject
-    public VerifyIotCertificate(CertificateRegistry certificateRegistry) {
+    public VerifyIotCertificate(IotAuthClient iotAuthClient, CertificateRegistry certificateRegistry) {
+        this.iotAuthClient = iotAuthClient;
         this.certificateRegistry = certificateRegistry;
     }
 
     @Override
     public Result<Boolean> apply(String certificatePem) {
-        return Result.ok(certificateRegistry.isCertificateValid(certificatePem));
+        Optional<String> certId = iotAuthClient.getActiveCertificateId(certificatePem);
 
-        /*
-        String source = "cloud";
-        Certificate iotCert;
+        // TODO: This code will not handle the case where a certificate is revoked
+        //  This will be handled as part of a subsequent PR, as making that change
+        //  now breaks a lot of fragile tests
+        if (certId.isPresent()) {
+            try {
+                Certificate clientCertificate;
+                Optional<Certificate> cert = certificateRegistry.getCertificateFromPem(certificatePem);
 
-        try {
-            iotCert = iotAuthClient.getIotCertificate(certificatePem);
-        } catch (InvalidCertificateException e) {
-            return Result.ok(false);
+                if (cert.isPresent()) {
+                    clientCertificate = cert.get();
+                } else {
+                    clientCertificate = certificateRegistry.createCertificate(certificatePem);
+                }
+
+                clientCertificate.setStatus(Certificate.Status.ACTIVE);
+                certificateRegistry.updateCertificate(clientCertificate);
+            } catch (InvalidCertificateException e) {
+                // This should never happen
+                logger.atError()
+                        .kv("CertificateID", certId.get())
+                        .log("Unable to create Certificate object from client certificate, despite having received a "
+                                + "valid certificate ID from IoT Core");
+            }
         }
 
-        logger.atDebug().kv("CertificateID", iotCert.getCertificateId())
-                .kv("status", iotCert.getStatus())
-                .kv("source", source)
-                .log("Verifying client device certificate");
-
-        return Result.ok(iotCert.isActive());
-         */
+        return Result.ok(iotAuthClient.getActiveCertificateId(certificatePem).isPresent());
     }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/usecases/VerifyIotCertificate.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/usecases/VerifyIotCertificate.java
@@ -40,9 +40,12 @@ public class VerifyIotCertificate implements UseCases.UseCase<Boolean, String> {
     public Result<Boolean> apply(String certificatePem) {
         Optional<String> certId = iotAuthClient.getActiveCertificateId(certificatePem);
 
-        // TODO: This code will not handle the case where a certificate is revoked
-        //  This will be handled as part of a subsequent PR, as making that change
-        //  now breaks a lot of fragile tests
+        // NOTE: This code will not remove certificates from the registry if they are revoked
+        //  in IoT Core. This is currently okay, as we will fail those connections during the
+        //  TLS handshake.
+        // Eventually, we need to handle offline and cert revocation scenarios. However, that
+        //  will be handled as part of a subsequent PR, as making that change now breaks a lot
+        //  of fragile tests
         if (certId.isPresent()) {
             try {
                 Certificate clientCertificate;

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/DeviceAuthClientTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/DeviceAuthClientTest.java
@@ -12,7 +12,6 @@ import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.clientdevices.auth.configuration.GroupManager;
 import com.aws.greengrass.clientdevices.auth.configuration.Permission;
 import com.aws.greengrass.clientdevices.auth.exception.AuthorizationException;
-import com.aws.greengrass.clientdevices.auth.iot.Certificate;
 import com.aws.greengrass.clientdevices.auth.iot.Component;
 import com.aws.greengrass.clientdevices.auth.session.Session;
 import com.aws.greengrass.clientdevices.auth.session.SessionImpl;
@@ -74,7 +73,7 @@ public class DeviceAuthClientTest {
     @Test
     void GIVEN_missingDevicePermission_WHEN_canDevicePerform_THEN_authorizationReturnFalse() throws Exception {
         String sessionId = "FAKE_SESSION";
-        Session session = new SessionImpl(new Certificate("certificateId"));
+        Session session = new SessionImpl();
         when(sessionManager.findSession(sessionId)).thenReturn(session);
         AuthorizationRequest authorizationRequest =
                 new AuthorizationRequest("mqtt:connect", "mqtt:clientId:clientId", sessionId);
@@ -83,7 +82,7 @@ public class DeviceAuthClientTest {
 
     @Test
     void GIVEN_sessionHasPermission_WHEN_canDevicePerform_THEN_authorizationReturnTrue() throws Exception {
-        Session session = new SessionImpl(new Certificate("certificateId"));
+        Session session = new SessionImpl();
         when(sessionManager.findSession("sessionId")).thenReturn(session);
         when(groupManager.getApplicablePolicyPermissions(session)).thenReturn(Collections.singletonMap("group1",
                 Collections.singleton(
@@ -97,7 +96,7 @@ public class DeviceAuthClientTest {
 
     @Test
     void GIVEN_internalClientSession_WHEN_canDevicePerform_THEN_authorizationReturnTrue() throws Exception {
-        Session session = new SessionImpl(new Certificate("certificateId"), new Component());
+        Session session = new SessionImpl(new Component());
         when(sessionManager.findSession("sessionId")).thenReturn(session);
 
         boolean authorized = authClient.canDevicePerform(constructAuthorizationRequest());

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/helpers/CertificateTestHelpers.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/helpers/CertificateTestHelpers.java
@@ -70,7 +70,7 @@ public final class CertificateTestHelpers {
     }
 
     private enum CertificateTypes {
-        ROOT_CA, INTERMEDIATE_CA, SERVER_CERTIFICATE
+        ROOT_CA, INTERMEDIATE_CA, SERVER_CERTIFICATE, CLIENT_CERTIFICATE
     }
 
     public static X509Certificate createRootCertificateAuthority(String commonName, KeyPair kp)
@@ -85,10 +85,18 @@ public final class CertificateTestHelpers {
         return createCertificate(caCert, commonName, publicKey, caPrivateKey, CertificateTypes.INTERMEDIATE_CA);
     }
 
-    static X509Certificate createServerCertificate(X509Certificate caCert, String commonName, PublicKey publicKey,
+    public static X509Certificate createServerCertificate(X509Certificate caCert, String commonName,
+                                                          PublicKey publicKey,
                                                    PrivateKey caPrivateKey)
             throws NoSuchAlgorithmException, CertificateException, IOException, OperatorCreationException {
         return createCertificate(caCert, commonName, publicKey, caPrivateKey, CertificateTypes.SERVER_CERTIFICATE);
+    }
+
+    public static X509Certificate createClientCertificate(X509Certificate caCert, String commonName,
+                                                          PublicKey publicKey,
+                                                   PrivateKey caPrivateKey)
+            throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, CertIOException {
+        return createCertificate(caCert, commonName, publicKey, caPrivateKey, CertificateTypes.CLIENT_CERTIFICATE);
     }
 
     private static X509Certificate createCertificate(X509Certificate caCert, String commonName, PublicKey publicKey,
@@ -149,6 +157,15 @@ public final class CertificateTestHelpers {
                     .addExtension(Extension.basicConstraints, true, new BasicConstraints(false))
                     .addExtension(Extension.extendedKeyUsage, true,
                             new ExtendedKeyUsage(KeyPurposeId.id_kp_serverAuth));
+        }
+
+        if (type == CertificateTypes.CLIENT_CERTIFICATE) {
+            builder
+                    .addExtension(Extension.authorityKeyIdentifier, false,
+                            extUtils.createAuthorityKeyIdentifier(caCert))
+                    .addExtension(Extension.basicConstraints, true, new BasicConstraints(false))
+                    .addExtension(Extension.extendedKeyUsage, true,
+                            new ExtendedKeyUsage(KeyPurposeId.id_kp_clientAuth));
         }
     }
 

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/CertificateFake.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/CertificateFake.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.iot;
+
+import lombok.Getter;
+import org.bouncycastle.util.encoders.Hex;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public final class CertificateFake extends Certificate {
+    @Getter
+    private final String certificatePem;
+
+    private CertificateFake(String certificatePem, String certificateId) {
+        super(certificateId);
+        this.certificatePem = certificatePem;
+    }
+
+    public static CertificateFake of(String certPem) throws InvalidCertificateException {
+        return new CertificateFake(certPem, CertificateFake.computeCertificateId(certPem));
+    }
+
+    public static CertificateFake activeCertificate() throws InvalidCertificateException {
+        return CertificateFake.activeCertificate("");
+    }
+
+    public static CertificateFake activeCertificate(String certPem) throws InvalidCertificateException {
+        CertificateFake cert = CertificateFake.of(certPem);
+        cert.setStatus(Status.ACTIVE);
+        return cert;
+    }
+
+    private static String computeCertificateId(String certPem) throws InvalidCertificateException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            digest.reset();
+            return new String(Hex.encode(digest.digest(certPem.getBytes(StandardCharsets.UTF_8))), StandardCharsets.UTF_8);
+        } catch (NoSuchAlgorithmException e) {
+            throw new InvalidCertificateException("Unable to compute certificate ID", e);
+        }
+    }
+}

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/registry/CertificateRegistryTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/registry/CertificateRegistryTest.java
@@ -12,7 +12,6 @@ import com.aws.greengrass.clientdevices.auth.iot.Certificate;
 import com.aws.greengrass.clientdevices.auth.iot.InvalidCertificateException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.bouncycastle.operator.OperatorCreationException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,18 +40,16 @@ class CertificateRegistryTest {
     private CertificateRegistry registry;
 
     @BeforeAll
-    static void beforeAll() {
-        try {
-            KeyPair rootKeyPair = CertificateStore.newRSAKeyPair(2048);
-            KeyPair clientKeyPair = CertificateStore.newRSAKeyPair(2048);
-            X509Certificate rootCA = CertificateTestHelpers.createRootCertificateAuthority("root", rootKeyPair);
+    static void beforeAll()
+            throws CertificateException, NoSuchAlgorithmException, OperatorCreationException, IOException {
+        KeyPair rootKeyPair = CertificateStore.newRSAKeyPair(2048);
+        KeyPair clientKeyPair = CertificateStore.newRSAKeyPair(2048);
+        X509Certificate rootCA = CertificateTestHelpers.createRootCertificateAuthority("root", rootKeyPair);
 
-            validClientCertificate = CertificateTestHelpers.createClientCertificate(rootCA, "Client", clientKeyPair.getPublic(),
-                    rootKeyPair.getPrivate());
-            validClientCertificatePem = CertificateHelper.toPem(validClientCertificate);
-        } catch (NoSuchAlgorithmException | CertificateException | OperatorCreationException | IOException e) {
-            Assertions.fail("Unable to initialize test certificates!");
-        }
+        validClientCertificate =
+                CertificateTestHelpers.createClientCertificate(rootCA, "Client", clientKeyPair.getPublic(),
+                        rootKeyPair.getPrivate());
+        validClientCertificatePem = CertificateHelper.toPem(validClientCertificate);
     }
 
     @BeforeEach

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistryTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistryTest.java
@@ -9,6 +9,8 @@ package com.aws.greengrass.clientdevices.auth.iot.registry;
 import com.aws.greengrass.clientdevices.auth.api.DomainEvents;
 import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
 import com.aws.greengrass.clientdevices.auth.iot.Certificate;
+import com.aws.greengrass.clientdevices.auth.iot.CertificateFake;
+import com.aws.greengrass.clientdevices.auth.iot.InvalidCertificateException;
 import com.aws.greengrass.clientdevices.auth.iot.IotAuthClient;
 import com.aws.greengrass.clientdevices.auth.iot.Thing;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
@@ -37,8 +39,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 class ThingRegistryTest {
     private static final String mockThingName = "mock-thing";
-    private static final Thing mockThing = Thing.of("mock-thing");
-    private static final Certificate mockCertificate = new Certificate("mock-certificateId");
+    private static final Thing mockThing = Thing.of(mockThingName);
+    private static Certificate mockCertificate;
 
     @Mock
     private IotAuthClient mockIotAuthClient;
@@ -46,9 +48,10 @@ class ThingRegistryTest {
     private ThingRegistry registry;
 
     @BeforeEach
-    void beforeEach() {
+    void beforeEach() throws InvalidCertificateException {
         domainEvents = new DomainEvents();
         registry = new ThingRegistry(mockIotAuthClient, domainEvents);
+        mockCertificate = CertificateFake.of("mock-certificateId");
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/session/SessionImplTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/session/SessionImplTest.java
@@ -6,6 +6,8 @@
 package com.aws.greengrass.clientdevices.auth.session;
 
 import com.aws.greengrass.clientdevices.auth.iot.Certificate;
+import com.aws.greengrass.clientdevices.auth.iot.CertificateFake;
+import com.aws.greengrass.clientdevices.auth.iot.InvalidCertificateException;
 import com.aws.greengrass.clientdevices.auth.iot.Thing;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.junit.jupiter.api.Assertions;
@@ -17,8 +19,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class SessionImplTest {
 
     @Test
-    public void GIVEN_sessionWithThingAndCert_WHEN_getSessionAttributes_THEN_attributesAreReturned() {
-        Certificate cert = new Certificate("FAKE_CERT_ID");
+    public void GIVEN_sessionWithThingAndCert_WHEN_getSessionAttributes_THEN_attributesAreReturned()
+            throws InvalidCertificateException {
+        Certificate cert = CertificateFake.of("FAKE_CERT_ID");
         Thing thing = Thing.of("MyThing");
         Session session = new SessionImpl(cert, thing);
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This change removes IoT Core logic from the Certificate Registry -- it now serves as a repository for certificates.

The VerifyIotCertificate use case now inserts certificates into the registry after it validates them.

The MqttSessionFactory retrieves certificates from the Certificate Registry, which removes one cloud API call. However, it is still calling IoT Core to validate  Thing <-> Certificate attachment. Removing that can come later.

This change also introduces a new CertificateFake object helps somewhat with tests, as it allows us to instantiate Certificates without a valid PEM. There are also now test utils for generating client certs. We can slowly improve our test quality over time by migrating to these. Currently the tests are still quite fragile.

**Why is this change necessary:**

**How was this change tested:**
Manual / unit tests

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
