### PR TITLE
feat: add Thing configuration store adapter

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -15,6 +15,7 @@ import com.aws.greengrass.clientdevices.auth.certificate.handlers.CertificateRot
 import com.aws.greengrass.clientdevices.auth.configuration.CDAConfiguration;
 import com.aws.greengrass.clientdevices.auth.configuration.GroupConfiguration;
 import com.aws.greengrass.clientdevices.auth.configuration.GroupManager;
+import com.aws.greengrass.clientdevices.auth.configuration.RuntimeConfiguration;
 import com.aws.greengrass.clientdevices.auth.connectivity.CISShadowMonitor;
 import com.aws.greengrass.clientdevices.auth.infra.NetworkState;
 import com.aws.greengrass.clientdevices.auth.session.MqttSessionFactory;
@@ -89,6 +90,7 @@ public class ClientDevicesAuthService extends PluginService {
 
         context.get(UseCases.class).init(context);
         context.get(CertificateManager.class).updateCertificatesConfiguration(new CertificatesConfig(getConfig()));
+        context.put(RuntimeConfiguration.class, RuntimeConfiguration.from(getRuntimeConfig()));
         initializeInfrastructure();
         initializeHandlers();
         subscribeToConfigChanges();

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -90,7 +90,6 @@ public class ClientDevicesAuthService extends PluginService {
 
         context.get(UseCases.class).init(context);
         context.get(CertificateManager.class).updateCertificatesConfiguration(new CertificatesConfig(getConfig()));
-        context.put(RuntimeConfiguration.class, RuntimeConfiguration.from(getRuntimeConfig()));
         initializeInfrastructure();
         initializeHandlers();
         subscribeToConfigChanges();
@@ -109,6 +108,7 @@ public class ClientDevicesAuthService extends PluginService {
     }
 
     private void initializeInfrastructure() {
+        context.put(RuntimeConfiguration.class, RuntimeConfiguration.from(getRuntimeConfig()));
         cloudCallQueueSize = DEFAULT_CLOUD_CALL_QUEUE_SIZE;
         cloudCallQueueSize = getValidCloudCallQueueSize(config);
         cloudCallThreadPool = new ThreadPoolExecutor(1,

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/RuntimeConfiguration.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/RuntimeConfiguration.java
@@ -21,8 +21,9 @@ import java.util.Map;
  * |    |---- certificates:
  * |         |---- authorities: [...]
  * |    |---- clientDeviceThings:
- * |          |---- thingName:
- * |                |---- key: value
+ * |          |---- schemaVersion:
+ * |                |---- thingName:
+ * |                      |---- key: value
  * </p>
  */
 public final class RuntimeConfiguration {
@@ -73,31 +74,37 @@ public final class RuntimeConfiguration {
     /**
      * Retrieves opaque client device thing configuration.
      *
-     * @param thingName Thing name
+     * @param thingName     Thing name
+     * @param schemaVersion Thing config schema version
      * @return config topic mapped to given thing name
      */
-    public Topics getClientDeviceThing(String thingName) {
-        return config.findTopics(CLIENT_DEVICE_THINGS_KEY, thingName);
+    public Topics getClientDeviceThing(String thingName, String schemaVersion) {
+        return config.findTopics(CLIENT_DEVICE_THINGS_KEY, schemaVersion, thingName);
     }
 
     /**
      * Create or replace client device thing details in the config.
-     * @param thingName    client device thing name
-     * @param thingDetails thing details
+     *
+     * @param thingName     client device thing name
+     * @param thingDetails  thing details
+     * @param schemaVersion Thing config schema version
      */
-    public void createOrReplaceClientDeviceThing(String thingName, Map<String, Object> thingDetails) {
-        Topics clientDeviceThing = config.lookupTopics(CLIENT_DEVICE_THINGS_KEY, thingName);
+    public void createOrReplaceClientDeviceThing(String thingName,
+                                                 Map<String, Object> thingDetails,
+                                                 String schemaVersion) {
+        Topics clientDeviceThing = config.lookupTopics(CLIENT_DEVICE_THINGS_KEY, schemaVersion, thingName);
         clientDeviceThing.replaceAndWait(thingDetails);
     }
 
     /**
      * Update client device thing details in the config.
      *
-     * @param thingName    client device Thing name
-     * @param thingDetails map of client device Thing details to be updated
+     * @param thingName     client device Thing name
+     * @param thingDetails  map of client device Thing details to be updated
+     * @param schemaVersion Thing config schema version
      */
-    public void updateClientDeviceThing(String thingName, Map<String, Object> thingDetails) {
-        Topics clientDeviceThing = config.findTopics(CLIENT_DEVICE_THINGS_KEY, thingName);
+    public void updateClientDeviceThing(String thingName, Map<String, Object> thingDetails, String schemaVersion) {
+        Topics clientDeviceThing = config.findTopics(CLIENT_DEVICE_THINGS_KEY, schemaVersion, thingName);
         if (clientDeviceThing == null) {
             return;
         }
@@ -108,7 +115,7 @@ public final class RuntimeConfiguration {
     private void updateClientDeviceThingDetail(Topics clientDeviceThing, String detailKey, Object newValue) {
         Topic thingDetail = clientDeviceThing.lookup(detailKey);
         IllegalArgumentException ex = new IllegalArgumentException(
-                String.format("Unsupported thing detail value %s", newValue));
+                String.format("Unsupported thing detail value: %s", newValue));
         if (newValue instanceof Integer) {
             thingDetail.withValue((Integer) newValue);
         } else if (newValue instanceof String) {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/RuntimeConfiguration.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/RuntimeConfiguration.java
@@ -9,7 +9,9 @@ import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.util.Coerce;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Manages the runtime configuration for the plugin. It allows to read and write
@@ -19,6 +21,9 @@ import java.util.List;
  * |    |---- ca_passphrase: "..."
  * |    |---- certificates:
  * |         |---- authorities: [...]
+ * |    |---- clientDeviceThings:
+ * |          |---- thingName:
+ * |                |---- key: "value"
  * |
  * </p>
  */
@@ -26,6 +31,7 @@ public final class RuntimeConfiguration {
     public static final String CA_PASSPHRASE_KEY = "ca_passphrase";
     private static final String AUTHORITIES_KEY = "authorities";
     private static final String CERTIFICATES_KEY = "certificates";
+    private static final String CLIENT_DEVICE_THINGS_KEY = "clientDeviceThings";
     private final Topics config;
 
 
@@ -66,4 +72,31 @@ public final class RuntimeConfiguration {
         caPassphrase.withValue(passphrase);
     }
 
+    /**
+     * Update (or create if not available) opaque client device thing details in the config.
+     *
+     * @param thingName    client device Thing name
+     * @param thingDetails opaque client device Thing details
+     */
+    public void updateClientDeviceThing(String thingName, Map<String, Object> thingDetails) {
+        Topics clientDeviceThings = config.lookupTopics(CLIENT_DEVICE_THINGS_KEY);
+        Topics clientDeviceThing = clientDeviceThings.lookupTopics(thingName);
+        clientDeviceThing.replaceAndWait(thingDetails);
+    }
+
+    /**
+     * Retrieves opaque client device thing details from the config.
+     *
+     * @param thingName Thing name
+     * @return map of thing details
+     */
+    public Map<String, Object> getClientDeviceThing(String thingName) {
+        Topics clientDeviceThings = config.findTopics(CLIENT_DEVICE_THINGS_KEY);
+        if (clientDeviceThings == null || clientDeviceThings.findTopics(thingName) == null
+                || clientDeviceThings.findTopics(thingName).isEmpty()) {
+            return Collections.emptyMap();
+        } else {
+            return clientDeviceThings.findTopics(thingName).toPOJO();
+        }
+    }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingConfigStoreAdapter.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingConfigStoreAdapter.java
@@ -7,10 +7,10 @@ package com.aws.greengrass.clientdevices.auth.iot.registry;
 
 import com.aws.greengrass.clientdevices.auth.configuration.RuntimeConfiguration;
 import com.aws.greengrass.clientdevices.auth.iot.Thing;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.util.Coerce;
 import software.amazon.awssdk.utils.ImmutableMap;
 
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import javax.inject.Inject;
 
@@ -26,14 +26,30 @@ import javax.inject.Inject;
  * </p>
  */
 public class ThingConfigStoreAdapter {
-    private static final String ATTACHED_CERTIFICATE_IDS_KEY = "attachedCertificateIds";
-    private static final String THING_VERSION_KEY = "version";
-
+    public static final String THING_VERSION_KEY = "version";
+    public static final String ATTACHED_CERTIFICATE_IDS_KEY = "attachedCertificateIds";
     private final RuntimeConfiguration runtimeConfig;
 
     @Inject
     protected ThingConfigStoreAdapter(RuntimeConfiguration runtimeConfig) {
         this.runtimeConfig = runtimeConfig;
+    }
+
+    /**
+     * Creates client device thing in the runtime config store.
+     *
+     * @param thing client device thing
+     * @throws IllegalArgumentException for invalid thing
+     */
+    void createThing(Thing thing) {
+        if (thing == null) {
+            throw new IllegalArgumentException("Thing cannot be null");
+        }
+        runtimeConfig.createOrReplaceClientDeviceThing(thing.getThingName(),
+                ImmutableMap.of(
+                        THING_VERSION_KEY, thing.getVersion(),
+                        ATTACHED_CERTIFICATE_IDS_KEY, thing.getAttachedCertificateIds()
+                ));
     }
 
     /**
@@ -44,31 +60,17 @@ public class ThingConfigStoreAdapter {
      * @return optional of client device Thing
      */
     Optional<Thing> getThing(String thingName) {
-        Map<String, Object> thingDetails = runtimeConfig.getClientDeviceThing(thingName);
-        if (thingDetails.isEmpty()) {
+        Topics thingDetails = runtimeConfig.getClientDeviceThing(thingName);
+        if (thingDetails == null || thingDetails.isEmpty()) {
             return Optional.empty();
         }
 
-        Thing thing = Thing.of((int) thingDetails.get(THING_VERSION_KEY),
-                thingName, (List<String>) thingDetails.get(ATTACHED_CERTIFICATE_IDS_KEY));
-
-        return Optional.of(thing);
+        return Optional.of(getThingFromConfig(thingName, thingDetails));
     }
 
-    /**
-     * Store (or update if available) client device thing in the runtime config store.
-     *
-     * @param thing client device thing
-     * @throws IllegalArgumentException for invalid thing
-     */
-    void createOrUpdateThing(Thing thing) {
-        if (thing == null) {
-            throw new IllegalArgumentException("Thing cannot be null");
-        }
-        runtimeConfig.updateClientDeviceThing(thing.getThingName(),
-                ImmutableMap.of(
-                        THING_VERSION_KEY, thing.getVersion(),
-                        ATTACHED_CERTIFICATE_IDS_KEY, thing.getAttachedCertificateIds()
-                ));
+    private Thing getThingFromConfig(String thingName, Topics thingDetails) {
+        // thing version defaults to 0 if NumberFormatException while coercing
+        return Thing.of(Coerce.toInt(thingDetails.find(THING_VERSION_KEY)), thingName,
+                Coerce.toStringList(thingDetails.find(ATTACHED_CERTIFICATE_IDS_KEY)));
     }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingConfigStoreAdapter.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingConfigStoreAdapter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.iot.registry;
+
+import com.aws.greengrass.clientdevices.auth.configuration.RuntimeConfiguration;
+import com.aws.greengrass.clientdevices.auth.iot.Thing;
+import software.amazon.awssdk.utils.ImmutableMap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.inject.Inject;
+
+/**
+ * Adapter from Thing domain to Thing runtime configuration.
+ * Thing configuration is stored as an opaque map to the runtime config store.
+ * <p>
+ * |---- runtime
+ * |    |---- clientDeviceThings:
+ * |          |---- thingName:
+ * |                |---- version: "..."
+ * |                |---- attachedCertificateIds: [...]
+ * </p>
+ */
+public class ThingConfigStoreAdapter {
+    private static final String ATTACHED_CERTIFICATE_IDS_KEY = "attachedCertificateIds";
+    private static final String THING_VERSION_KEY = "version";
+
+    private final RuntimeConfiguration runtimeConfig;
+
+    @Inject
+    protected ThingConfigStoreAdapter(RuntimeConfiguration runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
+    }
+
+    /**
+     * Retrieves client device thing from the runtime config store.
+     * Returns an empty optional if the thing is not available in the config store
+     *
+     * @param thingName client device Thing name
+     * @return optional of client device Thing
+     */
+    Optional<Thing> getThing(String thingName) {
+        Map<String, Object> thingDetails = runtimeConfig.getClientDeviceThing(thingName);
+        if (thingDetails.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Thing thing = Thing.of((int) thingDetails.get(THING_VERSION_KEY),
+                thingName, (List<String>) thingDetails.get(ATTACHED_CERTIFICATE_IDS_KEY));
+
+        return Optional.of(thing);
+    }
+
+    /**
+     * Store (or update if available) client device thing in the runtime config store.
+     *
+     * @param thing client device thing
+     * @throws IllegalArgumentException for invalid thing
+     */
+    void createOrUpdateThing(Thing thing) {
+        if (thing == null) {
+            throw new IllegalArgumentException("Thing cannot be null");
+        }
+        runtimeConfig.updateClientDeviceThing(thing.getThingName(),
+                ImmutableMap.of(
+                        THING_VERSION_KEY, thing.getVersion(),
+                        ATTACHED_CERTIFICATE_IDS_KEY, thing.getAttachedCertificateIds()
+                ));
+    }
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingConfigStoreAdapter.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingConfigStoreAdapter.java
@@ -20,14 +20,16 @@ import javax.inject.Inject;
  * <p>
  * |---- runtime
  * |    |---- clientDeviceThings:
- * |          |---- thingName:
- * |                |---- version: "..."
- * |                |---- attachedCertificateIds: [...]
+ * |          |---- schemaVersion:
+ * |                |---- thingName:
+ * |                      |---- version: "..."
+ * |                      |---- attachedCertificateIds: [...]
  * </p>
  */
 public class ThingConfigStoreAdapter {
-    public static final String THING_VERSION_KEY = "version";
-    public static final String ATTACHED_CERTIFICATE_IDS_KEY = "attachedCertificateIds";
+    private static final String CONFIG_SCHEMA_VERSION = "1.0";
+    private static final String THING_VERSION_KEY = "version";
+    private static final String ATTACHED_CERTIFICATE_IDS_KEY = "attachedCertificateIds";
     private final RuntimeConfiguration runtimeConfig;
 
     @Inject
@@ -49,7 +51,7 @@ public class ThingConfigStoreAdapter {
                 ImmutableMap.of(
                         THING_VERSION_KEY, thing.getVersion(),
                         ATTACHED_CERTIFICATE_IDS_KEY, thing.getAttachedCertificateIds()
-                ));
+                ), CONFIG_SCHEMA_VERSION);
     }
 
     /**
@@ -60,7 +62,7 @@ public class ThingConfigStoreAdapter {
      * @return optional of client device Thing
      */
     Optional<Thing> getThing(String thingName) {
-        Topics thingDetails = runtimeConfig.getClientDeviceThing(thingName);
+        Topics thingDetails = runtimeConfig.getClientDeviceThing(thingName, CONFIG_SCHEMA_VERSION);
         if (thingDetails == null || thingDetails.isEmpty()) {
             return Optional.empty();
         }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistry.java
@@ -107,7 +107,7 @@ public class ThingRegistry {
     }
 
     private Thing storeThing(Thing thing) {
-        configStoreAdapter.createOrUpdateThing(thing);
+        configStoreAdapter.createThing(thing);
         domainEvents.emit(new ThingUpdated(thing.getThingName(), thing.getVersion()));
         return thing;
     }

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingConfigStoreAdapterTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingConfigStoreAdapterTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.iot.registry;
+
+
+import com.aws.greengrass.clientdevices.auth.configuration.RuntimeConfiguration;
+import com.aws.greengrass.clientdevices.auth.iot.Thing;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.dependency.Context;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+class ThingConfigStoreAdapterTest {
+    private static final String mockThingName = "mock-thing";
+    private static final List<String> mockAttachedCertIds = Arrays.asList("cert-1", "cert-2", "cert-3");
+
+    private Topics configTopic;
+    private ThingConfigStoreAdapter configStoreAdapter;
+
+    @BeforeEach
+    void beforeEach() {
+        configTopic = Topics.of(new Context(), "config", null);
+        configStoreAdapter = new ThingConfigStoreAdapter(RuntimeConfiguration.from(configTopic));
+    }
+
+    @AfterEach
+    void afterEach() throws IOException {
+        configTopic.context.close();
+    }
+
+    @Test
+    void GIVEN_validThingName_WHEN_getThing_THEN_validThingReturned() {
+        Thing createdThing = Thing.of(1, mockThingName, mockAttachedCertIds);
+        configStoreAdapter.createOrUpdateThing(createdThing);
+        Thing retrievedThing = configStoreAdapter.getThing(mockThingName).get();
+        assertNotNull(retrievedThing);
+        assertEquals(retrievedThing, createdThing);
+    }
+
+    @Test
+    void GIVEN_validThing_WHEN_updateThing_THEN_thingUpdated() {
+        Thing createdThing = Thing.of(1, mockThingName, mockAttachedCertIds);
+        configStoreAdapter.createOrUpdateThing(createdThing);
+        Thing updatedThing = Thing.of(2, mockThingName, Collections.emptyList());
+        configStoreAdapter.createOrUpdateThing(updatedThing);
+        Thing retrievedThing = configStoreAdapter.getThing(mockThingName).get();
+        assertNotNull(retrievedThing);
+        assertEquals(retrievedThing, updatedThing);
+    }
+
+    @Test
+    void GIVEN_invalidThingName_WHEN_getThing_THEN_emptyOptionalReturned() {
+        assertThat(configStoreAdapter.getThing(mockThingName), is(Optional.empty()));
+        assertThat(configStoreAdapter.getThing(null), is(Optional.empty()));
+        assertThat(configStoreAdapter.getThing(""), is(Optional.empty()));
+    }
+
+    @Test
+    void GIVEN_invalidThing_WHEN_updateThing_THEN_exceptionThrown() {
+        assertThrows(IllegalArgumentException.class, () -> configStoreAdapter.createOrUpdateThing(null));
+    }
+
+}

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingConfigStoreAdapterTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingConfigStoreAdapterTest.java
@@ -52,7 +52,7 @@ class ThingConfigStoreAdapterTest {
     @Test
     void GIVEN_validThingName_WHEN_getThing_THEN_validThingReturned() {
         Thing createdThing = Thing.of(1, mockThingName, mockAttachedCertIds);
-        configStoreAdapter.createOrUpdateThing(createdThing);
+        configStoreAdapter.createThing(createdThing);
         Thing retrievedThing = configStoreAdapter.getThing(mockThingName).get();
         assertNotNull(retrievedThing);
         assertEquals(retrievedThing, createdThing);
@@ -61,9 +61,9 @@ class ThingConfigStoreAdapterTest {
     @Test
     void GIVEN_validThing_WHEN_updateThing_THEN_thingUpdated() {
         Thing createdThing = Thing.of(1, mockThingName, mockAttachedCertIds);
-        configStoreAdapter.createOrUpdateThing(createdThing);
+        configStoreAdapter.createThing(createdThing);
         Thing updatedThing = Thing.of(2, mockThingName, Collections.emptyList());
-        configStoreAdapter.createOrUpdateThing(updatedThing);
+        configStoreAdapter.createThing(updatedThing);
         Thing retrievedThing = configStoreAdapter.getThing(mockThingName).get();
         assertNotNull(retrievedThing);
         assertEquals(retrievedThing, updatedThing);
@@ -78,7 +78,7 @@ class ThingConfigStoreAdapterTest {
 
     @Test
     void GIVEN_invalidThing_WHEN_updateThing_THEN_exceptionThrown() {
-        assertThrows(IllegalArgumentException.class, () -> configStoreAdapter.createOrUpdateThing(null));
+        assertThrows(IllegalArgumentException.class, () -> configStoreAdapter.createThing(null));
     }
 
 }


### PR DESCRIPTION
**Description of changes:** 
- Adds Thing configuration store adapter for ThingRegistry to store and retrieve client device Thing metadata from the Runtime config. Updates to runtime config are flushed to the disk immediately. Newly added runtime configuration has following structure:
```
 * |---- runtime
 * |    |---- clientDeviceThings:
 * |          |---- <schemaVersion>:
 * |                   |---- <thingName>:
 * |                            |---- version: "..."
 * |                            |---- attachedCertificateIds: [...]
 * |
```
- This config schema is versioned for better backward compatibility with future schema changes.
- ThingRegistry writes to or reads directly off of the runtime config store. Metadata written to the config store is opaque to the Config store. 

**Why is this change necessary:** To persist Thing metadata across device power-cycle or restart.

**How was this change tested:** unit tests, integ tests (`mvn package`, `mvn verify`)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
