### PR TITLE
Refresh when network back up

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.15.47</version>
+                <version>2.17.81</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -113,8 +113,10 @@ public class ClientDevicesAuthService extends PluginService {
         // Infra setup
         context.put(RuntimeConfiguration.class, RuntimeConfiguration.from(getRuntimeConfig()));
         NetworkState networkState = context.get(NetworkState.class);
+        BackgroundCertificateRefresh certRefresh = context.get(BackgroundCertificateRefresh.class);
         networkState.registerHandler(context.get(CISShadowMonitor.class));
-        context.get(BackgroundCertificateRefresh.class).start();
+        networkState.registerHandler(certRefresh);
+        certRefresh.start();
 
         // Initialize IPC thread pool
         cloudCallQueueSize = DEFAULT_CLOUD_CALL_QUEUE_SIZE;

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/infra/BackgroundCertificateRefresh.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/infra/BackgroundCertificateRefresh.java
@@ -19,6 +19,7 @@ import com.aws.greengrass.clientdevices.auth.iot.usecases.VerifyThingAttachedToC
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.util.RetryUtils;
+import software.amazon.awssdk.services.greengrassv2data.model.AccessDeniedException;
 import software.amazon.awssdk.services.greengrassv2data.model.InternalServerException;
 import software.amazon.awssdk.services.greengrassv2data.model.ThrottlingException;
 
@@ -31,6 +32,7 @@ import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.inject.Inject;
@@ -39,7 +41,7 @@ import javax.inject.Inject;
  * Periodically updates the certificates and its relationships to things
  * (whether they are still attached or not to a thing) to keep them in sync with the cloud.
  */
-public class BackgroundCertificateRefresh implements Runnable {
+public class BackgroundCertificateRefresh implements Runnable, Consumer<NetworkState.ConnectionState> {
     private final UseCases useCases;
     private final NetworkState networkState;
     private static final int DEFAULT_INTERVAL_SECONDS = 60 * 60 * 24; // Once a day
@@ -93,6 +95,7 @@ public class BackgroundCertificateRefresh implements Runnable {
            return;
         }
 
+        networkState.registerHandler(this);
         logger.info("Starting background refresh of client certificates every {} seconds", intervalSeconds);
         scheduledFuture =
             scheduler.scheduleAtFixedRate(this, intervalSeconds, intervalSeconds, TimeUnit.SECONDS);
@@ -132,6 +135,19 @@ public class BackgroundCertificateRefresh implements Runnable {
         associations.ifPresent(this::refresh);
     }
 
+
+    /**
+     * Handler to react to network changes.
+     * @param connectionState - A network state
+     */
+    @Override
+    public void accept(NetworkState.ConnectionState connectionState) {
+        if (connectionState == NetworkState.ConnectionState.NETWORK_UP) {
+            logger.atInfo("Network back up - refreshing certificates");
+            run();
+        }
+    }
+
     /**
      * Returns ThingAssociations which has information about what Things are associated with the core device and
      * which things are no longer associated with the core device.
@@ -146,14 +162,18 @@ public class BackgroundCertificateRefresh implements Runnable {
         try {
             Stream<Thing> cloudThings = RetryUtils.runWithRetry(
                     retryConfig, iotAuthClient::getThingsAssociatedWithCoreDevice,
-                            "get-things-associated-with-core-device", logger);
+                    "get-things-associated-with-core-device", logger);
 
             Stream<Thing> localThings = thingRegistry.getAllThings();
-            ThingAssociations associations =  ThingAssociations.create(cloudThings);
+            ThingAssociations associations = ThingAssociations.create(cloudThings);
             associations.setLocalThings(localThings);
             return Optional.of(associations);
+        } catch (AccessDeniedException e) {
+            logger.atInfo().cause(e).log(
+                "Did not refresh local certificates. To enable certificate refresh add a policy to the core device"
+                        + "that grants the greengrass:ListClientDevicesAssociatedWithCoreDevice permission");
         } catch (Exception e) {
-            logger.atWarn().cause(e).log(
+                logger.atWarn().cause(e).log(
                     "Failed to get things associated to the core device. Retry will be scheduled later");
         }
 

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/infra/ClientCertificateStore.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/infra/ClientCertificateStore.java
@@ -20,12 +20,14 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Optional;
 
+
 /**
  * A KeyStore for client certificates. When a client device provides their certificate we store it
  * in this store it so that later we can refresh it later on using the cloud API.
  */
 public class ClientCertificateStore {
     private final KeyStore keyStore;
+
 
     /**
      * Create a certificate store for tests.
@@ -77,11 +79,24 @@ public class ClientCertificateStore {
     }
 
     /**
+     * Removes the PEM for a certificateId alias.
+     * @param certificateId - a certificate id
+     * @throws KeyStoreException - if the keystore has not been initialized, or if the entry cannot be removed.
+     */
+    public void removePem(String certificateId) throws KeyStoreException {
+        keyStore.deleteEntry(certificateId);
+    }
+
+    /**
      * Returns the PEM for a certificate.
      *
      * @param certificateId - The id of a Certificate
      */
     public Optional<String> getPem(String certificateId) {
+        if (certificateId == null) {
+            return Optional.empty();
+        }
+
         try {
             X509Certificate cert = (X509Certificate) keyStore.getCertificate(certificateId);
 

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/RuntimeConfiguration.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/RuntimeConfiguration.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * Manages the runtime configuration for the plugin. It allows to read and write
@@ -140,22 +141,6 @@ public final class RuntimeConfiguration {
     }
 
     /**
-     * Get all the certificate ids stored under.
-     * |    |---- "clientDeviceCerts":
-     * |          |---- "v1":
-     * |                |---- certificateId:
-     */
-    public String[] getAllCertificateIdsV1() {
-        Topics v1CertTopics = config.findTopics(CERTS_KEY, CERTS_V1_KEY);
-
-        if (v1CertTopics == null) {
-            return new String[]{};
-        }
-
-        return Coerce.toStringArray(v1CertTopics.children.keySet().toArray());
-    }
-
-    /**
      * Get a certificate.
      *
      * @param certificateId Certificate ID
@@ -230,5 +215,37 @@ public final class RuntimeConfiguration {
             }
         }
         return root.lookupTopics(path);
+    }
+
+    /**
+     * Returns all the Things that have been stored.
+     */
+    public Stream<ThingV1DTO> getAllThingsV1() {
+        Topics v1ThingTopics = config.findTopics(THINGS_KEY, THINGS_V1_KEY);
+
+        if (v1ThingTopics == null) {
+            return Stream.empty();
+        }
+
+        return v1ThingTopics.children.keySet().stream().map(Coerce::toString).map(this::getThingV1).map(Optional::get);
+    }
+
+
+
+    /**
+     * Returns all the stored certificates under.
+     * |    |---- "clientDeviceCerts":
+     * |          |---- "v1":
+     * |                |---- certificateId:
+     */
+    public Stream<CertificateV1DTO> getAllCertificatesV1() {
+        Topics v1CertTopics = config.findTopics(CERTS_KEY, CERTS_V1_KEY);
+
+        if (v1CertTopics == null) {
+            return Stream.empty();
+        }
+
+        return v1CertTopics.children.keySet().stream().map(Coerce::toString).map(this::getCertificateV1)
+                .map(Optional::get);
     }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Certificate.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Certificate.java
@@ -46,6 +46,10 @@ public class Certificate implements AttributeProvider {
     private Instant statusLastUpdated;
 
 
+    /**
+     * Builds a new Certificate instance given its id generated from PEM file.
+     * @param certificateId - a certificateId
+     */
     Certificate(String certificateId) {
         this.certificateId = certificateId;
         this.status = Status.UNKNOWN;

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClient.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClient.java
@@ -171,9 +171,6 @@ public interface IotAuthClient {
                         .map(AssociatedClientDevice::thingName)
                         .map(Thing::of);
             } catch (Exception e) {
-                logger.atError().cause(e).kv("thing", thingName).log(
-                        "Failed to list client devices associated to the core. Check that the core device's IoT"
-                                + "policy grants the greengrass:ListClientDevicesAssociatedWithCoreDevice permission");
                 throw new CloudServiceInteractionException(
                         String.format("Failed to list things attached to core %s", thingName), e);
             }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClient.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClient.java
@@ -6,17 +6,35 @@
 package com.aws.greengrass.clientdevices.auth.iot;
 
 import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
+import com.aws.greengrass.componentmanager.ClientConfigurationUtils;
+import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.tes.LazyCredentialProvider;
+import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
+import com.aws.greengrass.util.IotSdkClientFactory;
+import com.aws.greengrass.util.RegionUtils;
 import com.aws.greengrass.util.Utils;
+import com.aws.greengrass.util.exceptions.InvalidEnvironmentStageException;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.greengrassv2.GreengrassV2Client;
+import software.amazon.awssdk.services.greengrassv2.GreengrassV2ClientBuilder;
+import software.amazon.awssdk.services.greengrassv2.model.AssociatedClientDevice;
+import software.amazon.awssdk.services.greengrassv2.model.ListClientDevicesAssociatedWithCoreDeviceRequest;
+import software.amazon.awssdk.services.greengrassv2.model.ListClientDevicesAssociatedWithCoreDeviceResponse;
 import software.amazon.awssdk.services.greengrassv2data.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.greengrassv2data.model.ValidationException;
 import software.amazon.awssdk.services.greengrassv2data.model.VerifyClientDeviceIdentityRequest;
 import software.amazon.awssdk.services.greengrassv2data.model.VerifyClientDeviceIdentityResponse;
 import software.amazon.awssdk.services.greengrassv2data.model.VerifyClientDeviceIoTCertificateAssociationRequest;
 
+import java.net.URI;
 import java.util.Optional;
+import java.util.stream.Stream;
 import javax.inject.Inject;
 
 public interface IotAuthClient {
@@ -26,11 +44,14 @@ public interface IotAuthClient {
 
     boolean isThingAttachedToCertificate(Thing thing, Certificate certificate);
 
+    Stream<Thing> getThingsAssociatedWithCoreDevice();
+
     class Default implements IotAuthClient {
         private static final Logger logger = LogManager.getLogger(Default.class);
         private static final String CERTPEM_KEY = "certificatePem";
 
         private final GreengrassServiceClientFactory clientFactory;
+        private final LazyCredentialProvider lazyCredentialProvider;
 
         /**
          * Default IotAuthClient constructor.
@@ -38,8 +59,9 @@ public interface IotAuthClient {
          * @param clientFactory greengrass cloud service client factory
          */
         @Inject
-        Default(GreengrassServiceClientFactory clientFactory) {
+        Default(GreengrassServiceClientFactory clientFactory, LazyCredentialProvider lazyCredentialProvider) {
             this.clientFactory = clientFactory;
+            this.lazyCredentialProvider = lazyCredentialProvider;
         }
 
         @Override
@@ -123,11 +145,69 @@ public interface IotAuthClient {
                 logger.atError().cause(e).kv("thingName", thing.getThingName())
                         .kv("certificateId", certificate.getCertificateId())
                         .log("Failed to verify certificate thing association. Check that the core device's IoT policy"
-                                + " grants the greengrass:VerifyClientDeviceIoTCertificateAssociation permission.");
+                                + " grants the greengrass:VerifyClientDeviceIoTCertificateAssociation permission");
                 throw new CloudServiceInteractionException(
                         String.format("Failed to verify certificate %s thing %s association",
                                 certificate.getCertificateId(), thing.getThingName()), e);
             }
+        }
+
+        @Override
+        @SuppressWarnings("PMD.AvoidCatchingGenericException")
+        public Stream<Thing> getThingsAssociatedWithCoreDevice() {
+            DeviceConfiguration configuration = clientFactory.getDeviceConfiguration();
+            String thingName = Coerce.toString(configuration.getThingName());
+
+            ListClientDevicesAssociatedWithCoreDeviceRequest request =
+                    ListClientDevicesAssociatedWithCoreDeviceRequest.builder()
+                            .coreDeviceThingName(thingName)
+                            .build();
+
+            try (GreengrassV2Client client = getGGV2Client(configuration)) {
+                ListClientDevicesAssociatedWithCoreDeviceResponse response =
+                        client.listClientDevicesAssociatedWithCoreDevice(request);
+
+                return response.associatedClientDevices().stream()
+                        .map(AssociatedClientDevice::thingName)
+                        .map(Thing::of);
+            } catch (Exception e) {
+                logger.atError().cause(e).kv("thing", thingName).log(
+                        "Failed to list client devices associated to the core. Check that the core device's IoT"
+                                + "policy grants the greengrass:ListClientDevicesAssociatedWithCoreDevice permission");
+                throw new CloudServiceInteractionException(
+                        String.format("Failed to list things attached to core %s", thingName), e);
+            }
+        }
+
+        // TODO: This should not live here ideally it should be returned by the clientFactory but we
+        //  are adding it here to avoid introducing new changes to the nucleus
+        private GreengrassV2Client getGGV2Client(DeviceConfiguration deviceConfiguration)  {
+            ApacheHttpClient.Builder httpClient = ClientConfigurationUtils
+                    .getConfiguredClientBuilder(deviceConfiguration);
+
+            String awsRegion = Coerce.toString(deviceConfiguration.getAWSRegion());
+            GreengrassV2ClientBuilder clientBuilder = GreengrassV2Client.builder()
+                    .httpClient(httpClient.build())
+                    .credentialsProvider(lazyCredentialProvider)
+                    .overrideConfiguration(
+                            ClientOverrideConfiguration.builder().retryPolicy(RetryMode.STANDARD).build());
+
+            if (Utils.isEmpty(awsRegion)) {
+                return clientBuilder.build();
+            }
+
+            clientBuilder.region(Region.of(awsRegion));
+
+            try {
+                String environment = Coerce.toString(deviceConfiguration.getEnvironmentStage());
+                String greengrassServiceEndpoint = RegionUtils.getGreengrassControlPlaneEndpoint(
+                        awsRegion, IotSdkClientFactory.EnvironmentStage.fromString(environment));
+                clientBuilder.endpointOverride(URI.create(greengrassServiceEndpoint));
+            } catch (InvalidEnvironmentStageException e) {
+                logger.atError().cause(e).log("Failed to configure greengrass service endpoint");
+            }
+
+            return clientBuilder.build();
         }
     }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Thing.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Thing.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
@@ -99,7 +100,21 @@ public final class Thing implements AttributeProvider, Cloneable {
      * @return Certificate IDs
      */
     public Map<String, Instant> getAttachedCertificateIds() {
+        // TODO: Do not expose this it is breaking encapsulation. Instead add methods inside of here that can
+        //  answer to questions external callers might have
         return new HashMap<>(attachedCertificateIds);
+    }
+
+    /**
+     * Returns the last updated instant we updated the value of a certificate being attached to a thing.
+     * @param certificateId - A certificateId
+     */
+    public Optional<Instant> certificateLastAttachedOn(String certificateId) {
+        if (!attachedCertificateIds.containsKey(certificateId)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(attachedCertificateIds.get(certificateId));
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/infra/ThingRegistry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/infra/ThingRegistry.java
@@ -15,6 +15,7 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.inject.Inject;
 
 public class ThingRegistry {
@@ -103,6 +104,22 @@ public class ThingRegistry {
         runtimeConfig.putThing(thingToDto(thing));
         domainEvents.emit(new ThingUpdated(thing.getThingName(), 0)); // TODO: remove from event
         return thing;
+    }
+
+    /**
+     * Gets all the things stored in the registry.
+     */
+    public Stream<Thing> getAllThings() {
+        return runtimeConfig.getAllThingsV1().map(this::dtoToThing);
+    }
+
+    /**
+     * Deletes a thing from the repository.
+     *
+     * @param thing thing to remove
+     */
+    public void deleteThing(Thing thing) {
+        runtimeConfig.removeThingV1(thing.getThingName());
     }
 
     private Thing dtoToThing(ThingV1DTO dto) {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/usecases/CreateIoTThingSession.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/usecases/CreateIoTThingSession.java
@@ -28,6 +28,7 @@ public class CreateIoTThingSession
     private final UseCases useCases;
 
 
+
     /**
      * Verify a certificate with IoT Core.
      *
@@ -76,5 +77,4 @@ public class CreateIoTThingSession
 
         throw new AuthenticationException("Failed to verify certificate with attached to thing");
     }
-
 }

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/certificate/BackgroundCertificateRefreshTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/certificate/BackgroundCertificateRefreshTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.certificate;
+
+import com.aws.greengrass.clientdevices.auth.api.DomainEvents;
+import com.aws.greengrass.clientdevices.auth.api.UseCases;
+import com.aws.greengrass.clientdevices.auth.certificate.infra.BackgroundCertificateRefresh;
+import com.aws.greengrass.clientdevices.auth.certificate.infra.ClientCertificateStore;
+import com.aws.greengrass.clientdevices.auth.configuration.RuntimeConfiguration;
+import com.aws.greengrass.clientdevices.auth.helpers.CertificateTestHelpers;
+import com.aws.greengrass.clientdevices.auth.infra.NetworkState;
+import com.aws.greengrass.clientdevices.auth.iot.Certificate;
+import com.aws.greengrass.clientdevices.auth.iot.CertificateRegistry;
+import com.aws.greengrass.clientdevices.auth.iot.InvalidCertificateException;
+import com.aws.greengrass.clientdevices.auth.iot.IotAuthClientFake;
+import com.aws.greengrass.clientdevices.auth.iot.Thing;
+import com.aws.greengrass.clientdevices.auth.iot.infra.ThingRegistry;
+import com.aws.greengrass.clientdevices.auth.iot.usecases.VerifyIotCertificate;
+import com.aws.greengrass.clientdevices.auth.iot.usecases.VerifyThingAttachedToCertificate;
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.dependency.Context;
+import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.util.GreengrassServiceClientFactory;
+
+import org.bouncycastle.cert.CertIOException;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.greengrassv2data.GreengrassV2DataClient;
+
+import java.io.IOException;
+import java.security.KeyPair;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+import static com.aws.greengrass.clientdevices.auth.helpers.CertificateTestHelpers.createClientCertificate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+public class BackgroundCertificateRefreshTest {
+    @Mock
+    private GreengrassServiceClientFactory clientFactory;
+    @Mock
+    private GreengrassV2DataClient client;
+    @Mock
+    private NetworkState networkStateMock;
+    @Mock
+    private ScheduledThreadPoolExecutor schedulerMock;
+    @Mock
+    private VerifyThingAttachedToCertificate verifyThingAttachedToCertificateMock;
+    @Mock
+    private VerifyIotCertificate verifyIotCertificateMock;
+    private IotAuthClientFake iotAuthClientFake;
+    private CertificateRegistry certificateRegistry;
+    private Topics configurationTopics;
+    private ThingRegistry thingRegistry;
+    private ClientCertificateStore pemStore;
+    private BackgroundCertificateRefresh backgroundRefresh;
+
+
+    @BeforeEach
+    void setup() throws DeviceConfigurationException, KeyStoreException {
+        iotAuthClientFake = new IotAuthClientFake();
+        lenient().when(clientFactory.fetchGreengrassV2DataClient()).thenReturn(client);
+
+        DomainEvents domainEvents =  new DomainEvents();
+        configurationTopics = Topics.of(new Context(), "config", null);
+        RuntimeConfiguration runtimeConfiguration = RuntimeConfiguration.from(configurationTopics);
+        pemStore = new ClientCertificateStore();
+        certificateRegistry = new CertificateRegistry(runtimeConfiguration, pemStore);
+        thingRegistry = new ThingRegistry(domainEvents, runtimeConfiguration);
+
+        UseCases useCases = new UseCases();
+        configurationTopics.getContext().put(VerifyThingAttachedToCertificate.class, verifyThingAttachedToCertificateMock);
+        configurationTopics.getContext().put(VerifyIotCertificate.class, verifyIotCertificateMock);
+        useCases.init(configurationTopics.getContext());
+
+        backgroundRefresh = new BackgroundCertificateRefresh(
+                schedulerMock, thingRegistry, networkStateMock, 
+                certificateRegistry, pemStore, iotAuthClientFake, useCases);
+    }
+
+    @AfterEach
+    void cleanup() throws IOException {
+        configurationTopics.getContext().close();
+    }
+
+    private List<X509Certificate> generateClientCerts(int numberOfCerts) throws NoSuchAlgorithmException,
+            CertificateException, OperatorCreationException, CertIOException {
+        KeyPair rootKeyPair = CertificateStore.newRSAKeyPair(2048);
+        X509Certificate rootCA = CertificateTestHelpers.createRootCertificateAuthority("root", rootKeyPair);
+        ArrayList<X509Certificate> clientCerts = new ArrayList<>();
+
+        for (int i = 0; i < numberOfCerts; i++) {
+            KeyPair clientAKeyPair = CertificateStore.newRSAKeyPair(2048);
+            clientCerts.add(createClientCertificate(
+                    rootCA, "AWS IoT Certificate", clientAKeyPair.getPublic(), rootKeyPair.getPrivate()));
+        }
+
+        return clientCerts;
+    }
+
+    @Test
+    void GIVEN_certsAndThings_WHEN_orphanedCertificate_THEN_itGetsRemoved() throws
+            NoSuchAlgorithmException, CertificateException, OperatorCreationException, IOException,
+            InvalidCertificateException {
+        // Given
+        Thing thingOne = Thing.of("ThingOne");
+        Thing thingTwo = Thing.of("ThingTwo");
+        List<X509Certificate> clientCerts = generateClientCerts(2);
+
+        String certificateAPem = CertificateHelper.toPem(clientCerts.get(0));
+        Certificate certA = Certificate.fromPem(certificateAPem);
+        certificateRegistry.getOrCreateCertificate(certificateAPem);
+        String certificateBPem = CertificateHelper.toPem(clientCerts.get(1));
+        Certificate certB = Certificate.fromPem(certificateBPem);
+        certificateRegistry.getOrCreateCertificate(certificateBPem);
+
+        thingRegistry.createThing(thingOne.getThingName());
+        thingRegistry.createThing(thingTwo.getThingName());
+
+        // Attach the certificate to only one thing so that certificateBPem is orphaned
+        thingOne.attachCertificate(certA.getCertificateId());
+        thingRegistry.updateThing(thingOne);
+
+        iotAuthClientFake.attachThingToCore(thingOne.getThingName());
+
+        // When
+        backgroundRefresh.run();
+
+        // Then
+        assertNotNull(thingRegistry.getThing(thingOne.getThingName()));
+        assertNull(thingRegistry.getThing(thingTwo.getThingName()));
+        assertTrue(certificateRegistry.getCertificateFromPem(certificateAPem).isPresent());
+        assertEquals(pemStore.getPem(certA.getCertificateId()).get(), certificateAPem);
+        assertFalse(certificateRegistry.getCertificateFromPem(certificateBPem).isPresent());
+        assertFalse(pemStore.getPem(certB.getCertificateId()).isPresent());
+    }
+
+    @Test
+    void GIVEN_certsAndThings_WHEN_certificateAssociatedToMoreThanOneThing_THEN_itDoesNotGetRemoved() throws
+            NoSuchAlgorithmException, CertificateException, OperatorCreationException, IOException,
+            InvalidCertificateException {
+        // Given
+        Thing thingOne = Thing.of("ThingOne");
+        Thing thingTwo = Thing.of("ThingTwo");
+        List<X509Certificate> clientCerts = generateClientCerts(1);
+
+        String certificateAPem = CertificateHelper.toPem(clientCerts.get(0));
+        Certificate certA = Certificate.fromPem(certificateAPem);
+        certificateRegistry.getOrCreateCertificate(certificateAPem);
+
+        thingRegistry.createThing(thingOne.getThingName());
+        thingRegistry.createThing(thingTwo.getThingName());
+
+        // Attach the certificate to only one thing so that certificateBPem is orphaned
+        thingOne.attachCertificate(certA.getCertificateId());
+        thingRegistry.updateThing(thingOne);
+        thingTwo.attachCertificate(certA.getCertificateId());
+        thingRegistry.updateThing(thingTwo);
+
+        iotAuthClientFake.attachThingToCore(thingOne.getThingName());
+
+        // When
+        backgroundRefresh.run();
+
+        // Then
+        assertNotNull(thingRegistry.getThing(thingOne.getThingName()));
+        assertNull(thingRegistry.getThing(thingTwo.getThingName()));
+        assertTrue(certificateRegistry.getCertificateFromPem(certificateAPem).isPresent());
+        assertEquals(pemStore.getPem(certA.getCertificateId()).get(), certificateAPem);
+    }
+
+}

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClientFake.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClientFake.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * IoT Auth Client Fake allows test writers to set up valid and invalid certificates,
@@ -19,6 +20,7 @@ public class IotAuthClientFake implements IotAuthClient {
     private final Map<String, Set<String>> thingToCerts = new HashMap<>();
     private final Set<String> activeCertIds = new HashSet<>();
     private final Set<String> inactiveCertIds = new HashSet<>();
+    private final Set<String> thingsAttachedToCore = new HashSet<>();
 
     public void activateCert(String certPem) throws InvalidCertificateException {
         Certificate cert = Certificate.fromPem(certPem);
@@ -50,6 +52,14 @@ public class IotAuthClientFake implements IotAuthClient {
         if (thingToCerts.containsKey(thing)) {
             thingToCerts.get(thing).remove(certId);
         }
+    }
+
+    public void attachThingToCore(String thingName) {
+       thingsAttachedToCore.add(thingName);
+    }
+
+    public void detachThingFromCore(String thingName) {
+       thingsAttachedToCore.remove(thingName);
     }
 
     @Override
@@ -92,5 +102,10 @@ public class IotAuthClientFake implements IotAuthClient {
             return thingToCerts.get(thing.getThingName()).contains(certificate.getCertificateId());
         }
         return false;
+    }
+
+    @Override
+    public Stream<Thing> getThingsAssociatedWithCoreDevice() {
+        return thingsAttachedToCore.stream().map(Thing::of);
     }
 }


### PR DESCRIPTION
**Description of changes:**
This makes it so that the background refresh runs when the network connectivity is resumed

**Why is this change necessary:**
Improves when we refresh the certificate cache so we opportunistically update the values in it.
