### PR TITLE
fix: update default client device trust duration

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/SecurityConfiguration.java
@@ -26,9 +26,8 @@ public final class SecurityConfiguration {
     private static final Logger logger = LogManager.getLogger(SecurityConfiguration.class);
     public static final String SECURITY_TOPIC = "security";
     public static final String CLIENT_DEVICE_TRUST_DURATION_MINUTES_TOPIC = "clientDeviceTrustDurationMinutes";
-    // TODO: change default value to zero (opt-in offline auth)
-    public static final int DEFAULT_CLIENT_DEVICE_TRUST_DURATION_MINUTES = 60;
-    public static final int MIN_CLIENT_DEVICE_TRUST_DURATION_MINUTES = 0;
+    public static final int DEFAULT_CLIENT_DEVICE_TRUST_DURATION_MINUTES = 1;
+    public static final int MIN_CLIENT_DEVICE_TRUST_DURATION_MINUTES = 1;
 
     private int clientDeviceTrustDurationMinutes;
 
@@ -67,8 +66,7 @@ public final class SecurityConfiguration {
     private static int getClientDeviceTrustDurationMinutes(Topics securityTopics) {
         int configValue = Coerce.toInt(securityTopics.findOrDefault(DEFAULT_CLIENT_DEVICE_TRUST_DURATION_MINUTES,
                 CLIENT_DEVICE_TRUST_DURATION_MINUTES_TOPIC));
-        // overflown integer
-        if (configValue < 0) {
+        if (configValue < MIN_CLIENT_DEVICE_TRUST_DURATION_MINUTES) {
             logger.warn("Illegal value {} for configuration {}. Using minimum value {}",
                     configValue, CLIENT_DEVICE_TRUST_DURATION_MINUTES_TOPIC, MIN_CLIENT_DEVICE_TRUST_DURATION_MINUTES);
             configValue = MIN_CLIENT_DEVICE_TRUST_DURATION_MINUTES;

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/configuration/SecurityConfigurationTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/configuration/SecurityConfigurationTest.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.clientdevices.auth.configuration;
 
 
+import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
@@ -50,19 +51,25 @@ class SecurityConfigurationTest {
 
     @Test
     public void GIVEN_invalidConfiguredTrustDuration_WHEN_getClientDeviceTrustDurationMinutes_THEN_returnsMinimumTrustDuration() {
+        Topic trustDurationConfig = configurationTopics.lookup(SECURITY_TOPIC, CLIENT_DEVICE_TRUST_DURATION_MINUTES_TOPIC);
         // overflown integer
         int overflown = Integer.MAX_VALUE + 1;
-        configurationTopics.lookup(SECURITY_TOPIC, CLIENT_DEVICE_TRUST_DURATION_MINUTES_TOPIC).withValue(overflown);
+        trustDurationConfig.withValue(overflown);
         securityConfig = SecurityConfiguration.from(configurationTopics);
         assertThat(securityConfig.getClientDeviceTrustDurationMinutes(), is(equalTo(MIN_CLIENT_DEVICE_TRUST_DURATION_MINUTES)));
 
         // integer max value
-        configurationTopics.lookup(SECURITY_TOPIC, CLIENT_DEVICE_TRUST_DURATION_MINUTES_TOPIC).withValue(Integer.MAX_VALUE);
+        trustDurationConfig.withValue(Integer.MAX_VALUE);
         securityConfig = SecurityConfiguration.from(configurationTopics);
         assertThat(securityConfig.getClientDeviceTrustDurationMinutes(), is(equalTo(Integer.MAX_VALUE)));
 
+        // zero value (or anything less than minimum)
+        trustDurationConfig.withValue(0);
+        securityConfig = SecurityConfiguration.from(configurationTopics);
+        assertThat(securityConfig.getClientDeviceTrustDurationMinutes(), is(equalTo(MIN_CLIENT_DEVICE_TRUST_DURATION_MINUTES)));
+
         String empty = "";
-        configurationTopics.lookup(SECURITY_TOPIC, CLIENT_DEVICE_TRUST_DURATION_MINUTES_TOPIC).withValue(empty);
+        trustDurationConfig.withValue(empty);
         securityConfig = SecurityConfiguration.from(configurationTopics);
         assertThat(securityConfig.getClientDeviceTrustDurationMinutes(), is(equalTo(MIN_CLIENT_DEVICE_TRUST_DURATION_MINUTES)));
     }


### PR DESCRIPTION
**Description of changes:** Updates default client device trust duration to one minute.

**How was this change tested:** Unit tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
