### PR TITLE
feat: refresh certificates in the background

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/infra/BackgroundCertificateRefresh.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/infra/BackgroundCertificateRefresh.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.certificate.infra;
+
+import com.aws.greengrass.clientdevices.auth.api.UseCases;
+import com.aws.greengrass.clientdevices.auth.infra.NetworkState;
+import com.aws.greengrass.clientdevices.auth.iot.CertificateRegistry;
+import com.aws.greengrass.clientdevices.auth.iot.usecases.VerifyIotCertificate;
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.inject.Inject;
+
+/**
+ * Periodically calls the VerifyIotCertificate to update the
+ * locally cached certificates on a cadence.
+ */
+public class BackgroundCertificateRefresh implements Runnable {
+    private final CertificateRegistry registry;
+    private final UseCases useCases;
+    private final NetworkState networkState;
+    private static final int DEFAULT_INTERVAL_SECONDS = 60 * 60; // 1H
+    private static final Logger logger = LogManager.getLogger(BackgroundCertificateRefresh.class);
+
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    private final AtomicReference<ScheduledFuture<?>> scheduledFuture = new AtomicReference<>(null);
+
+
+    /**
+     * Creates an instance of the BackgroundCertificateRefresh.
+     * @param certificateRegistry - A certificate registry
+     * @param networkState - A network state
+     * @param useCases - useCases service
+     */
+    @Inject
+    public BackgroundCertificateRefresh(CertificateRegistry certificateRegistry, NetworkState networkState,
+            UseCases useCases) {
+        this.registry = certificateRegistry;
+        this.networkState = networkState;
+        this.useCases = useCases;
+    }
+
+    /**
+     * Start running the task every DEFAULT_INTERVAL_SECONDS.
+     */
+    public void start() {
+        start(DEFAULT_INTERVAL_SECONDS);
+    }
+
+    /**
+     * Start running the task on every intervalSeconds.
+     * @param intervalSeconds - frequency for this task to run
+     */
+    public void start(int intervalSeconds) {
+        if (scheduledFuture.get() != null) {
+           return;
+        }
+
+        logger.info("Starting background refresh of client certificates every {} seconds", intervalSeconds);
+        scheduledFuture.set(
+            scheduler.scheduleAtFixedRate(this, intervalSeconds, intervalSeconds, TimeUnit.SECONDS)
+        );
+    }
+
+    /**
+     * Stops the task if it has already been started.
+     */
+    public void stop() {
+        if (scheduledFuture.get() == null) {
+            return;
+        }
+
+        this.scheduledFuture.get().cancel(true);
+        scheduledFuture.set(null);
+    }
+
+    /**
+     * Return true if the background refresh has started.
+     */
+    public boolean isRunning() {
+        return scheduledFuture.get() != null;
+    }
+
+    /**
+     * Runs verifyIotCertificate useCase for all the registered client certificate PEMs.
+     */
+    @Override
+    public void run() {
+        if (isNetworkDown()) {
+            logger.debug("Network is down - not refreshing certificates");
+            return;
+        }
+
+        VerifyIotCertificate verifyIotCertificate = useCases.get(VerifyIotCertificate.class);
+        registry.getAllCertificatePems().forEach(verifyIotCertificate::apply);
+    }
+
+    private boolean isNetworkDown() {
+        return networkState.getConnectionStateFromMqtt() == NetworkState.ConnectionState.NETWORK_DOWN;
+    }
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/infra/BackgroundCertificateRefresh.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/infra/BackgroundCertificateRefresh.java
@@ -12,11 +12,9 @@ import com.aws.greengrass.clientdevices.auth.iot.usecases.VerifyIotCertificate;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import javax.inject.Inject;
 
 /**
@@ -29,22 +27,28 @@ public class BackgroundCertificateRefresh implements Runnable {
     private final NetworkState networkState;
     private static final int DEFAULT_INTERVAL_SECONDS = 60 * 60; // 1H
     private static final Logger logger = LogManager.getLogger(BackgroundCertificateRefresh.class);
+    private final ClientCertificateStore pemStore;
 
-    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
-    private final AtomicReference<ScheduledFuture<?>> scheduledFuture = new AtomicReference<>(null);
+    private ScheduledFuture<?> scheduledFuture = null;
+    private final ScheduledThreadPoolExecutor scheduler;
 
 
     /**
-     * Creates an instance of the BackgroundCertificateRefresh.
+     * Creates an instance of the BackgroundCertificateRefresh.A
+     * @param scheduler - A ScheduledThreadPoolExecutor
      * @param certificateRegistry - A certificate registry
      * @param networkState - A network state
+     * @param pemStore -  Store for the client certificates
      * @param useCases - useCases service
      */
     @Inject
-    public BackgroundCertificateRefresh(CertificateRegistry certificateRegistry, NetworkState networkState,
-            UseCases useCases) {
+    public BackgroundCertificateRefresh(
+            ScheduledThreadPoolExecutor scheduler, CertificateRegistry certificateRegistry, NetworkState networkState,
+            ClientCertificateStore pemStore, UseCases useCases) {
+        this.scheduler = scheduler;
         this.registry = certificateRegistry;
         this.networkState = networkState;
+        this.pemStore = pemStore;
         this.useCases = useCases;
     }
 
@@ -60,33 +64,34 @@ public class BackgroundCertificateRefresh implements Runnable {
      * @param intervalSeconds - frequency for this task to run
      */
     public void start(int intervalSeconds) {
-        if (scheduledFuture.get() != null) {
+        if (scheduledFuture != null) {
            return;
         }
 
         logger.info("Starting background refresh of client certificates every {} seconds", intervalSeconds);
-        scheduledFuture.set(
-            scheduler.scheduleAtFixedRate(this, intervalSeconds, intervalSeconds, TimeUnit.SECONDS)
-        );
+        scheduledFuture =
+            scheduler.scheduleAtFixedRate(this, intervalSeconds, intervalSeconds, TimeUnit.SECONDS);
+
     }
 
     /**
      * Stops the task if it has already been started.
      */
+    @SuppressWarnings("PMD.NullAssignment")
     public void stop() {
-        if (scheduledFuture.get() == null) {
+        if (scheduledFuture == null) {
             return;
         }
 
-        this.scheduledFuture.get().cancel(true);
-        scheduledFuture.set(null);
+        this.scheduledFuture.cancel(true);
+        scheduledFuture = null;
     }
 
     /**
      * Return true if the background refresh has started.
      */
     public boolean isRunning() {
-        return scheduledFuture.get() != null;
+        return scheduledFuture != null;
     }
 
     /**
@@ -100,7 +105,14 @@ public class BackgroundCertificateRefresh implements Runnable {
         }
 
         VerifyIotCertificate verifyIotCertificate = useCases.get(VerifyIotCertificate.class);
-        registry.getAllCertificatePems().forEach(verifyIotCertificate::apply);
+        String[] certificateIds = registry.getAllCertificateIds();
+
+        for (String certificateId : certificateIds) {
+            if (pemStore.exists(certificateId)) {
+                String pem = pemStore.getPem(certificateId).get();
+                verifyIotCertificate.apply(pem);
+            }
+        }
     }
 
     private boolean isNetworkDown() {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/RuntimeConfiguration.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/RuntimeConfiguration.java
@@ -140,6 +140,22 @@ public final class RuntimeConfiguration {
     }
 
     /**
+     * Get all the certificate ids stored under.
+     * |    |---- "clientDeviceCerts":
+     * |          |---- "v1":
+     * |                |---- certificateId:
+     */
+    public String[] getAllCertificateIdsV1() {
+        Topics v1CertTopics = config.findTopics(CERTS_KEY, CERTS_V1_KEY);
+
+        if (v1CertTopics == null) {
+            return new String[]{};
+        }
+
+        return Coerce.toStringArray(v1CertTopics.children.keySet().toArray());
+    }
+
+    /**
      * Get a certificate.
      *
      * @param certificateId Certificate ID

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Certificate.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Certificate.java
@@ -94,6 +94,18 @@ public class Certificate implements AttributeProvider {
         throw new UnsupportedOperationException("Retrieving certificate PEM currently not supported");
     }
 
+    /**
+     * Determined whether this certificate was updated after another.
+     * @param cert - another Certificate
+     */
+    public boolean wasUpdatedAfter(Certificate cert) {
+        if (statusLastUpdated == null) {
+            return false;
+        }
+
+        return statusLastUpdated.isAfter(cert.getStatusLastUpdated());
+    }
+
     @Override
     public String getNamespace() {
         return NAMESPACE;

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/CertificateRegistry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/CertificateRegistry.java
@@ -15,11 +15,8 @@ import software.amazon.awssdk.utils.ImmutableMap;
 import java.security.KeyStoreException;
 import java.security.cert.CertificateException;
 import java.time.Instant;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.inject.Inject;
 
 
@@ -106,14 +103,8 @@ public class CertificateRegistry {
     /**
      * Returns the PEMs that are stored for all the certificate ids that are being tracked.
      */
-    public List<String> getAllCertificatePems() {
-        String[] certificateIds = runtimeConfiguration.getAllCertificateIdsV1();
-
-        return Stream.of(certificateIds)
-                .filter(pemStore::exists)
-                .map(pemStore::getPem)
-                .map(Optional::get)
-                .collect(Collectors.toList());
+    public String[] getAllCertificateIds() {
+        return runtimeConfiguration.getAllCertificateIdsV1();
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/CertificateRegistry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/CertificateRegistry.java
@@ -15,8 +15,11 @@ import software.amazon.awssdk.utils.ImmutableMap;
 import java.security.KeyStoreException;
 import java.security.cert.CertificateException;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.inject.Inject;
 
 
@@ -98,6 +101,19 @@ public class CertificateRegistry {
      */
     public void updateCertificate(Certificate certificate) {
         runtimeConfiguration.putCertificate(certificateToCertificateV1DTO(certificate));
+    }
+
+    /**
+     * Returns the PEMs that are stored for all the certificate ids that are being tracked.
+     */
+    public List<String> getAllCertificatePems() {
+        String[] certificateIds = runtimeConfiguration.getAllCertificateIdsV1();
+
+        return Stream.of(certificateIds)
+                .filter(pemStore::exists)
+                .map(pemStore::getPem)
+                .map(Optional::get)
+                .collect(Collectors.toList());
     }
 
     /**


### PR DESCRIPTION
**Description of changes:**
This PR introduces the `BackgrounCertificateRefresh` infra class whose sole purpose is to re verify stored certificates on a cadence, so when a client goes offline the stored value is one that fairly up to date. We are using a polling mechanism but it might change in the future to a push mechanism connecting to IoT Core and listening for certificate revocations.

**Why is this change necessary:**
We want to give customers a way to ensure their cached values are fairly recent in case the go offline, their devices can still communicate.

**How was this change tested:**
Integration test.
