### PR TITLE
refactor: avoid passing the entire configuration with the ca configuration changed event

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/CertificateManager.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/CertificateManager.java
@@ -16,7 +16,7 @@ import com.aws.greengrass.clientdevices.auth.certificate.CertificatesConfig;
 import com.aws.greengrass.clientdevices.auth.certificate.ClientCertificateGenerator;
 import com.aws.greengrass.clientdevices.auth.certificate.ServerCertificateGenerator;
 import com.aws.greengrass.clientdevices.auth.certificate.handlers.CertificateRotationHandler;
-import com.aws.greengrass.clientdevices.auth.configuration.CDAConfiguration;
+import com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration;
 import com.aws.greengrass.clientdevices.auth.connectivity.CISShadowMonitor;
 import com.aws.greengrass.clientdevices.auth.connectivity.ConnectivityInformation;
 import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationException;
@@ -272,7 +272,7 @@ public class CertificateManager {
      *                                      certificateUri
      */
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
-    public void configureCustomCA(CDAConfiguration configuration) throws InvalidConfigurationException {
+    public void configureCustomCA(CAConfiguration configuration) throws InvalidConfigurationException {
         if (!configuration.isUsingCustomCA()) {
             throw new InvalidConfigurationException(
                     "Invalid configuration: certificateUri and privateKeyUri are required.");

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/events/CAConfigurationChanged.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/events/CAConfigurationChanged.java
@@ -6,12 +6,12 @@
 package com.aws.greengrass.clientdevices.auth.certificate.events;
 
 import com.aws.greengrass.clientdevices.auth.api.DomainEvent;
-import com.aws.greengrass.clientdevices.auth.configuration.CDAConfiguration;
+import com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @AllArgsConstructor
 public class CAConfigurationChanged implements DomainEvent {
     @Getter
-    private CDAConfiguration configuration;
+    private CAConfiguration configuration;
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/handlers/CAConfigurationChangedHandler.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/handlers/CAConfigurationChangedHandler.java
@@ -10,7 +10,7 @@ import com.aws.greengrass.clientdevices.auth.api.UseCases;
 import com.aws.greengrass.clientdevices.auth.certificate.events.CAConfigurationChanged;
 import com.aws.greengrass.clientdevices.auth.certificate.usecases.ConfigureCustomCertificateAuthority;
 import com.aws.greengrass.clientdevices.auth.certificate.usecases.ConfigureManagedCertificateAuthority;
-import com.aws.greengrass.clientdevices.auth.configuration.CDAConfiguration;
+import com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration;
 
 import java.util.function.Consumer;
 import javax.inject.Inject;
@@ -45,7 +45,7 @@ public class CAConfigurationChangedHandler implements Consumer<CAConfigurationCh
      */
     @Override
     public void accept(CAConfigurationChanged event)  {
-        CDAConfiguration configuration = event.getConfiguration();
+        CAConfiguration configuration = event.getConfiguration();
 
         if (configuration.isUsingCustomCA()) {
             useCases.get(ConfigureCustomCertificateAuthority.class).apply(configuration);

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfiguration.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfiguration.java
@@ -18,6 +18,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -78,6 +79,16 @@ public final class CAConfiguration {
      */
     public boolean isUsingCustomCA() {
         return privateKeyUri.isPresent() && certificateUri.isPresent();
+    }
+
+    /**
+     * Compares 2 CAConfigurations and returns true if it has changed.
+     * @param config - an existing CAConfiguration
+     */
+    public boolean hasChanged(CAConfiguration config) {
+        return !Objects.equals(config.getCertificateUri(), getCertificateUri())
+                || !Objects.equals(config.getPrivateKeyUri(), getPrivateKeyUri())
+                || !Objects.equals(config.getCaType(), getCaType());
     }
 
     private static List<String> getCaTypeListFromConfiguration(Topics configurationTopic) {

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/CertificateManagerTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/CertificateManagerTest.java
@@ -154,7 +154,7 @@ public class CertificateManagerTest {
                 .loadCaCertificateChain(privateKeyUri, certificateUri);
 
         // When
-        certificateManager.configureCustomCA(cdaConfiguration);
+        certificateManager.configureCustomCA(cdaConfiguration.getCertificateAuthorityConfiguration());
 
         // Then
         List<String> caPemStrings = certificateManager.getCACertificates();

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthServiceTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthServiceTest.java
@@ -12,7 +12,6 @@ import com.aws.greengrass.clientdevices.auth.certificate.CertificateHelper;
 import com.aws.greengrass.clientdevices.auth.certificate.usecases.ConfigureCustomCertificateAuthority;
 import com.aws.greengrass.clientdevices.auth.certificate.usecases.ConfigureManagedCertificateAuthority;
 import com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration;
-import com.aws.greengrass.clientdevices.auth.configuration.CDAConfiguration;
 import com.aws.greengrass.clientdevices.auth.configuration.ConfigurationFormatVersion;
 import com.aws.greengrass.clientdevices.auth.configuration.GroupConfiguration;
 import com.aws.greengrass.clientdevices.auth.configuration.GroupManager;
@@ -363,7 +362,7 @@ class ClientDevicesAuthServiceTest {
     @Test
     void GIVEN_certificateAuthorityConfiguration_WHEN_itChanges_THEN_CAisConfigured() throws InterruptedException,
             ServiceLoadException {
-        ArgumentCaptor<CDAConfiguration> configurationCaptor = ArgumentCaptor.forClass(CDAConfiguration.class);
+        ArgumentCaptor<CAConfiguration> configurationCaptor = ArgumentCaptor.forClass(CAConfiguration.class);
         UseCases useCasesMock = mock(UseCases.class);
         ConfigureCustomCertificateAuthority customCAUseCase = mock(ConfigureCustomCertificateAuthority.class);
         when(customCAUseCase.apply(configurationCaptor.capture())).thenReturn(Result.ok());

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/api/UseCasesTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/api/UseCasesTest.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.clientdevices.auth.api;
 
+import com.aws.greengrass.clientdevices.auth.configuration.CAConfiguration;
 import com.aws.greengrass.clientdevices.auth.configuration.CDAConfiguration;
 import com.aws.greengrass.clientdevices.auth.exception.InvalidConfigurationException;
 import com.aws.greengrass.config.Topics;
@@ -75,7 +76,8 @@ public class UseCasesTest {
 
         @Override
         public Result<String> apply(Void dto) {
-            return Result.ok(configuration.getCertificateUri().get().toString());
+            CAConfiguration caConfig = configuration.getCertificateAuthorityConfiguration();
+            return Result.ok(caConfig.getCertificateUri().get().toString());
         }
     }
 


### PR DESCRIPTION
**Description of changes:**
This is a lower priority refactor but I think it is still important to avoid passing stuff that is not needed with events. Otherwise they might start getting misused leading to code that is coupled and not cohesive in the future.

**Why is this change necessary:**
We are establishing new patterns and other developers might copy them and if we don't tend to this things it might lead to us un-intendedly open the door for code that can get entangled.
