### PR TITLE
feat: refresh certificates when network comes back up

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -114,6 +114,7 @@ public class ClientDevicesAuthService extends PluginService {
         context.put(RuntimeConfiguration.class, RuntimeConfiguration.from(getRuntimeConfig()));
         NetworkState networkState = context.get(NetworkState.class);
         networkState.registerHandler(context.get(CISShadowMonitor.class));
+        networkState.registerHandler(context.get(BackgroundCertificateRefresh.class));
         context.get(BackgroundCertificateRefresh.class).start();
 
         // Initialize IPC thread pool

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/infra/BackgroundCertificateRefresh.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/infra/BackgroundCertificateRefresh.java
@@ -146,7 +146,7 @@ public class BackgroundCertificateRefresh implements Runnable, Consumer<NetworkS
 
         Optional<ThingAssociations> associations = getThingsAssociatedWithCoreDevice();
         associations.ifPresent(a -> {
-            refresh(a);
+            this.refresh(a);
             lastRan.set(Instant.now());
         });
         this.scheduleNextRun();
@@ -157,7 +157,7 @@ public class BackgroundCertificateRefresh implements Runnable, Consumer<NetworkS
 
         Instant now = Instant.now();
         nextScheduledRun.set(now.plus(Duration.ofSeconds(DEFAULT_INTERVAL_SECONDS)));
-        Duration duration = Duration.between(nextScheduledRun.get(), now);
+        Duration duration = Duration.between(now, nextScheduledRun.get());
 
         scheduledFuture = scheduler.schedule(this, duration.getSeconds(), TimeUnit.SECONDS);
     }
@@ -219,8 +219,7 @@ public class BackgroundCertificateRefresh implements Runnable, Consumer<NetworkS
         associations.getThings().forEach(this::refreshCertificateThingAttachment);
         associations.getStaleThings().forEach(thingRegistry::deleteThing);
 
