### PR TITLE
feat: support pagination on refreshing things and certificates

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Thing.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Thing.java
@@ -40,11 +40,6 @@ public final class Thing implements AttributeProvider, Cloneable {
     // map of certificate ID to the time this certificate was known to be attached to the Thing
     private final Map<String, Instant> attachedCertificateIds;
     private boolean modified = false;
-    private final Source source;
-
-    public enum Source {
-        LOCAL, CLOUD, UNSET;
-    }
 
     /**
      * Create a new Thing.
@@ -53,7 +48,7 @@ public final class Thing implements AttributeProvider, Cloneable {
      * @throws IllegalArgumentException If the given ThingName contains illegal characters
      */
     public static Thing of(String thingName) {
-        return Thing.of(thingName, null, Source.UNSET);
+        return Thing.of(thingName, null);
     }
 
     /**
@@ -64,38 +59,15 @@ public final class Thing implements AttributeProvider, Cloneable {
      * @throws IllegalArgumentException If the given ThingName contains illegal characters
      */
     public static Thing of(String thingName, Map<String, Instant> certificateIds) {
-        return new Thing(thingName, certificateIds, Source.UNSET);
-    }
-
-    /**
-     * Create a new Thing.
-     *
-     * @param thingName      AWS IoT ThingName
-     * @param source        Source of creation
-     * @throws IllegalArgumentException If the given ThingName contains illegal characters
-     */
-    public static Thing of(String thingName, Source source) {
-        return new Thing(thingName, null, source);
-    }
-
-    /**
-     * Create a new Thing.
-     *
-     * @param thingName      AWS IoT ThingName
-     * @param certificateIds Attached certificate IDs
-     * @param source        Source of creation
-     * @throws IllegalArgumentException If the given ThingName contains illegal characters
-     */
-    public static Thing of(String thingName, Map<String, Instant> certificateIds, Source source) {
         if (!Pattern.matches(thingNamePattern, thingName)) {
             throw new IllegalArgumentException("Invalid thing name. The thing name must match \"[a-zA-Z0-9\\-_:]+\".");
         }
-        return new Thing(thingName, certificateIds, source);
+        return new Thing(thingName, certificateIds);
     }
 
     @Override
     public Thing clone() {
-        Thing newThing = Thing.of(getThingName(), getAttachedCertificateIds(), getSource());
+        Thing newThing = Thing.of(getThingName(), getAttachedCertificateIds());
         newThing.modified = modified;
         return newThing;
     }
@@ -156,9 +128,8 @@ public final class Thing implements AttributeProvider, Cloneable {
         return lastVerified != null && isCertAttachmentTrusted(lastVerified);
     }
 
-    private Thing(String thingName, Map<String, Instant> certificateIds, Source source) {
+    private Thing(String thingName, Map<String, Instant> certificateIds) {
         this.thingName = thingName;
-        this.source = source;
         if (certificateIds == null) {
             this.attachedCertificateIds = new ConcurrentHashMap<>();
         } else {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/dto/VerifyThingAttachedToCertificateDTO.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/dto/VerifyThingAttachedToCertificateDTO.java
@@ -5,8 +5,6 @@
 
 package com.aws.greengrass.clientdevices.auth.iot.dto;
 
-import com.aws.greengrass.clientdevices.auth.iot.Certificate;
-import com.aws.greengrass.clientdevices.auth.iot.Thing;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 
@@ -14,7 +12,7 @@ import lombok.Value;
 @Value
 @AllArgsConstructor
 public class VerifyThingAttachedToCertificateDTO {
-    Thing thing;
-    Certificate certificate;
+    String thingName;
+    String certificateId;
 }
 

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/infra/ThingRegistry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/infra/ThingRegistry.java
@@ -91,7 +91,7 @@ public class ThingRegistry {
             return thing;
         }
 
-        Thing newThing = Thing.of(thing.getThingName(), thing.getAttachedCertificateIds(), Thing.Source.LOCAL);
+        Thing newThing = Thing.of(thing.getThingName(), thing.getAttachedCertificateIds());
         return storeThing(newThing);
     }
 
@@ -128,7 +128,7 @@ public class ThingRegistry {
                         Map.Entry::getKey,
                         entry -> Instant.ofEpochMilli(entry.getValue())
                 ));
-        return Thing.of(dto.getThingName(), certIds, Thing.Source.LOCAL);
+        return Thing.of(dto.getThingName(), certIds);
     }
 
     private ThingV1DTO thingToDto(Thing thing) {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/infra/ThingRegistry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/infra/ThingRegistry.java
@@ -91,7 +91,7 @@ public class ThingRegistry {
             return thing;
         }
 
-        Thing newThing = Thing.of(thing.getThingName(), thing.getAttachedCertificateIds());
+        Thing newThing = Thing.of(thing.getThingName(), thing.getAttachedCertificateIds(), Thing.Source.LOCAL);
         return storeThing(newThing);
     }
 
@@ -128,7 +128,7 @@ public class ThingRegistry {
                         Map.Entry::getKey,
                         entry -> Instant.ofEpochMilli(entry.getValue())
                 ));
