### PR TITLE
fix: dispatch network change events asynchronously

### DIFF
--- a/src/test/java/com/aws/greengrass/clientdevices/auth/infra/NetworkStateTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/infra/NetworkStateTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.infra;
+
+import com.aws.greengrass.mqttclient.CallbackEventManager;
+import com.aws.greengrass.mqttclient.MqttClient;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.crt.mqtt.MqttClientConnectionEvents;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+
+
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+public class NetworkStateTest {
+    @Mock
+    MqttClient mqttClient;
+    @Captor
+    ArgumentCaptor<CallbackEventManager.OnConnectCallback> onConnectCaptor;
+    @Captor
+    ArgumentCaptor<MqttClientConnectionEvents> connectionEventsArgumentCaptor;
+    private ForkJoinPool fjp = new ForkJoinPool();
+    private NetworkState networkState;
+
+    @BeforeEach
+    void beforeEach() {
+        fjp = new ForkJoinPool();
+        networkState = new NetworkState(mqttClient, fjp);
+        verify(mqttClient).addToCallbackEvents(onConnectCaptor.capture(), connectionEventsArgumentCaptor.capture());
+    }
+
+    @AfterEach
+    void afterEach() {
+        fjp.shutdown();
+    }
+
+    void assertNetworkDomainEventOnNetworkEvent(Runnable networkEvent, NetworkState.ConnectionState expectedState)
+            throws InterruptedException {
+        CountDownLatch cdl = new CountDownLatch(1);
+        AtomicLong callbackThreadId = new AtomicLong();
+        AtomicReference<NetworkState.ConnectionState> connState = new AtomicReference<>();
+        long curThreadId = Thread.currentThread().getId();
+
+        Consumer<NetworkState.ConnectionState> networkStateConsumer = (state) -> {
+            connState.set(state);
+            callbackThreadId.set(Thread.currentThread().getId());
+            cdl.countDown();
+        };
+        networkState.registerHandler(networkStateConsumer);
+
+        networkEvent.run();
+
+        // Assert that NETWORK_UP event was emitted, and that it was emitted in a separate thread.
+        // We're checking this because network change events are triggered in a CRT thread, which
+        // we should not ever block
+        assertTrue(cdl.await(1, TimeUnit.SECONDS));
+        assertThat(callbackThreadId.get(), is(not(curThreadId)));
+        assertThat(connState.get(), is(expectedState));
+    }
+
+    @Test
+    void GIVEN_networkStateChange_WHEN_onConnectCallback_THEN_networkUpEventEmitted() throws InterruptedException {
+        assertNetworkDomainEventOnNetworkEvent(() -> onConnectCaptor.getValue().onConnect(true),
+                NetworkState.ConnectionState.NETWORK_UP);
+    }
+
+    @Test
+    void GIVEN_networkStateChange_WHEN_connectionResumedCallback_THEN_networkUpEventEmitted()
+            throws InterruptedException {
+        assertNetworkDomainEventOnNetworkEvent(
+                () -> connectionEventsArgumentCaptor.getValue().onConnectionResumed(true),
+                NetworkState.ConnectionState.NETWORK_UP);
+    }
+
+    @Test
+    void GIVEN_networkStateChange_WHEN_connectionInterruptedCallback_THEN_networkDownEventEmitted()
+            throws InterruptedException {
+        assertNetworkDomainEventOnNetworkEvent(
+                () -> connectionEventsArgumentCaptor.getValue().onConnectionInterrupted(0),
+                NetworkState.ConnectionState.NETWORK_DOWN);
+    }
+}

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/infra/NetworkStateTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/infra/NetworkStateTest.java
@@ -61,7 +61,7 @@ public class NetworkStateTest {
 
     @ParameterizedTest
     @MethodSource("provideNetworkEventsAndExpectedState")
-    void assertNetworkDomainEventOnNetworkEvent(
+    void GIVEN_subscriptionToNetworkChanges_WHEN_connectionStateChanges_THEN_networkEventTriggeredOnSeparateThread(
             Callable<NetworkState.ConnectionState> triggerNetworkChangeAndGetExpectedConnectionState) throws Exception {
         // GIVEN
         CountDownLatch cdl = new CountDownLatch(1);

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/infra/NetworkStateTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/infra/NetworkStateTest.java
@@ -88,20 +88,22 @@ public class NetworkStateTest {
         assertThat(connState.get(), is(expectedState));
     }
 
+    // Called by JUnit
+    @SuppressWarnings("PMD.UnusedPrivateMethod")
     private static Stream<Arguments> provideNetworkEventsAndExpectedState() {
         return Stream.of(
-                Arguments.arguments((Callable< NetworkState.ConnectionState>)() -> {
-                    onConnectCaptor.getValue().onConnect(true);
-                    return NetworkState.ConnectionState.NETWORK_UP;
-                }),
-                Arguments.arguments((Callable< NetworkState.ConnectionState>)() -> {
-                    connectionEventsArgumentCaptor.getValue().onConnectionResumed(true);
-                    return NetworkState.ConnectionState.NETWORK_UP;
-                }),
-                Arguments.arguments((Callable< NetworkState.ConnectionState>)() -> {
-                    connectionEventsArgumentCaptor.getValue().onConnectionInterrupted(0);
-                    return NetworkState.ConnectionState.NETWORK_DOWN;
-                })
+            Arguments.arguments((Callable<NetworkState.ConnectionState>)() -> {
+                onConnectCaptor.getValue().onConnect(true);
+                return NetworkState.ConnectionState.NETWORK_UP;
+            }),
+            Arguments.arguments((Callable<NetworkState.ConnectionState>)() -> {
+                connectionEventsArgumentCaptor.getValue().onConnectionResumed(true);
+                return NetworkState.ConnectionState.NETWORK_UP;
+            }),
+            Arguments.arguments((Callable<NetworkState.ConnectionState>)() -> {
+                connectionEventsArgumentCaptor.getValue().onConnectionInterrupted(0);
+                return NetworkState.ConnectionState.NETWORK_DOWN;
+            })
         );
     }
 }


### PR DESCRIPTION
Network state change events are running in a CRT thread, which means it is not safe to do any meaningful work since we'll be blocking the CRT. This change emits network state change events on an executor service so that callees can safely do whatever work is needed.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
