### PR TITLE
refactor: remove Thing versioning

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Thing.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Thing.java
@@ -29,7 +29,6 @@ public final class Thing implements AttributeProvider, Cloneable {
     public static final String NAMESPACE = "Thing";
     private static final String thingNamePattern = "[a-zA-Z0-9\\-_:]+";
 
-    private final int version;
     private final String thingName;
     private final CopyOnWriteArrayList<String> attachedCertificateIds;
     private boolean modified = false;
@@ -37,45 +36,30 @@ public final class Thing implements AttributeProvider, Cloneable {
     /**
      * Create a new Thing.
      *
-     * @param thingName AWS IoT ThingName
-     * @throws IllegalArgumentException If the given ThingName contains illegal characters
-     */
-    public static Thing of(String thingName) {
-        return Thing.of(0, thingName);
-    }
-
-    /**
-     * Create a new Thing.
-     *
-     * @param version        Thing version
      * @param thingName      AWS IoT ThingName
      * @throws IllegalArgumentException If the given ThingName contains illegal characters
      */
-    public static Thing of(int version, String thingName) {
-        return Thing.of(version, thingName, new ArrayList<>());
+    public static Thing of(String thingName) {
+        return Thing.of(thingName, new ArrayList<>());
     }
 
     /**
      * Create a new Thing.
      *
-     * @param version        Thing version
      * @param thingName      AWS IoT ThingName
      * @param certificateIds Attached certificate IDs
      * @throws IllegalArgumentException If the given ThingName contains illegal characters
      */
-    public static Thing of(int version, String thingName, List<String> certificateIds) {
-        if (version < 0) {
-            throw new IllegalArgumentException("Invalid version. Version must not be < 0");
-        }
+    public static Thing of(String thingName, List<String> certificateIds) {
         if (!Pattern.matches(thingNamePattern, thingName)) {
             throw new IllegalArgumentException("Invalid thing name. The thing name must match \"[a-zA-Z0-9\\-_:]+\".");
         }
-        return new Thing(version, thingName, certificateIds);
+        return new Thing(thingName, certificateIds);
     }
 
     @Override
     public Thing clone() {
-        Thing newThing = Thing.of(getVersion(), getThingName(), getAttachedCertificateIds());
+        Thing newThing = Thing.of(getThingName(), getAttachedCertificateIds());
         newThing.modified = modified;
         return newThing;
     }
@@ -112,8 +96,7 @@ public final class Thing implements AttributeProvider, Cloneable {
         return new ArrayList<>(attachedCertificateIds);
     }
 
-    private Thing(int version, String thingName, List<String> certificateIds) {
-        this.version = version;
+    private Thing(String thingName, List<String> certificateIds) {
         this.thingName = thingName;
         this.attachedCertificateIds = new CopyOnWriteArrayList<>(certificateIds);
     }
@@ -132,14 +115,13 @@ public final class Thing implements AttributeProvider, Cloneable {
             return false;
         }
 
-        return version == other.version
-                && thingName.equals(other.thingName)
+        return thingName.equals(other.thingName)
                 && attachedCertificateIds.equals(other.attachedCertificateIds);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(version, thingName, attachedCertificateIds);
+        return Objects.hash(thingName, attachedCertificateIds);
     }
 
     @Override

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistry.java
@@ -57,7 +57,7 @@ public class ThingRegistry {
      * @return Thing object
      */
     public Thing createThing(String thingName) {
-        Thing newThing = Thing.of(1, thingName);
+        Thing newThing = Thing.of(thingName);
         storeThing(newThing);
         return newThing.clone();
     }
@@ -83,15 +83,10 @@ public class ThingRegistry {
      */
     public Thing updateThing(Thing thing) {
         // TODO: this method should throw exceptions instead of returning
-        //  null if the Thing doesn't exist, if the caller is attempting to
-        //  update an old version, or if the Thing hasn't been modified.
+        //  null if the Thing doesn't exist or if the Thing hasn't been modified.
         Thing oldThing = getThingInternal(thing.getThingName());
 
         if (oldThing == null) {
-            return null;
-        }
-
-        if (thing.getVersion() != oldThing.getVersion()) {
             return null;
         }
 
@@ -100,7 +95,7 @@ public class ThingRegistry {
             return thing;
         }
 
-        Thing newThing = Thing.of(thing.getVersion() + 1, thing.getThingName(), thing.getAttachedCertificateIds());
+        Thing newThing = Thing.of(thing.getThingName(), thing.getAttachedCertificateIds());
         return storeThing(newThing);
     }
 
@@ -110,7 +105,7 @@ public class ThingRegistry {
 
     private Thing storeThing(Thing thing) {
         registry.put(thing.getThingName(), thing);
-        domainEvents.emit(new ThingUpdated(thing.getThingName(), thing.getVersion()));
+        domainEvents.emit(new ThingUpdated(thing.getThingName(), 0)); // TODO: remove from event
         return thing;
     }
 

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/ThingTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/ThingTest.java
@@ -49,14 +49,8 @@ public class ThingTest {
     }
 
     @Test
-    void GIVEN_invalidVersion_WHEN_Thing_THEN_exceptionThrown() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> Thing.of(-1, "Thing"));
-        Assertions.assertDoesNotThrow(() -> Thing.of(0, "Thing"));
-    }
-
-    @Test
     void GIVEN_thing_WHEN_attachCertificate_THEN_certAttachedAndDirtyBitSet() {
-        Thing thing = Thing.of(0, "Thing");
+        Thing thing = Thing.of("Thing");
         thing.attachCertificate("cert-id");
 
         assertThat(thing.isModified(), is(true));
@@ -66,7 +60,7 @@ public class ThingTest {
 
     @Test
     void GIVEN_thingWithCertificate_WHEN_attachSameCertificate_THEN_noChange() {
-        Thing thing = Thing.of(0, "Thing", Collections.singletonList("cert-id"));
+        Thing thing = Thing.of("Thing", Collections.singletonList("cert-id"));
         thing.attachCertificate("cert-id");
 
         assertThat(thing.isModified(), is(false));
@@ -76,7 +70,7 @@ public class ThingTest {
 
     @Test
     void GIVEN_thingWithoutCertificate_WHEN_detachCertificate_THEN_noChange() {
-        Thing thing = Thing.of(0, "Thing");
+        Thing thing = Thing.of("Thing");
         thing.detachCertificate("cert-id");
 
         assertThat(thing.isModified(), is(false));
@@ -86,7 +80,7 @@ public class ThingTest {
 
     @Test
     void GIVEN_thingWithCertificate_WHEN_detachCertificate_THEN_certDetachedAndDirtyBitSet() {
-        Thing thing = Thing.of(0, "Thing", Collections.singletonList("cert-id"));
+        Thing thing = Thing.of("Thing", Collections.singletonList("cert-id"));
         thing.detachCertificate("cert-id");
 
         assertThat(thing.isModified(), is(true));
@@ -96,22 +90,21 @@ public class ThingTest {
 
     @Test
     void testEquals() {
-        Thing version0_Thing_NoList = Thing.of(0, "Thing");
-        Thing version0_Thing2_NoList = Thing.of(0, "Thing2", Collections.emptyList());
-        Thing version0_Thing_EmptyList = Thing.of(0, "Thing", Collections.emptyList());
-        Thing version1_Thing_SingleCert = Thing.of(1, "Thing", Collections.singletonList("certId"));
-        Thing version1_Thing_SingleCert_copy = Thing.of(1, "Thing", Collections.singletonList("certId"));
-        Thing version2_Thing_SingleCert = Thing.of(2, "Thing", Collections.singletonList("certId"));
-        Thing version3_Thing_CertA = Thing.of(3, "Thing", Collections.singletonList("CertA"));
-        Thing version3_Thing_CertB = Thing.of(3, "Thing", Collections.singletonList("CertB"));
-        Thing version4_Thing_MultiCert = Thing.of(4, "Thing", Arrays.asList("Cert1", "Cert2"));
-        Thing version4_Thing_MultiCert_copy = Thing.of(4, "Thing", Arrays.asList("Cert1", "Cert2"));
+        Thing Thing_NoList = Thing.of("Thing");
+        Thing Thing2_NoList = Thing.of("Thing2", Collections.emptyList());
+        Thing Thing_EmptyList = Thing.of("Thing", Collections.emptyList());
+        Thing Thing_SingleCert = Thing.of("Thing", Collections.singletonList("certId"));
+        Thing Thing_SingleCert_copy = Thing.of("Thing", Collections.singletonList("certId"));
+        Thing Thing_CertA = Thing.of("Thing", Collections.singletonList("CertA"));
+        Thing Thing_CertB = Thing.of("Thing", Collections.singletonList("CertB"));
+        Thing Thing_MultiCert = Thing.of("Thing", Arrays.asList("Cert1", "Cert2"));
+        Thing Thing_MultiCert_copy = Thing.of("Thing", Arrays.asList("Cert1", "Cert2"));
 
-        assertThat(version0_Thing_NoList, equalTo(version0_Thing_EmptyList));
-        assertThat(version0_Thing_NoList, not(equalTo(version0_Thing2_NoList)));
-        assertThat(version1_Thing_SingleCert, equalTo(version1_Thing_SingleCert_copy));
-        assertThat(version1_Thing_SingleCert, not(equalTo(version2_Thing_SingleCert)));
-        assertThat(version3_Thing_CertA, not(equalTo(version3_Thing_CertB)));
-        assertThat(version4_Thing_MultiCert, equalTo(version4_Thing_MultiCert_copy));
+        assertThat(Thing_NoList, equalTo(Thing_EmptyList));
+        assertThat(Thing_NoList, not(equalTo(Thing2_NoList)));
+        assertThat(Thing_SingleCert, equalTo(Thing_SingleCert_copy));
+        assertThat(Thing_SingleCert, equalTo(Thing_SingleCert));
+        assertThat(Thing_CertA, not(equalTo(Thing_CertB)));
+        assertThat(Thing_MultiCert, equalTo(Thing_MultiCert_copy));
     }
 }

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistryTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/registry/ThingRegistryTest.java
@@ -61,7 +61,6 @@ class ThingRegistryTest {
         Thing retrievedThing = registry.getThing(mockThingName);
 
         assertThat(createdThing.getThingName(), is(mockThingName));
-        assertThat(createdThing.getVersion(), is(1));
         assertThat(createdThing.getAttachedCertificateIds(), equalTo(Collections.emptyList()));
 
         assertThat(createdThing, equalTo(retrievedThing));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Remove Thing versioning logic.

Refer to https://github.com/aws-greengrass/aws-greengrass-client-device-auth/pull/155/files#r990478687 

**Why is this change necessary:**
We don't want to need to persist version information. We'll come up with a different approach for serializing Thing updates

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