-        certificateRegistry.getAllCertificates()
-                .forEach(certificate -> {
+        certificateRegistry.getAllCertificates().forEach(certificate -> {
             if (associations.isAttachedToThing(certificate)) {
                 refreshCertificateValidity(certificate);
             } else {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClient.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClient.java
@@ -171,9 +171,6 @@ public interface IotAuthClient {
                         .map(AssociatedClientDevice::thingName)
                         .map(Thing::of);
             } catch (Exception e) {
-                logger.atError().cause(e).kv("thing", thingName).log(
-                        "Failed to list client devices associated to the core. Check that the core device's IoT"
-                                + "policy grants the greengrass:ListClientDevicesAssociatedWithCoreDevice permission");
                 throw new CloudServiceInteractionException(
                         String.format("Failed to list things attached to core %s", thingName), e);
             }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClient.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClient.java
@@ -153,7 +153,6 @@ public interface IotAuthClient {
         }
 
         @Override
-        @SuppressWarnings("PMD.AvoidCatchingGenericException")
         public Stream<Thing> getThingsAssociatedWithCoreDevice() {
             DeviceConfiguration configuration = clientFactory.getDeviceConfiguration();
             String thingName = Coerce.toString(configuration.getThingName());
@@ -170,9 +169,6 @@ public interface IotAuthClient {
                 return response.associatedClientDevices().stream()
                         .map(AssociatedClientDevice::thingName)
                         .map(Thing::of);
-            } catch (Exception e) {
-                throw new CloudServiceInteractionException(
-                        String.format("Failed to list things attached to core %s", thingName), e);
             }
         }
 

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/certificate/BackgroundCertificateRefreshTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/certificate/BackgroundCertificateRefreshTest.java
@@ -33,6 +33,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.ScopedMock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.greengrassv2data.GreengrassV2DataClient;
 
@@ -42,8 +44,12 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import static com.aws.greengrass.clientdevices.auth.helpers.CertificateTestHelpers.createClientCertificate;
@@ -54,9 +60,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 public class BackgroundCertificateRefreshTest {
@@ -78,11 +86,12 @@ public class BackgroundCertificateRefreshTest {
     private ThingRegistry thingRegistry;
     private ClientCertificateStore pemStore;
     private BackgroundCertificateRefresh backgroundRefresh;
+    private Optional<MockedStatic<Clock>> clockMock;
 
 
     @BeforeEach
     void setup() throws DeviceConfigurationException, KeyStoreException {
-        iotAuthClientFake = new IotAuthClientFake();
+        iotAuthClientFake = spy(new IotAuthClientFake());
         lenient().when(clientFactory.fetchGreengrassV2DataClient()).thenReturn(client);
 
         DomainEvents domainEvents =  new DomainEvents();
@@ -97,6 +106,8 @@ public class BackgroundCertificateRefreshTest {
         configurationTopics.getContext().put(VerifyIotCertificate.class, verifyIotCertificateMock);
         useCases.init(configurationTopics.getContext());
 
+        this.clockMock = Optional.empty();
+
         backgroundRefresh = spy(new BackgroundCertificateRefresh(
                 schedulerMock, thingRegistry, networkStateMock, 
                 certificateRegistry, pemStore, iotAuthClientFake, useCases));
@@ -104,7 +115,19 @@ public class BackgroundCertificateRefreshTest {
 
     @AfterEach
     void cleanup() throws IOException {
+        this.clockMock.ifPresent(ScopedMock::close);
         configurationTopics.getContext().close();
+    }
+
+    @SuppressWarnings("PMD.CloseResource")
+    private void mockInstant(long expected) {
+        this.clockMock.ifPresent(ScopedMock::close);
+        Clock spyClock = spy(Clock.class);
+        MockedStatic<Clock> clockMock;
+        clockMock = mockStatic(Clock.class);
+        clockMock.when(Clock::systemUTC).thenReturn(spyClock);
+        when(spyClock.instant()).thenReturn(Instant.ofEpochMilli(expected));
+        this.clockMock = Optional.of(clockMock);
     }
 
     private List<X509Certificate> generateClientCerts(int numberOfCerts) throws NoSuchAlgorithmException,
@@ -193,14 +216,30 @@ public class BackgroundCertificateRefreshTest {
     }
 
     @Test
-    void GIVEN_networkWasDown_WHEN_networkUp_THEN_backgroundTaskTriggered() throws Exception {
+    void GIVEN_networkWasDown_WHEN_networkUp_THEN_backgroundTaskTriggered() {
         backgroundRefresh.accept(NetworkState.ConnectionState.NETWORK_DOWN);
         verify(backgroundRefresh, times(0)).run();
         backgroundRefresh.accept(NetworkState.ConnectionState.NETWORK_UP);
         verify(backgroundRefresh, times(1)).run();
         backgroundRefresh.accept(NetworkState.ConnectionState.NETWORK_DOWN);
         verify(backgroundRefresh, times(1)).run();
-        backgroundRefresh.accept(NetworkState.ConnectionState.NETWORK_UP);
-        verify(backgroundRefresh, times(2)).run();
+    }
+
+    @Test
+    void GIVEN_networkChangesAndScheduledByTime_WHEN_triggered_THEN_shouldNotRunMoreThanOnceADay() {
+        Instant now = Instant.now();
+        mockInstant(now.toEpochMilli());
+
+        verify(iotAuthClientFake, times(0)).getThingsAssociatedWithCoreDevice();
+        backgroundRefresh.run();
+        backgroundRefresh.run();
+        backgroundRefresh.run();
+        verify(iotAuthClientFake, times(1)).getThingsAssociatedWithCoreDevice();
+
+        Instant twentyFiveHoursLater = Instant.now().plus(Duration.ofHours(25));
+        mockInstant(twentyFiveHoursLater.toEpochMilli());
+
+        backgroundRefresh.run();
+        verify(iotAuthClientFake, times(2)).getThingsAssociatedWithCoreDevice();
     }
 }


### PR DESCRIPTION
**Description of changes:**
This makes it so that the background refresh runs when the network connectivity is resumed

**Why is this change necessary:**
Improves when we refresh the certificate cache so we opportunistically update the values in it.