### PR TITLE
refactor: extract iot client from registry and decouple update logic

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/api/Result.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/api/Result.java
@@ -10,6 +10,8 @@ public final class Result<T> {
     private final Status status;
     private final T value;
 
+    private Exception err;
+
     private enum Status {
         OK, WARNING, ERROR
     }
@@ -17,6 +19,12 @@ public final class Result<T> {
     private Result(Status status, T value) {
         this.value = value;
         this.status = status;
+    }
+
+    private Result(Status status, T value, Exception e) {
+        this.value = value;
+        this.status = status;
+        this.err = e;
     }
 
     public static <V> Result<V> ok(V value) {
@@ -27,8 +35,8 @@ public final class Result<T> {
         return ok(null);
     }
 
-    public static <E extends Exception> Result<E> error(E value) {
-        return new Result<>(Status.ERROR, value);
+    public static <T, E extends Exception> Result<T> error(E value) {
+        return new Result<>(Status.ERROR, null, value);
     }
 
     public static <E extends Exception> Result<E> warning(E value) {
@@ -42,6 +50,10 @@ public final class Result<T> {
 
     public T get() {
         return value;
+    }
+
+    public Exception getError() {
+        return this.err;
     }
 
     public boolean isError() {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/api/Result.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/api/Result.java
@@ -10,8 +10,6 @@ public final class Result<T> {
     private final Status status;
     private final T value;
 
-    private Exception err;
-
     private enum Status {
         OK, WARNING, ERROR
     }
@@ -19,12 +17,6 @@ public final class Result<T> {
     private Result(Status status, T value) {
         this.value = value;
         this.status = status;
-    }
-
-    private Result(Status status, T value, Exception e) {
-        this.value = value;
-        this.status = status;
-        this.err = e;
     }
 
     public static <V> Result<V> ok(V value) {
@@ -35,8 +27,8 @@ public final class Result<T> {
         return ok(null);
     }
 
-    public static <T, E extends Exception> Result<T> error(E value) {
-        return new Result<>(Status.ERROR, null, value);
+    public static <T extends Exception> Result<T> error(T value) {
+        return new Result<>(Status.ERROR, value);
     }
 
     public static <E extends Exception> Result<E> warning(E value) {
@@ -47,13 +39,8 @@ public final class Result<T> {
         return new Result<>(Status.WARNING, null);
     }
 
-
     public T get() {
         return value;
-    }
-
-    public Exception getError() {
-        return this.err;
     }
 
     public boolean isError() {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/api/UseCases.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/api/UseCases.java
@@ -16,6 +16,9 @@ public class UseCases {
         Result<R> apply(D var1) throws Exception;
     }
 
+    public UseCases() {
+    }
+
     public UseCases(Context context) {
         this.context = context;
     }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/api/UseCases.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/api/UseCases.java
@@ -12,7 +12,15 @@ public class UseCases {
     private Context context;
 
     public interface UseCase<R, D>  {
-        Result<R> apply(D var1);
+        @SuppressWarnings("PMD.SignatureDeclareThrowsException")
+        Result<R> apply(D var1) throws Exception;
+    }
+
+    public UseCases() {
+    }
+
+    public UseCases(Context context) {
+        this.context = context;
     }
 
     public void init(Context context) {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/api/UseCases.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/api/UseCases.java
@@ -16,9 +16,6 @@ public class UseCases {
         Result<R> apply(D var1) throws Exception;
     }
 
-    public UseCases() {
-    }
-
     public UseCases(Context context) {
         this.context = context;
     }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/dto/CreateSessionCommand.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/dto/CreateSessionCommand.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.iot.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Value;
+
+@Value
+@AllArgsConstructor
+public class CreateSessionCommand {
+    String thingName;
+    String certificatePem;
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/dto/CreateSessionDTO.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/dto/CreateSessionDTO.java
@@ -10,7 +10,7 @@ import lombok.Value;
 
 @Value
 @AllArgsConstructor
-public class CreateSessionCommand {
+public class CreateSessionDTO {
     String thingName;
     String certificatePem;
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/dto/VerifyThingAttachedToCertificateDTO.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/dto/VerifyThingAttachedToCertificateDTO.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.iot.dto;
+
+import com.aws.greengrass.clientdevices.auth.iot.Certificate;
+import com.aws.greengrass.clientdevices.auth.iot.Thing;
+import lombok.AllArgsConstructor;
+import lombok.Value;
+
+
+@Value
+@AllArgsConstructor
+public class VerifyThingAttachedToCertificateDTO {
+    Thing thing;
+    Certificate certificate;
+}
+

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/infra/ThingRegistry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/infra/ThingRegistry.java
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.aws.greengrass.clientdevices.auth.iot;
+package com.aws.greengrass.clientdevices.auth.iot.infra;
 
 import com.aws.greengrass.clientdevices.auth.api.DomainEvents;
 import com.aws.greengrass.clientdevices.auth.configuration.RuntimeConfiguration;
-import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
+import com.aws.greengrass.clientdevices.auth.iot.Thing;
 import com.aws.greengrass.clientdevices.auth.iot.dto.ThingV1DTO;
 import com.aws.greengrass.clientdevices.auth.iot.events.ThingUpdated;
 
@@ -18,22 +18,17 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 
 public class ThingRegistry {
-    private final IotAuthClient iotAuthClient;
     private final DomainEvents domainEvents;
     private final RuntimeConfiguration runtimeConfig;
 
     /**
      * Construct Thing registry.
      *
-     * @param iotAuthClient IoT auth client
      * @param domainEvents Domain events
      * @param runtimeConfig Runtime configuration store
      */
     @Inject
-    public ThingRegistry(IotAuthClient iotAuthClient,
-                         DomainEvents domainEvents,
-                         RuntimeConfiguration runtimeConfig) {
-        this.iotAuthClient = iotAuthClient;
+    public ThingRegistry(DomainEvents domainEvents, RuntimeConfiguration runtimeConfig) {
         this.domainEvents = domainEvents;
         this.runtimeConfig = runtimeConfig;
     }
@@ -108,32 +103,6 @@ public class ThingRegistry {
         runtimeConfig.putThing(thingToDto(thing));
         domainEvents.emit(new ThingUpdated(thing.getThingName(), 0)); // TODO: remove from event
         return thing;
-    }
-
-    /**
-     * Returns whether the Thing is associated to the given IoT Certificate.
-     * Returns valid locally registered result when IoT Core cannot be reached.
-     *
-     * @param thing IoT Thing
-     * @param certificate IoT Certificate
-     * @return whether thing is attached to the certificate
-     * @throws CloudServiceInteractionException when thing <-> certificate association cannot be verified
-     */
-    public boolean isThingAttachedToCertificate(Thing thing, Certificate certificate) {
-        // If we have a local cache hit, then return true. Else, go to cloud
-        if (thing.isCertificateAttached(certificate.getCertificateId())) {
-            return true;
-        }
-
-        if (iotAuthClient.isThingAttachedToCertificate(thing, certificate)) {
-            thing.attachCertificate(certificate.getCertificateId());
-            updateThing(thing);
-            return true;
-        } else {
-            thing.detachCertificate(certificate.getCertificateId());
-            updateThing(thing);
-            return false;
-        }
     }
 
     private Thing dtoToThing(ThingV1DTO dto) {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/usecases/CreateIoTThingSession.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/usecases/CreateIoTThingSession.java
@@ -57,7 +57,7 @@ public class CreateIoTThingSession
         try {
             certificate = certificateRegistry.getCertificateFromPem(certificatePem);
 
-            if (!certificate.isPresent()) {
+            if (!certificate.isPresent() || !certificate.get().isActive()) {
                 throw new AuthenticationException("Certificate isn't active");
             }
 

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/usecases/CreateIoTThingSession.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/usecases/CreateIoTThingSession.java
@@ -16,13 +16,14 @@ import com.aws.greengrass.clientdevices.auth.iot.Thing;
 import com.aws.greengrass.clientdevices.auth.iot.dto.CreateSessionDTO;
 import com.aws.greengrass.clientdevices.auth.iot.dto.VerifyThingAttachedToCertificateDTO;
 import com.aws.greengrass.clientdevices.auth.iot.infra.ThingRegistry;
+import com.aws.greengrass.clientdevices.auth.session.Session;
 import com.aws.greengrass.clientdevices.auth.session.SessionImpl;
 
 import java.util.Optional;
 import javax.inject.Inject;
 
 public class CreateIoTThingSession
-        implements UseCases.UseCase<SessionImpl, CreateSessionDTO> {
+        implements UseCases.UseCase<Session, CreateSessionDTO> {
     private final ThingRegistry thingRegistry;
     private final CertificateRegistry certificateRegistry;
     private final UseCases useCases;
@@ -49,7 +50,7 @@ public class CreateIoTThingSession
      * @param dto - VerifyCertificateAttachedToThingDTO
      */
     @Override
-    public Result<SessionImpl> apply(CreateSessionDTO dto) throws AuthenticationException {
+    public Result<Session> apply(CreateSessionDTO dto) throws AuthenticationException {
         String certificatePem = dto.getCertificatePem();
         String thingName = dto.getThingName();
         Optional<Certificate> certificate;

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/usecases/CreateIoTThingSession.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/usecases/CreateIoTThingSession.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.iot.usecases;
+
+import com.aws.greengrass.clientdevices.auth.api.Result;
+import com.aws.greengrass.clientdevices.auth.api.UseCases;
+import com.aws.greengrass.clientdevices.auth.exception.AuthenticationException;
+import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
+import com.aws.greengrass.clientdevices.auth.infra.NetworkState;
+import com.aws.greengrass.clientdevices.auth.iot.Certificate;
+import com.aws.greengrass.clientdevices.auth.iot.CertificateRegistry;
+import com.aws.greengrass.clientdevices.auth.iot.InvalidCertificateException;
+import com.aws.greengrass.clientdevices.auth.iot.IotAuthClient;
+import com.aws.greengrass.clientdevices.auth.iot.Thing;
+import com.aws.greengrass.clientdevices.auth.iot.dto.CreateSessionCommand;
+import com.aws.greengrass.clientdevices.auth.iot.infra.ThingRegistry;
+import com.aws.greengrass.clientdevices.auth.session.SessionImpl;
+
+import java.util.Optional;
+import javax.inject.Inject;
+
+public class CreateIoTThingSession
+        implements UseCases.UseCase<SessionImpl, CreateSessionCommand> {
+    private final IotAuthClient iotAuthClient;
+    private final NetworkState networkState;
+    private final ThingRegistry thingRegistry;
+    private final CertificateRegistry certificateRegistry;
+
+
+    /**
+     * Verify a certificate with IoT Core.
+     *
+     * @param iotAuthClient       IoT auth client
+     * @param thingRegistry       Thing Registry
+     * @param certificateRegistry  Certificate Registry
+     * @param networkState        Network state
+     */
+    @Inject
+    public CreateIoTThingSession(IotAuthClient iotAuthClient, ThingRegistry thingRegistry,
+                                 CertificateRegistry certificateRegistry, NetworkState networkState) {
+        this.iotAuthClient = iotAuthClient;
+        this.thingRegistry = thingRegistry;
+        this.certificateRegistry = certificateRegistry;
+        this.networkState = networkState;
+    }
+
+    private boolean verifyLocally(Thing thing, Certificate certificate) {
+        return thing.isCertificateAttached(certificate.getCertificateId());
+    }
+
+    private boolean verifyFromCloud(Thing thing, Certificate certificate) {
+        if (iotAuthClient.isThingAttachedToCertificate(thing, certificate)) {
+            thing.attachCertificate(certificate.getCertificateId());
+            thingRegistry.updateThing(thing);
+            return true;
+        }
+
+        thing.detachCertificate(certificate.getCertificateId());
+        thingRegistry.updateThing(thing);
+        return false;
+    }
+
+    private boolean isNetworkUp() {
+        return networkState.getConnectionStateFromMqtt() == NetworkState.ConnectionState.NETWORK_UP;
+    }
+
+    /**
+     * Verifies if a certificate is attached to a thing. When the device is online it will try to verify
+     * it from the cloud and update the local values in case the device goes offline. When offline, the assertion
+     * will be based on the locally stored values.
+     * @param dto - VerifyCertificateAttachedToThingDTO
+     */
+    @Override
+    public Result<SessionImpl> apply(CreateSessionCommand dto) throws AuthenticationException {
+        String certificatePem = dto.getCertificatePem();
+        String thingName = dto.getThingName();
+        Optional<Certificate> certificate;
+
+        try {
+            certificate = certificateRegistry.getCertificateFromPem(certificatePem);
+
+            if (!certificate.isPresent()) {
+                throw new AuthenticationException("Certificate isn't active");
+            }
+
+            Thing thing = thingRegistry.getOrCreateThing(thingName);
+
+            if (isNetworkUp() && verifyFromCloud(thing, certificate.get())) {
+                return Result.ok(new SessionImpl(certificate.get(), thing));
+            }
+
+            if (verifyLocally(thing, certificate.get())) {
+                return Result.ok(new SessionImpl(certificate.get(), thing));
+            }
+
+            return Result.error(new AuthenticationException("Failed to verify certificate with attached to thing"));
+        } catch (CloudServiceInteractionException | InvalidCertificateException e) {
+            throw new AuthenticationException("Failed to verify certificate with cloud", e);
+        }
+    }
+
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/usecases/VerifyThingAttachedToCertificate.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/usecases/VerifyThingAttachedToCertificate.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.iot.usecases;
+
+import com.aws.greengrass.clientdevices.auth.api.Result;
+import com.aws.greengrass.clientdevices.auth.api.UseCases;
+import com.aws.greengrass.clientdevices.auth.exception.AuthenticationException;
+import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
+import com.aws.greengrass.clientdevices.auth.infra.NetworkState;
+import com.aws.greengrass.clientdevices.auth.iot.Certificate;
+import com.aws.greengrass.clientdevices.auth.iot.IotAuthClient;
+import com.aws.greengrass.clientdevices.auth.iot.Thing;
+import com.aws.greengrass.clientdevices.auth.iot.dto.VerifyThingAttachedToCertificateDTO;
+import com.aws.greengrass.clientdevices.auth.iot.infra.ThingRegistry;
+
+import javax.inject.Inject;
+
+
+public class VerifyThingAttachedToCertificate
+        implements UseCases.UseCase<Boolean, VerifyThingAttachedToCertificateDTO> {
+    private final IotAuthClient iotAuthClient;
+    private final NetworkState networkState;
+    private final ThingRegistry thingRegistry;
+
+
+    /**
+     * Verify a certificate with IoT Core.
+     *
+     * @param iotAuthClient       IoT auth client
+     * @param thingRegistry       Thing Registry
+     * @param networkState        Network state
+     */
+    @Inject
+    public VerifyThingAttachedToCertificate(IotAuthClient iotAuthClient, ThingRegistry thingRegistry,
+                                  NetworkState networkState) {
+        this.iotAuthClient = iotAuthClient;
+        this.thingRegistry = thingRegistry;
+        this.networkState = networkState;
+    }
+
+    private boolean verifyLocally(Thing thing, Certificate certificate) {
+        return thing.isCertificateAttached(certificate.getCertificateId());
+    }
+
+    private boolean verifyFromCloud(Thing thing, Certificate certificate) {
+        if (iotAuthClient.isThingAttachedToCertificate(thing, certificate)) {
+            thing.attachCertificate(certificate.getCertificateId());
+            thingRegistry.updateThing(thing);
+            return true;
+        }
+
+        thing.detachCertificate(certificate.getCertificateId());
+        thingRegistry.updateThing(thing);
+        return false;
+    }
+
+    private boolean isNetworkUp() {
+        return networkState.getConnectionStateFromMqtt() == NetworkState.ConnectionState.NETWORK_UP;
+    }
+
+    /**
+     * Verifies if a certificate is attached to a thing. When the device is online it will try to verify
+     * it from the cloud and update the local values in case the device goes offline. When offline, the assertion
+     * will be based on the locally stored values.
+     * @param dto - VerifyCertificateAttachedToThingDTO
+     */
+    @Override
+    public Result<Boolean> apply(VerifyThingAttachedToCertificateDTO dto) throws AuthenticationException {
+        Certificate certificate = dto.getCertificate();
+        Thing thing = dto.getThing();
+
+        try {
+            if (isNetworkUp()) {
+                return Result.ok(verifyFromCloud(thing, certificate));
+            }
+
+            return Result.ok(verifyLocally(thing, certificate));
+        } catch (CloudServiceInteractionException e) {
+            return Result.ok(false);
+        }
+    }
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactory.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactory.java
@@ -50,7 +50,7 @@ public class MqttSessionFactory implements SessionFactory {
         //  refactor this later
         CreateIoTThingSession useCase = useCases.get(CreateIoTThingSession.class);
         CreateSessionDTO command = new CreateSessionDTO(mqttCredential.clientId, mqttCredential.certificatePem);
-        Result<SessionImpl> sessionResult = useCase.apply(command);
+        Result<Session> sessionResult = useCase.apply(command);
 
         if (sessionResult.isOk()) {
             return sessionResult.get();

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactory.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactory.java
@@ -51,12 +51,7 @@ public class MqttSessionFactory implements SessionFactory {
         CreateIoTThingSession useCase = useCases.get(CreateIoTThingSession.class);
         CreateSessionDTO command = new CreateSessionDTO(mqttCredential.clientId, mqttCredential.certificatePem);
         Result<Session> sessionResult = useCase.apply(command);
-
-        if (sessionResult.isOk()) {
-            return sessionResult.get();
-        }
-
-        throw new AuthenticationException(sessionResult.getError());
+        return sessionResult.get();
     }
 
     private Session createGreengrassComponentSession() {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactory.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactory.java
@@ -10,7 +10,7 @@ import com.aws.greengrass.clientdevices.auth.api.Result;
 import com.aws.greengrass.clientdevices.auth.api.UseCases;
 import com.aws.greengrass.clientdevices.auth.exception.AuthenticationException;
 import com.aws.greengrass.clientdevices.auth.iot.Component;
-import com.aws.greengrass.clientdevices.auth.iot.dto.CreateSessionCommand;
+import com.aws.greengrass.clientdevices.auth.iot.dto.CreateSessionDTO;
 import com.aws.greengrass.clientdevices.auth.iot.usecases.CreateIoTThingSession;
 
 import java.util.Map;
@@ -49,7 +49,7 @@ public class MqttSessionFactory implements SessionFactory {
         // NOTE: We should remove  calling this useCase from here, but for now it serves its purpose. We will
         //  refactor this later
         CreateIoTThingSession useCase = useCases.get(CreateIoTThingSession.class);
-        CreateSessionCommand command = new CreateSessionCommand(mqttCredential.clientId, mqttCredential.certificatePem);
+        CreateSessionDTO command = new CreateSessionDTO(mqttCredential.clientId, mqttCredential.certificatePem);
         Result<SessionImpl> sessionResult = useCase.apply(command);
 
         if (sessionResult.isOk()) {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactory.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactory.java
@@ -6,38 +6,30 @@
 package com.aws.greengrass.clientdevices.auth.session;
 
 import com.aws.greengrass.clientdevices.auth.DeviceAuthClient;
+import com.aws.greengrass.clientdevices.auth.api.Result;
+import com.aws.greengrass.clientdevices.auth.api.UseCases;
 import com.aws.greengrass.clientdevices.auth.exception.AuthenticationException;
-import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
-import com.aws.greengrass.clientdevices.auth.iot.Certificate;
-import com.aws.greengrass.clientdevices.auth.iot.CertificateRegistry;
 import com.aws.greengrass.clientdevices.auth.iot.Component;
-import com.aws.greengrass.clientdevices.auth.iot.InvalidCertificateException;
-import com.aws.greengrass.clientdevices.auth.iot.Thing;
-import com.aws.greengrass.clientdevices.auth.iot.ThingRegistry;
+import com.aws.greengrass.clientdevices.auth.iot.dto.CreateSessionCommand;
+import com.aws.greengrass.clientdevices.auth.iot.usecases.CreateIoTThingSession;
 
 import java.util.Map;
-import java.util.Optional;
 import javax.inject.Inject;
 
 public class MqttSessionFactory implements SessionFactory {
     private final DeviceAuthClient deviceAuthClient;
-    private final CertificateRegistry certificateRegistry;
-    private final ThingRegistry thingRegistry;
+    private final UseCases useCases;
 
     /**
      * Constructor.
      *
      * @param deviceAuthClient    Device auth client
-     * @param certificateRegistry device Certificate registry
-     * @param thingRegistry       thing registry
+     * @param useCases       useCases
      */
     @Inject
-    public MqttSessionFactory(DeviceAuthClient deviceAuthClient,
-                              CertificateRegistry certificateRegistry,
-                              ThingRegistry thingRegistry) {
+    public MqttSessionFactory(DeviceAuthClient deviceAuthClient, UseCases useCases) {
         this.deviceAuthClient = deviceAuthClient;
-        this.certificateRegistry = certificateRegistry;
-        this.thingRegistry = thingRegistry;
+        this.useCases = useCases;
     }
 
     @Override
@@ -54,19 +46,17 @@ public class MqttSessionFactory implements SessionFactory {
     }
 
     private Session createIotThingSession(MqttCredential mqttCredential) throws AuthenticationException {
-        try {
-            Optional<Certificate> cert = certificateRegistry.getCertificateFromPem(mqttCredential.certificatePem);
-            if (!cert.isPresent() || !cert.get().isActive()) {
-                throw new AuthenticationException("Certificate isn't active");
-            }
-            Thing thing = thingRegistry.getOrCreateThing(mqttCredential.clientId);
-            if (!thingRegistry.isThingAttachedToCertificate(thing, cert.get())) {
-                throw new AuthenticationException("unable to authenticate device");
-            }
-            return new SessionImpl(cert.get(), thing);
-        } catch (CloudServiceInteractionException | InvalidCertificateException e) {
-            throw new AuthenticationException("Failed to verify certificate with cloud", e);
+        // NOTE: We should remove  calling this useCase from here, but for now it serves its purpose. We will
+        //  refactor this later
+        CreateIoTThingSession useCase = useCases.get(CreateIoTThingSession.class);
+        CreateSessionCommand command = new CreateSessionCommand(mqttCredential.clientId, mqttCredential.certificatePem);
+        Result<SessionImpl> sessionResult = useCase.apply(command);
+
+        if (sessionResult.isOk()) {
+            return sessionResult.get();
         }
+
+        throw new AuthenticationException(sessionResult.getError());
     }
 
     private Session createGreengrassComponentSession() {

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/api/UseCasesTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/api/UseCasesTest.java
@@ -100,7 +100,7 @@ public class UseCasesTest {
     @Test
     void GIVEN_aUseCaseWithExceptions_WHEN_ran_THEN_itThrowsAnException() {
         UseCaseWithExceptions useCase = useCases.get(UseCaseWithExceptions.class);
-        assertTrue(useCase.apply(null).getError() instanceof InvalidConfigurationException);
+        assertTrue(useCase.apply(null).get() instanceof InvalidConfigurationException);
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/api/UseCasesTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/api/UseCasesTest.java
@@ -84,7 +84,7 @@ public class UseCasesTest {
     @BeforeEach
     void beforeEach() {
         topics = Topics.of(new Context(), CLIENT_DEVICES_AUTH_SERVICE_NAME, null);
-        this.useCases = new UseCases();
+        this.useCases = new UseCases(topics.getContext());
         this.useCases.init(topics.getContext());
     }
 

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/api/UseCasesTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/api/UseCasesTest.java
@@ -100,7 +100,7 @@ public class UseCasesTest {
     @Test
     void GIVEN_aUseCaseWithExceptions_WHEN_ran_THEN_itThrowsAnException() {
         UseCaseWithExceptions useCase = useCases.get(UseCaseWithExceptions.class);
-        assertTrue(useCase.apply(null).get() instanceof InvalidConfigurationException);
+        assertTrue(useCase.apply(null).getError() instanceof InvalidConfigurationException);
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/usecases/ConnectivityInformationUseCasesTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/usecases/ConnectivityInformationUseCasesTest.java
@@ -56,7 +56,7 @@ public class ConnectivityInformationUseCasesTest {
         context.put(GreengrassServiceClientFactory.class, Mockito.mock(GreengrassServiceClientFactory.class));
 
         Topics topics = Topics.of(context, CONFIGURATION_CONFIG_KEY, null);
-        this.useCases = new UseCases();
+        this.useCases = new UseCases(topics.getContext());
         this.useCases.init(topics.getContext());
     }
 

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactoryTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactoryTest.java
@@ -18,6 +18,7 @@ import com.aws.greengrass.clientdevices.auth.iot.CertificateRegistry;
 import com.aws.greengrass.clientdevices.auth.iot.infra.ThingRegistry;
 import com.aws.greengrass.clientdevices.auth.iot.Component;
 import com.aws.greengrass.clientdevices.auth.iot.usecases.CreateIoTThingSession;
+import com.aws.greengrass.clientdevices.auth.iot.usecases.VerifyThingAttachedToCertificate;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.hamcrest.core.IsNull;
@@ -67,10 +68,13 @@ public class MqttSessionFactoryTest {
     @BeforeEach
     void beforeEach() {
         context = new Context();
-        CreateIoTThingSession useCase = new CreateIoTThingSession(
-                iotAuthClientMock, mockThingRegistry, mockCertificateRegistry, mockNetworkState);
-        context.put(CreateIoTThingSession.class, useCase);
         UseCases useCases = new UseCases(context);
+        CreateIoTThingSession createIoTThingSession =
+                new CreateIoTThingSession(mockThingRegistry, mockCertificateRegistry, useCases);
+        VerifyThingAttachedToCertificate verifyThingAttachedToCertificate =
+                new VerifyThingAttachedToCertificate(iotAuthClientMock, mockThingRegistry, mockNetworkState);
+        context.put(CreateIoTThingSession.class, createIoTThingSession);
+        context.put(VerifyThingAttachedToCertificate.class, verifyThingAttachedToCertificate);
         mqttSessionFactory = new MqttSessionFactory(mockDeviceAuthClient, useCases);
     }
 

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactoryTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactoryTest.java
@@ -6,16 +6,22 @@
 package com.aws.greengrass.clientdevices.auth.session;
 
 import com.aws.greengrass.clientdevices.auth.DeviceAuthClient;
+import com.aws.greengrass.clientdevices.auth.api.UseCases;
 import com.aws.greengrass.clientdevices.auth.exception.AuthenticationException;
 import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
+import com.aws.greengrass.clientdevices.auth.infra.NetworkState;
 import com.aws.greengrass.clientdevices.auth.iot.CertificateFake;
 import com.aws.greengrass.clientdevices.auth.iot.InvalidCertificateException;
+import com.aws.greengrass.clientdevices.auth.iot.IotAuthClient;
 import com.aws.greengrass.clientdevices.auth.iot.Thing;
 import com.aws.greengrass.clientdevices.auth.iot.CertificateRegistry;
+import com.aws.greengrass.clientdevices.auth.iot.infra.ThingRegistry;
 import com.aws.greengrass.clientdevices.auth.iot.Component;
-import com.aws.greengrass.clientdevices.auth.iot.ThingRegistry;
+import com.aws.greengrass.clientdevices.auth.iot.usecases.CreateIoTThingSession;
+import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.hamcrest.core.IsNull;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,6 +30,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.utils.ImmutableMap;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 
@@ -42,7 +49,13 @@ public class MqttSessionFactoryTest {
     private CertificateRegistry mockCertificateRegistry;
     @Mock
     private ThingRegistry mockThingRegistry;
+    @Mock
+    private NetworkState mockNetworkState;
+    @Mock
+    private IotAuthClient iotAuthClientMock;
     private MqttSessionFactory mqttSessionFactory;
+    private Context context;
+
     private final Map<String, String> credentialMap = ImmutableMap.of(
             "certificatePem", "PEM",
             "clientId", "clientId",
@@ -50,18 +63,30 @@ public class MqttSessionFactoryTest {
             "password", ""
     );
 
+
     @BeforeEach
     void beforeEach() {
-        mqttSessionFactory = new MqttSessionFactory(mockDeviceAuthClient, mockCertificateRegistry, mockThingRegistry);
+        context = new Context();
+        CreateIoTThingSession useCase = new CreateIoTThingSession(
+                iotAuthClientMock, mockThingRegistry, mockCertificateRegistry, mockNetworkState);
+        context.put(CreateIoTThingSession.class, useCase);
+        UseCases useCases = new UseCases(context);
+        mqttSessionFactory = new MqttSessionFactory(mockDeviceAuthClient, useCases);
+    }
+
+    @AfterEach
+    void afterEach() throws IOException {
+        context.close();
     }
 
     @Test
     void GIVEN_credentialsWithUnknownClientId_WHEN_createSession_THEN_throwsAuthenticationException()
             throws InvalidCertificateException {
+        when(mockNetworkState.getConnectionStateFromMqtt()).thenReturn(NetworkState.ConnectionState.NETWORK_UP);
         when(mockCertificateRegistry.getCertificateFromPem(any()))
                 .thenReturn(Optional.of(CertificateFake.activeCertificate()));
         when(mockThingRegistry.getOrCreateThing(any())).thenReturn(Thing.of("clientId"));
-        when(mockThingRegistry.isThingAttachedToCertificate(any(), any())).thenReturn(false);
+        when(iotAuthClientMock.isThingAttachedToCertificate(any(), any())).thenReturn(false);
 
         Assertions.assertThrows(AuthenticationException.class,
                 () -> mqttSessionFactory.createSession(credentialMap));
@@ -78,10 +103,11 @@ public class MqttSessionFactoryTest {
     @Test
     void GIVEN_credentialsWithCertificate_WHEN_createSession_AND_cloudError_THEN_throwsAuthenticationException()
             throws InvalidCertificateException {
+        when(mockNetworkState.getConnectionStateFromMqtt()).thenReturn(NetworkState.ConnectionState.NETWORK_UP);
         when(mockCertificateRegistry.getCertificateFromPem(any()))
                 .thenReturn(Optional.of(CertificateFake.activeCertificate()));
         when(mockThingRegistry.getOrCreateThing(any())).thenReturn(Thing.of("clientId"));
-        when(mockThingRegistry.isThingAttachedToCertificate(any(), any()))
+        when(iotAuthClientMock.isThingAttachedToCertificate(any(), any()))
                 .thenThrow(CloudServiceInteractionException.class);
         Assertions.assertThrows(AuthenticationException.class,
                 () -> mqttSessionFactory.createSession(credentialMap));
@@ -90,10 +116,11 @@ public class MqttSessionFactoryTest {
     @Test
     void GIVEN_credentialsWithValidClientId_WHEN_createSession_THEN_returnsSession()
             throws AuthenticationException, InvalidCertificateException {
+        when(mockNetworkState.getConnectionStateFromMqtt()).thenReturn(NetworkState.ConnectionState.NETWORK_UP);
         when(mockThingRegistry.getOrCreateThing("clientId")).thenReturn(Thing.of("clientId"));
         when(mockCertificateRegistry.getCertificateFromPem(any()))
                 .thenReturn(Optional.of(CertificateFake.activeCertificate()));
-        when(mockThingRegistry.isThingAttachedToCertificate(any(), any())).thenReturn(true);
+        when(iotAuthClientMock.isThingAttachedToCertificate(any(), any())).thenReturn(true);
 
         Session session = mqttSessionFactory.createSession(credentialMap);
         assertThat(session, is(IsNull.notNullValue()));


### PR DESCRIPTION
**Description of changes:**
This changes extract the iot client from the registry effectively decoupling them. Before this change we had a boolean method that would mutate the registry. Now we moved the logic into a use case that can be called separately I will further decouple the logic that updates the registry in the next PR but this is the first step.

**Why is this change necessary:**
Refreshing the attached certificates to things is really hard to do without decoupling things. In the next PR I will split things a bit more so I can individually call something that would refresh the thing <-> cert attachements.

**How was this change tested:**
Existing tests pass