### PR TITLE
feat: add opt-in metadata trust verification

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/SecurityConfiguration.java
@@ -26,8 +26,9 @@ public final class SecurityConfiguration {
     private static final Logger logger = LogManager.getLogger(SecurityConfiguration.class);
     public static final String SECURITY_TOPIC = "security";
     public static final String CLIENT_DEVICE_TRUST_DURATION_MINUTES_TOPIC = "clientDeviceTrustDurationMinutes";
-    // TODO: change default value to zero (opt-in offline auth)
-    public static final int DEFAULT_CLIENT_DEVICE_TRUST_DURATION_MINUTES = 60;
+    // opt-in trust verification: metadata trust verification is enabled when configured trust duration is non-zero
+    // trust verification is disabled by default
+    public static final int DEFAULT_CLIENT_DEVICE_TRUST_DURATION_MINUTES = 0;
     public static final int MIN_CLIENT_DEVICE_TRUST_DURATION_MINUTES = 0;
 
     private int clientDeviceTrustDurationMinutes;

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Certificate.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Certificate.java
@@ -145,9 +145,20 @@ public class Certificate implements AttributeProvider {
         metadataTrustDurationMinutes.set(newTrustDuration);
     }
 
+    /**
+     * Following opt-in offline auth, verifies the certificate status trust.
+     * Metadata trust verification is enabled when configured trust duration is non-zero.
+     * Trust verification is disabled by default.
+     *
+     * @return whether the status is verified within configured trust duration
+     */
     private boolean isStatusTrusted() {
-        Instant validTill = statusLastUpdated.plus(metadataTrustDurationMinutes.get(), ChronoUnit.MINUTES);
-        return validTill.isAfter(Instant.now());
+        int trustDurationMinutes = metadataTrustDurationMinutes.get();
+        if (trustDurationMinutes > 0) {
+            Instant validTill = statusLastUpdated.plus(trustDurationMinutes, ChronoUnit.MINUTES);
+            return validTill.isAfter(Instant.now());
+        }
+        return true;
     }
 
     private static String computeCertificateId(String certificatePem)

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Thing.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Thing.java
@@ -164,8 +164,19 @@ public final class Thing implements AttributeProvider, Cloneable {
         metadataTrustDurationMinutes.set(newTrustDuration);
     }
 
+    /**
+     * Following opt-in offline auth, verifies the certificate attachment trust.
+     * Metadata trust verification is enabled when configured trust duration is non-zero.
+     * Trust verification is disabled by default.
+     *
+     * @return whether the cert attachment is verified within configured trust duration
+     */
     private boolean isCertAttachmentTrusted(Instant lastVerified) {
-        Instant validTill = lastVerified.plus(metadataTrustDurationMinutes.get(), ChronoUnit.MINUTES);
-        return validTill.isAfter(Instant.now());
+        int trustDurationMinutes = metadataTrustDurationMinutes.get();
+        if (trustDurationMinutes > 0) {
+            Instant validTill = lastVerified.plus(trustDurationMinutes, ChronoUnit.MINUTES);
+            return validTill.isAfter(Instant.now());
+        }
+        return true;
     }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Trustable.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Trustable.java
@@ -31,16 +31,7 @@ public interface Trustable {
             Instant validTill = lastVerified.plus(trustDuration, temporalUnit);
             return validTill.isAfter(Instant.now());
         }
-        return isTrustedByDefault();
-    }
-
-    /**
-     * Indicates whether to trust an entity by default
-     * when no absolute trust duration is configured.
-     *
-     * @return default trust indicator boolean
-     */
-    default boolean isTrustedByDefault() {
+        // trusted by default
         return true;
     }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Trustable.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Trustable.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.iot;
