### PR TITLE
test: add IotAuthClientFake

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/VerifyClientDeviceIdentityTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/VerifyClientDeviceIdentityTest.java
@@ -8,13 +8,11 @@ package com.aws.greengrass.integrationtests.ipc;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateHelper;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateStore;
 import com.aws.greengrass.clientdevices.auth.helpers.CertificateTestHelpers;
-import com.aws.greengrass.clientdevices.auth.iot.Certificate;
 import com.aws.greengrass.clientdevices.auth.iot.InvalidCertificateException;
+import com.aws.greengrass.clientdevices.auth.iot.IotAuthClientFake;
 import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.clientdevices.auth.ClientDevicesAuthService;
-import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
 import com.aws.greengrass.clientdevices.auth.iot.IotAuthClient;
-import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;
 import com.aws.greengrass.lifecyclemanager.Kernel;
@@ -22,7 +20,6 @@ import com.aws.greengrass.logging.impl.config.LogConfig;
 import com.aws.greengrass.mqttclient.spool.SpoolerStoreException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.testcommons.testutilities.UniqueRootPathExtension;
-import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -32,15 +29,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCClient;
 import software.amazon.awssdk.aws.greengrass.model.ClientDeviceCredential;
 import software.amazon.awssdk.aws.greengrass.model.VerifyClientDeviceIdentityRequest;
 import software.amazon.awssdk.aws.greengrass.model.VerifyClientDeviceIdentityResponse;
 import software.amazon.awssdk.eventstreamrpc.EventStreamRPCConnection;
-import software.amazon.awssdk.services.greengrassv2data.GreengrassV2DataClient;
-import software.amazon.awssdk.services.greengrassv2data.model.InternalServerException;
 import software.amazon.awssdk.services.greengrassv2data.model.ValidationException;
 
 import java.io.IOException;