-        return Thing.of(dto.getThingName(), certIds);
+        return Thing.of(dto.getThingName(), certIds, Thing.Source.LOCAL);
     }
 
     private ThingV1DTO thingToDto(Thing thing) {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/usecases/CreateIoTThingSession.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/usecases/CreateIoTThingSession.java
@@ -66,7 +66,7 @@ public class CreateIoTThingSession
 
             VerifyThingAttachedToCertificate verify = useCases.get(VerifyThingAttachedToCertificate.class);
             Boolean thingAttachedResult = verify.apply(
-                    new VerifyThingAttachedToCertificateDTO(thing, certificate.get()));
+                    new VerifyThingAttachedToCertificateDTO(thingName, certificate.get().getCertificateId()));
 
             if (thingAttachedResult) {
                 return new SessionImpl(certificate.get(), thing);

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClientFake.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClientFake.java
@@ -18,6 +18,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -101,8 +102,16 @@ public class IotAuthClientFake implements IotAuthClient {
 
     @Override
     public boolean isThingAttachedToCertificate(Thing thing, Certificate certificate) {
+        if (Objects.isNull(certificate)) {
+            return false;
+        }
+        return isThingAttachedToCertificate(thing, certificate.getCertificateId());
+    }
+
+    @Override
+    public boolean isThingAttachedToCertificate(Thing thing, String certificateId) {
         if (thingToCerts.containsKey(thing.getThingName())) {
-            return thingToCerts.get(thing.getThingName()).contains(certificate.getCertificateId());
+            return thingToCerts.get(thing.getThingName()).contains(certificateId);
         }
         return false;
     }

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClientFake.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClientFake.java
@@ -106,6 +106,6 @@ public class IotAuthClientFake implements IotAuthClient {
 
     @Override
     public Stream<Thing> getThingsAssociatedWithCoreDevice() {
-        return thingsAttachedToCore.stream().map(Thing::of);
+        return thingsAttachedToCore.stream().map(thing -> Thing.of(thing, Thing.Source.CLOUD));
     }
 }

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactoryTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactoryTest.java
@@ -89,8 +89,9 @@ public class MqttSessionFactoryTest {
         when(mockNetworkState.getConnectionStateFromMqtt()).thenReturn(NetworkState.ConnectionState.NETWORK_UP);
         when(mockCertificateRegistry.getCertificateFromPem(any()))
                 .thenReturn(Optional.of(CertificateFake.activeCertificate()));
+        when(mockThingRegistry.getThing(any())).thenReturn(Thing.of("clientId"));
         when(mockThingRegistry.getOrCreateThing(any())).thenReturn(Thing.of("clientId"));
-        when(iotAuthClientMock.isThingAttachedToCertificate(any(), any())).thenReturn(false);
+        when(iotAuthClientMock.isThingAttachedToCertificate(any(), (String) any())).thenReturn(false);
 
         Assertions.assertThrows(AuthenticationException.class,
                 () -> mqttSessionFactory.createSession(credentialMap));
@@ -110,8 +111,9 @@ public class MqttSessionFactoryTest {
         when(mockNetworkState.getConnectionStateFromMqtt()).thenReturn(NetworkState.ConnectionState.NETWORK_UP);
         when(mockCertificateRegistry.getCertificateFromPem(any()))
                 .thenReturn(Optional.of(CertificateFake.activeCertificate()));
+        when(mockThingRegistry.getThing(any())).thenReturn(Thing.of("clientId"));
         when(mockThingRegistry.getOrCreateThing(any())).thenReturn(Thing.of("clientId"));
-        when(iotAuthClientMock.isThingAttachedToCertificate(any(), any()))
+        when(iotAuthClientMock.isThingAttachedToCertificate(any(), (String) any()))
                 .thenThrow(CloudServiceInteractionException.class);
         Assertions.assertThrows(AuthenticationException.class,
                 () -> mqttSessionFactory.createSession(credentialMap));
@@ -122,9 +124,10 @@ public class MqttSessionFactoryTest {
             throws AuthenticationException, InvalidCertificateException {
         when(mockNetworkState.getConnectionStateFromMqtt()).thenReturn(NetworkState.ConnectionState.NETWORK_UP);
         when(mockThingRegistry.getOrCreateThing("clientId")).thenReturn(Thing.of("clientId"));
+        when(mockThingRegistry.getThing(any())).thenReturn(Thing.of("clientId"));
         when(mockCertificateRegistry.getCertificateFromPem(any()))
                 .thenReturn(Optional.of(CertificateFake.activeCertificate()));
-        when(iotAuthClientMock.isThingAttachedToCertificate(any(), any())).thenReturn(true);
+        when(iotAuthClientMock.isThingAttachedToCertificate((Thing) any(), (String) any())).thenReturn(true);
 
         Session session = mqttSessionFactory.createSession(credentialMap);
         assertThat(session, is(IsNull.notNullValue()));


### PR DESCRIPTION
**Description of changes:**
This changes the call we make to get the things attached to the core device to use the paginator provided by the aws sdk. It provides a stream that will call all the pages and allow us to process the received response in chunks. I reworked the refresh logic so that we could take advantage of the fact that the response pages can be streamed so we can process one page at a time.

There are still some additional improvements that could be made to improve performance now that we have this streams such as parallel processing of things and certificate updates as well as the cleanup (which can be done on a separate thread).

**Why is this change necessary:**
For clients with cores with more than 100 clients this is required. Otherwise we only ever refresh the first 100d