+
+import com.aws.greengrass.util.Pair;
+
+import java.time.Instant;
+import java.time.temporal.TemporalUnit;
+
+public interface Trustable {
+    /**
+     * Provides the time duration for which the entity is trusted.
+     *
+     * @return duration with the time unit
+     */
+    Pair<Integer, TemporalUnit> getTrustDuration();
+
+    /**
+     * Checks whether the trust has expired since the last verified time instant.
+     *
+     * @param lastVerified time instant when the entity was last verified
+     * @return whether the trust has expired
+     */
+    default boolean isTrustedSinceLastVerified(Instant lastVerified) {
+        int trustDuration = getTrustDuration().getLeft();
+        TemporalUnit temporalUnit = getTrustDuration().getRight();
+        if (trustDuration > 0) {
+            Instant validTill = lastVerified.plus(trustDuration, temporalUnit);
+            return validTill.isAfter(Instant.now());
+        }
+        return isTrustedByDefault();
+    }
+
+    /**
+     * Indicates whether to trust an entity by default
+     * when no absolute trust duration is configured.
+     *
+     * @return default trust indicator boolean
+     */
+    default boolean isTrustedByDefault() {
+        return true;
+    }
+}

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/configuration/SecurityConfigurationTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/configuration/SecurityConfigurationTest.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.clientdevices.auth.configuration;
 
 
+import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
@@ -50,21 +51,27 @@ class SecurityConfigurationTest {
 
     @Test
     public void GIVEN_invalidConfiguredTrustDuration_WHEN_getClientDeviceTrustDurationMinutes_THEN_returnsMinimumTrustDuration() {
+        Topic trustDurationTopic = configurationTopics.lookup(SECURITY_TOPIC, CLIENT_DEVICE_TRUST_DURATION_MINUTES_TOPIC);
         // overflown integer
         int overflown = Integer.MAX_VALUE + 1;
-        configurationTopics.lookup(SECURITY_TOPIC, CLIENT_DEVICE_TRUST_DURATION_MINUTES_TOPIC).withValue(overflown);
+        trustDurationTopic.withValue(overflown);
         securityConfig = SecurityConfiguration.from(configurationTopics);
         assertThat(securityConfig.getClientDeviceTrustDurationMinutes(), is(equalTo(MIN_CLIENT_DEVICE_TRUST_DURATION_MINUTES)));
 
         // integer max value
-        configurationTopics.lookup(SECURITY_TOPIC, CLIENT_DEVICE_TRUST_DURATION_MINUTES_TOPIC).withValue(Integer.MAX_VALUE);
+        trustDurationTopic.withValue(Integer.MAX_VALUE);
         securityConfig = SecurityConfiguration.from(configurationTopics);
         assertThat(securityConfig.getClientDeviceTrustDurationMinutes(), is(equalTo(Integer.MAX_VALUE)));
 
         String empty = "";
-        configurationTopics.lookup(SECURITY_TOPIC, CLIENT_DEVICE_TRUST_DURATION_MINUTES_TOPIC).withValue(empty);
+        trustDurationTopic.withValue(empty);
         securityConfig = SecurityConfiguration.from(configurationTopics);
         assertThat(securityConfig.getClientDeviceTrustDurationMinutes(), is(equalTo(MIN_CLIENT_DEVICE_TRUST_DURATION_MINUTES)));
+
+        float invalidSDecimal = 0.1f;
+        trustDurationTopic.withValue(invalidSDecimal);
+        securityConfig = SecurityConfiguration.from(configurationTopics);
+        assertThat(securityConfig.getClientDeviceTrustDurationMinutes(), is(equalTo((int) invalidSDecimal)));
     }
 
 }

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/CertificateTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/CertificateTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
@@ -22,10 +23,15 @@ import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.time.Clock;
+import java.time.Instant;
 
 import static com.aws.greengrass.clientdevices.auth.configuration.SecurityConfiguration.DEFAULT_CLIENT_DEVICE_TRUST_DURATION_MINUTES;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 class CertificateTest {
@@ -50,6 +56,16 @@ class CertificateTest {
         Certificate.updateMetadataTrustDurationMinutes(DEFAULT_CLIENT_DEVICE_TRUST_DURATION_MINUTES);
     }
 
+    private Runnable mockInstant(long expectedMillis) {
+        Clock spyClock = spy(Clock.class);
+        MockedStatic<Clock> clockMock;
+        clockMock = mockStatic(Clock.class);
+        clockMock.when(Clock::systemUTC).thenReturn(spyClock);
+        when(spyClock.instant()).thenReturn(Instant.ofEpochMilli(expectedMillis));
+
+        return clockMock::close;
+    }
+
     @Test
     void GIVEN_validActiveCertificate_WHEN_isActive_THEN_returnTrue() throws InvalidCertificateException {
         Certificate cert = Certificate.fromPem(validClientCertificatePem);
@@ -58,11 +74,49 @@ class CertificateTest {
     }
 
     @Test
-    void GIVEN_expiredActiveCertificate_WHEN_isActive_THEN_returnFalse() throws InvalidCertificateException {
-        // update trust duration to zero, indicating not to trust any metadata
+    void GIVEN_disabledTrustVerificationAndActiveCertificate_WHEN_isActive_THEN_returnTrue() throws InvalidCertificateException {
+        // update trust duration to zero, indicating disabled trust verification
         Certificate.updateMetadataTrustDurationMinutes(0);
         Certificate cert = Certificate.fromPem(validClientCertificatePem);
         cert.setStatus(Certificate.Status.ACTIVE);
+        assertTrue(cert.isActive());
+    }
+
+    @Test
+    void GIVEN_enabledTrustVerificationAndUnexpiredActiveCertificate_WHEN_isActive_THEN_returnTrue() throws InvalidCertificateException {
+        // update trust duration to non-zero, indicating enabled trust verification
+        Certificate.updateMetadataTrustDurationMinutes(5);
+        Instant now = Instant.now();
+        Runnable resetClock = mockInstant(now.toEpochMilli());
+
+        Certificate cert = Certificate.fromPem(validClientCertificatePem);
+        cert.setStatus(Certificate.Status.ACTIVE);
+
+        // verify certificate ACTIVE status before trust duration has passed
+        resetClock.run();
+        Instant oneMinuteLater = now.plusSeconds(60L);
+        resetClock = mockInstant(oneMinuteLater.toEpochMilli());
+        assertTrue(cert.isActive());
+
+        resetClock.run();
+    }
+
+    @Test
+    void GIVEN_enabledTrustVerificationAndExpiredActiveCertificate_WHEN_isActive_THEN_returnFalse() throws InvalidCertificateException {
+        // update trust duration to non-zero, indicating enabled trust verification
+        Certificate.updateMetadataTrustDurationMinutes(1);
+        Instant now = Instant.now();
+        Runnable resetClock = mockInstant(now.toEpochMilli());
+
+        Certificate cert = Certificate.fromPem(validClientCertificatePem);
+        cert.setStatus(Certificate.Status.ACTIVE);
+
+        // verify certificate ACTIVE status after trust duration has passed
+        resetClock.run();
+        Instant anHourLater = now.plusSeconds(60L * 60L);
+        resetClock = mockInstant(anHourLater.toEpochMilli());
         assertFalse(cert.isActive());
+
+        resetClock.run();
     }
 }


### PR DESCRIPTION
**Description of changes:** 
- Adds opt-in trust verification: metadata trust verification is enabled when configured trust duration is non-zero.
- Trust verification is disabled by default.

**Why is this change necessary:** Enable/disable offline auth as necessary

**How was this change tested:**  Unit tests (`mvn package`, `mvn verify`)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