@@ -61,9 +55,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.when;
 
 @ExtendWith({GGExtension.class, UniqueRootPathExtension.class, MockitoExtension.class})
 class VerifyClientDeviceIdentityTest {
@@ -71,15 +62,8 @@ class VerifyClientDeviceIdentityTest {
     @TempDir
     Path rootDir;
     private Kernel kernel;
-    @Mock
-    private GreengrassServiceClientFactory clientFactory;
-    @Mock
-    private GreengrassV2DataClient client;
-    @Mock
-    private IotAuthClient iotAuthClient;
-    private Certificate clientCertificate;
-    private static X509Certificate validClientX509Certificate;
     private static String validClientCertificatePem;
+    private static String invalidClientCertificatePem;
 
     @BeforeAll
     static void beforeAll()
@@ -88,28 +72,30 @@ class VerifyClientDeviceIdentityTest {
         KeyPair clientKeyPair = CertificateStore.newRSAKeyPair(2048);
         X509Certificate rootCA = CertificateTestHelpers.createRootCertificateAuthority("root", rootKeyPair);
 
-        validClientX509Certificate =
+        X509Certificate validClientX509Certificate =
                 CertificateTestHelpers.createClientCertificate(rootCA, "Client", clientKeyPair.getPublic(),
                         rootKeyPair.getPrivate());
         validClientCertificatePem = CertificateHelper.toPem(validClientX509Certificate);
+        X509Certificate invalidClientX509Certificate =
+                CertificateTestHelpers.createClientCertificate(rootCA, "Client", clientKeyPair.getPublic(),
+                        rootKeyPair.getPrivate());
+        invalidClientCertificatePem = CertificateHelper.toPem(invalidClientX509Certificate);
     }
 
     @BeforeEach
-    void beforeEach(ExtensionContext context) throws DeviceConfigurationException, InvalidCertificateException {
+    void beforeEach(ExtensionContext context) throws InvalidCertificateException {
         ignoreExceptionOfType(context, SpoolerStoreException.class);
         ignoreExceptionOfType(context, NoSuchFileException.class); // Loading CA keystore
 
         // Set this property for kernel to scan its own classpath to find plugins
         System.setProperty("aws.greengrass.scanSelfClasspath", "true");
         kernel = new Kernel();
-        kernel.getContext().put(GreengrassServiceClientFactory.class, clientFactory);
 
-        // TODO: getGreengrassV2DataClient mock can be removed once IotAuthClient migrates to new API
-        lenient().when(clientFactory.getGreengrassV2DataClient()).thenReturn(client);
-        when(clientFactory.fetchGreengrassV2DataClient()).thenReturn(client);
-
-        // Re-instantiate certs
-        clientCertificate = Certificate.fromPem(validClientCertificatePem);
+        // Set up Iot auth client
+        IotAuthClientFake iotAuthClientFake = new IotAuthClientFake();
+        iotAuthClientFake.activateCert(validClientCertificatePem);
+        iotAuthClientFake.deactivateCert(invalidClientCertificatePem);
+        kernel.getContext().put(IotAuthClient.class, iotAuthClientFake);
     }
 
     @AfterEach
@@ -140,9 +126,6 @@ class VerifyClientDeviceIdentityTest {
 
     @Test
     void GIVEN_requestWithValidCertificate_WHEN_verifyClientIdentity_THEN_returnValid() throws Exception {
-        kernel.getContext().put(IotAuthClient.class, iotAuthClient);
-        clientCertificate.setStatus(Certificate.Status.ACTIVE);
-        when(iotAuthClient.getIotCertificate(validClientCertificatePem)).thenReturn(Optional.of(clientCertificate));
         startNucleusWithConfig("cda.yaml");
         try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
                 "BrokerSubscribingToCertUpdates")) {
@@ -160,7 +143,6 @@ class VerifyClientDeviceIdentityTest {
     @Test
     void GIVEN_requestWithInvalidPem_WHEN_verifyClientIdentity_THEN_returnNotValid(ExtensionContext context)
             throws Exception {
-        kernel.getContext().put(IotAuthClient.class, iotAuthClient);
         ignoreExceptionOfType(context, InvalidCertificateException.class);
         startNucleusWithConfig("cda.yaml");
         try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
@@ -179,7 +161,6 @@ class VerifyClientDeviceIdentityTest {
     @Test
     void GIVEN_unauthorizedClient_WHEN_verifyClientIdentity_THEN_throwsUnauthorizedError()
             throws ExecutionException, InterruptedException {
-        kernel.getContext().put(IotAuthClient.class, iotAuthClient);
         startNucleusWithConfig("BrokerNotAuthorized.yaml");
         try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
                 "BrokerWithNoConfig")) {
@@ -197,36 +178,12 @@ class VerifyClientDeviceIdentityTest {
     void GIVEN_inactiveClientCertificate_WHEN_verifyClientIdentity_THEN_returnsNotValid(ExtensionContext context)
             throws Exception {
         startNucleusWithConfig("cda.yaml");
-        when(clientFactory.fetchGreengrassV2DataClient().verifyClientDeviceIdentity(
-                any(software.amazon.awssdk.services.greengrassv2data.model.VerifyClientDeviceIdentityRequest.class)))
-                .thenThrow(ValidationException.class);
         ignoreExceptionOfType(context, ValidationException.class);
         try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
                 "BrokerSubscribingToCertUpdates")) {
             GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
             VerifyClientDeviceIdentityRequest request = new VerifyClientDeviceIdentityRequest().withCredential(
-                    new ClientDeviceCredential().withClientDeviceCertificate(validClientCertificatePem));
-
-            CompletableFuture<VerifyClientDeviceIdentityResponse> response =
-                    ipcClient.verifyClientDeviceIdentity(request, Optional.empty()).getResponse();
-            assertFalse(response.get(10, TimeUnit.SECONDS).isIsValidClientDevice());
-        }
-    }
-
-    @Test
-    void GIVEN_validRequestWithCloud500s_WHEN_verifyClientIdentity_THEN_returnsNotValid(ExtensionContext context)
-            throws Exception {
-        startNucleusWithConfig("cda.yaml");
-        when(client.verifyClientDeviceIdentity(
-                any(software.amazon.awssdk.services.greengrassv2data.model.VerifyClientDeviceIdentityRequest.class)))
-                .thenThrow(InternalServerException.class);
-        ignoreExceptionOfType(context, CloudServiceInteractionException.class);
-        ignoreExceptionOfType(context, InternalServerException.class);
-        try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
-                "BrokerSubscribingToCertUpdates")) {
-            GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
-            VerifyClientDeviceIdentityRequest request = new VerifyClientDeviceIdentityRequest().withCredential(
-                    new ClientDeviceCredential().withClientDeviceCertificate(validClientCertificatePem));
+                    new ClientDeviceCredential().withClientDeviceCertificate(invalidClientCertificatePem));
 
             CompletableFuture<VerifyClientDeviceIdentityResponse> response =
                     ipcClient.verifyClientDeviceIdentity(request, Optional.empty()).getResponse();

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClientFake.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClientFake.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.iot;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * IoT Auth Client Fake allows test writers to set up valid and invalid certificates,
+ * as well as Thing <-> certificate attachments without needing to manage mocks.
+ */
+public class IotAuthClientFake implements IotAuthClient {
+    private final Map<String, Set<String>> thingToCerts = new HashMap<>();
+    private final Set<String> activeCertIds = new HashSet<>();
+    private final Set<String> inactiveCertIds = new HashSet<>();
+
+    public void activateCert(String certPem) throws InvalidCertificateException {
+        Certificate cert = Certificate.fromPem(certPem);
+        String certId = cert.getCertificateId();
+
+        activeCertIds.add(certId);
+        inactiveCertIds.remove(certId);
+    }
+
+    public void deactivateCert(String certPem) throws InvalidCertificateException {
+        Certificate cert = Certificate.fromPem(certPem);
+        String certId = cert.getCertificateId();
+
+        activeCertIds.remove(certId);
+        inactiveCertIds.add(certId);
+    }
+
+    public void attachCertificateToThing(String thing, String certPem) throws InvalidCertificateException {
+        Certificate cert = Certificate.fromPem(certPem);
+        String certId = cert.getCertificateId();
+
+        if (!thingToCerts.containsKey(thing)) {
+            thingToCerts.put(thing, new HashSet<>());
+        }
+        thingToCerts.get(thing).add(certId);
+    }
+
+    public void detachCertificateFromThing(String thing, String certPem) throws InvalidCertificateException {
+        Certificate cert = Certificate.fromPem(certPem);
+        String certId = cert.getCertificateId();
+
+        if (thingToCerts.containsKey(thing)) {
+            thingToCerts.get(thing).remove(certId);
+        }
+    }
+
+    @Override
+    public Optional<String> getActiveCertificateId(String certificatePem) {
+        // Current implementation returns empty optional if the cert is invalid
+        // This isn't ideal behavior, but we'll stick with it for now
+        Certificate cert;
+        try {
+            cert = Certificate.fromPem(certificatePem);
+        } catch (InvalidCertificateException e) {
+            return Optional.empty();
+        }
+
+        if (activeCertIds.contains(cert.getCertificateId())) {
+            return Optional.of(cert.getCertificateId());
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Certificate> getIotCertificate(String certificatePem) throws InvalidCertificateException {
+        Certificate cert = Certificate.fromPem(certificatePem);
+
+        if (activeCertIds.contains(cert.getCertificateId())) {
+            cert.setStatus(Certificate.Status.ACTIVE);
+            return Optional.of(cert);
+        }
+        if (inactiveCertIds.contains(cert.getCertificateId())) {
+            cert.setStatus(Certificate.Status.UNKNOWN);
+            return Optional.of(cert);
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean isThingAttachedToCertificate(Thing thing, Certificate certificate) {
+        if (thingToCerts.containsKey(thing.getThingName())) {
+            return thingToCerts.get(thing.getThingName()).contains(certificate.getCertificateId());
+        }
+        return false;
+    }
+}

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClientFake.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClientFake.java
@@ -40,10 +40,7 @@ public class IotAuthClientFake implements IotAuthClient {
         Certificate cert = Certificate.fromPem(certPem);
         String certId = cert.getCertificateId();
 
-        if (!thingToCerts.containsKey(thing)) {
-            thingToCerts.put(thing, new HashSet<>());
-        }
-        thingToCerts.get(thing).add(certId);
+        thingToCerts.computeIfAbsent(thing, (k) -> new HashSet<>()).add(certId);
     }
 
     public void detachCertificateFromThing(String thing, String certPem) throws InvalidCertificateException {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adds IotAuthClientFake which can be used during testing to avoid mocking IotAuthClient. More work is needed to remove mocks from some of the IPC tests.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
