### PR TITLE
fix: fix disabled flaky tests

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/certificateauthority/CustomCaConfigurationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/certificateauthority/CustomCaConfigurationTest.java
@@ -16,7 +16,6 @@ import com.aws.greengrass.clientdevices.auth.certificate.CertificateHelper;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateStore;
 import com.aws.greengrass.clientdevices.auth.configuration.GroupManager;
 import com.aws.greengrass.clientdevices.auth.connectivity.CISShadowMonitor;
-import com.aws.greengrass.clientdevices.auth.exception.CertificateChainLoadingException;
 import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationException;
 import com.aws.greengrass.clientdevices.auth.helpers.CertificateTestHelpers;
 import com.aws.greengrass.clientdevices.auth.helpers.TestHelpers;
@@ -29,8 +28,6 @@ import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
 import com.aws.greengrass.mqttclient.spool.SpoolerStoreException;
 import com.aws.greengrass.security.SecurityService;
-import com.aws.greengrass.security.exceptions.KeyLoadingException;
-import com.aws.greengrass.security.exceptions.ServiceUnavailableException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import com.aws.greengrass.util.Pair;
@@ -49,9 +46,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.greengrassv2data.GreengrassV2DataClient;
 import software.amazon.awssdk.services.greengrassv2data.model.PutCertificateAuthoritiesRequest;
 
-import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
@@ -60,7 +55,6 @@ import java.security.cert.X509Certificate;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -194,10 +188,7 @@ public class CustomCaConfigurationTest {
 
     @Test
     void Given_CustomCAConfiguration_WHEN_issuingAClientCertificate_THEN_itsSignedByCustomCA() throws
-            CertificateException, URISyntaxException, CertificateGenerationException, ExecutionException,
-            InterruptedException, ServiceLoadException, NoSuchAlgorithmException,
-            OperatorCreationException, IOException, KeyLoadingException, ServiceUnavailableException,
-            CertificateChainLoadingException {
+            Exception {
         Pair<X509Certificate[], KeyPair[]> credentials = givenRootAndIntermediateCA();
         X509Certificate[] chain = credentials.getLeft();
         X509Certificate intermediateCA = chain[0];
@@ -229,10 +220,7 @@ public class CustomCaConfigurationTest {
 
     @Test
     void GIVEN_CustomCAConfiguration_WHEN_whenGeneratingClientCerts_THEN_GGComponentIsVerified() throws
-            NoSuchAlgorithmException, CertificateException, OperatorCreationException, IOException,
-            URISyntaxException, KeyLoadingException, ServiceUnavailableException,
-            CertificateChainLoadingException, CertificateGenerationException, InterruptedException,
-            ServiceLoadException {
+            Exception {
         Pair<X509Certificate[], KeyPair[]> credentials = givenRootAndIntermediateCA();
         X509Certificate[] chain = credentials.getLeft();
         KeyPair[] certificateKeys = credentials.getRight();
@@ -276,9 +264,7 @@ public class CustomCaConfigurationTest {
 
     @Test
     void GIVEN_customCAConfigurationWithACAChain_WHEN_registeringCAWithIotCore_THEN_highestTrustCAUploaded() throws
-            CertificateChainLoadingException, KeyLoadingException, CertificateException, NoSuchAlgorithmException,
-            URISyntaxException, ServiceUnavailableException, OperatorCreationException, IOException,
-            ServiceLoadException, InterruptedException {
+            Exception {
         // Given
         Pair<X509Certificate[], KeyPair[]> credentials = givenRootAndIntermediateCA();
         X509Certificate[] chain = credentials.getLeft();
@@ -309,9 +295,7 @@ public class CustomCaConfigurationTest {
 
     @Test
     void GIVEN_managedCAConfiguration_WHEN_updatedToCustomCAConfiguration_THEN_serverCertificatesAreRotated() throws
-            InterruptedException, CertificateGenerationException, CertificateException, NoSuchAlgorithmException,
-            OperatorCreationException, IOException, URISyntaxException, KeyLoadingException,
-            ServiceUnavailableException, CertificateChainLoadingException, ServiceLoadException {
+           Exception {
         Pair<X509Certificate[], KeyPair[]> credentials = givenRootAndIntermediateCA();
         X509Certificate[] chain = credentials.getLeft();
         KeyPair[] certificateKeys = credentials.getRight();

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/certificateauthority/CustomCaConfigurationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/certificateauthority/CustomCaConfigurationTest.java
@@ -19,6 +19,7 @@ import com.aws.greengrass.clientdevices.auth.connectivity.CISShadowMonitor;
 import com.aws.greengrass.clientdevices.auth.exception.CertificateChainLoadingException;
 import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationException;
 import com.aws.greengrass.clientdevices.auth.helpers.CertificateTestHelpers;
+import com.aws.greengrass.clientdevices.auth.helpers.TestHelpers;
 import com.aws.greengrass.clientdevices.auth.iot.IotAuthClient;
 import com.aws.greengrass.clientdevices.auth.iot.IotAuthClientFake;
 import com.aws.greengrass.config.Topics;
@@ -31,7 +32,6 @@ import com.aws.greengrass.security.SecurityService;
 import com.aws.greengrass.security.exceptions.KeyLoadingException;
 import com.aws.greengrass.security.exceptions.ServiceUnavailableException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
-import com.aws.greengrass.testcommons.testutilities.TestUtils;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import com.aws.greengrass.util.Pair;
 import org.apache.commons.lang3.ArrayUtils;
@@ -39,7 +39,6 @@ import org.bouncycastle.cert.CertIOException;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -60,11 +59,9 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
@@ -75,7 +72,6 @@ import static com.aws.greengrass.componentmanager.KernelConfigResolver.CONFIGURA
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
@@ -196,11 +192,10 @@ public class CustomCaConfigurationTest {
         api.subscribeToCertificateUpdates(request);
     }
 
-    @Disabled("TODO - fix flaky test")
     @Test
     void Given_CustomCAConfiguration_WHEN_issuingAClientCertificate_THEN_itsSignedByCustomCA() throws
             CertificateException, URISyntaxException, CertificateGenerationException, ExecutionException,
-            InterruptedException, TimeoutException, ServiceLoadException, NoSuchAlgorithmException,
+            InterruptedException, ServiceLoadException, NoSuchAlgorithmException,
             OperatorCreationException, IOException, KeyLoadingException, ServiceUnavailableException,
             CertificateChainLoadingException {
         Pair<X509Certificate[], KeyPair[]> credentials = givenRootAndIntermediateCA();
@@ -215,31 +210,29 @@ public class CustomCaConfigurationTest {
         doReturn(chain).when(certificateStoreSpy).loadCaCertificateChain(privateKeyUri, certificateUri);
 
         AtomicReference<CertificateUpdateEvent> eventRef = new AtomicReference<>();
-        Pair<CompletableFuture<Void>, Consumer<CertificateUpdateEvent>> asyncCall =
-                TestUtils.asyncAssertOnConsumer(eventRef::set, 2);
         GetCertificateRequest request = buildCertificateUpdateRequest(
-                GetCertificateRequestOptions.CertificateType.CLIENT, asyncCall.getRight());
+                GetCertificateRequestOptions.CertificateType.CLIENT, eventRef::set);
 
         givenNucleusRunningWithConfig("config.yaml");
         subscribeToCertificateUpdates(request);
         givenCDAWithCustomCertificateAuthority(privateKeyUri, certificateUri);
 
-        asyncCall.getLeft().get(5, TimeUnit.SECONDS);
-        X509Certificate issuedClientCertificate = eventRef.get().getCertificate();
-        assertTrue(
-            CertificateTestHelpers.wasCertificateIssuedBy(intermediateCA, issuedClientCertificate),
-            String.format(
-                "Certificate not was not issued by intermediate CA %s", CertificateHelper.toPem(issuedClientCertificate)
-        ));
+        TestHelpers.eventuallyTrue(() -> {
+            try {
+                X509Certificate issuedClientCertificate = eventRef.get().getCertificate();
+                return CertificateTestHelpers.wasCertificateIssuedBy(intermediateCA, issuedClientCertificate);
+            } catch (CertificateException e) {
+                return  false;
+            }
+        });
     }
 
-    @Disabled("TODO - fix flaky test")
     @Test
     void GIVEN_CustomCAConfiguration_WHEN_whenGeneratingClientCerts_THEN_GGComponentIsVerified() throws
             NoSuchAlgorithmException, CertificateException, OperatorCreationException, IOException,
             URISyntaxException, KeyLoadingException, ServiceUnavailableException,
-            CertificateChainLoadingException, CertificateGenerationException, ExecutionException, InterruptedException,
-            TimeoutException, ServiceLoadException {
+            CertificateChainLoadingException, CertificateGenerationException, InterruptedException,
+            ServiceLoadException {
         Pair<X509Certificate[], KeyPair[]> credentials = givenRootAndIntermediateCA();
         X509Certificate[] chain = credentials.getLeft();
         KeyPair[] certificateKeys = credentials.getRight();
@@ -251,16 +244,23 @@ public class CustomCaConfigurationTest {
         doReturn(chain).when(certificateStoreSpy).loadCaCertificateChain(privateKeyUri, certificateUri);
 
         AtomicReference<CertificateUpdateEvent> eventRef = new AtomicReference<>();
-        Pair<CompletableFuture<Void>, Consumer<CertificateUpdateEvent>> asyncCall =
-                TestUtils.asyncAssertOnConsumer(eventRef::set, 2);
         GetCertificateRequest request = buildCertificateUpdateRequest(
-                GetCertificateRequestOptions.CertificateType.CLIENT, asyncCall.getRight());
+                GetCertificateRequestOptions.CertificateType.CLIENT, eventRef::set);
 
         givenNucleusRunningWithConfig("config.yaml");
         subscribeToCertificateUpdates(request);
         givenCDAWithCustomCertificateAuthority(privateKeyUri, certificateUri);
 
-        asyncCall.getLeft().get(5, TimeUnit.SECONDS);
+        TestHelpers.eventuallyTrue(() -> {
+            try {
+                X509Certificate intermediateCA =  chain[0];
+                X509Certificate issuedClientCertificate = eventRef.get().getCertificate();
+                return CertificateTestHelpers.wasCertificateIssuedBy(intermediateCA, issuedClientCertificate);
+            } catch (CertificateException e) {
+                return  false;
+            }
+        });
+
         CertificateUpdateEvent event = eventRef.get();
         X509Certificate[] clientChain = ArrayUtils.addAll(
                 new X509Certificate[]{event.getCertificate()},
@@ -274,12 +274,12 @@ public class CustomCaConfigurationTest {
         );
     }
 
-    @Disabled("TODO - fix flaky test")
     @Test
     void GIVEN_customCAConfigurationWithACAChain_WHEN_registeringCAWithIotCore_THEN_highestTrustCAUploaded() throws
             CertificateChainLoadingException, KeyLoadingException, CertificateException, NoSuchAlgorithmException,
             URISyntaxException, ServiceUnavailableException, OperatorCreationException, IOException,
             ServiceLoadException, InterruptedException {
+        // Given
         Pair<X509Certificate[], KeyPair[]> credentials = givenRootAndIntermediateCA();
         X509Certificate[] chain = credentials.getLeft();
         KeyPair[] certificateKeys = credentials.getRight();
@@ -290,6 +290,7 @@ public class CustomCaConfigurationTest {
         when(securityServiceMock.getKeyPair(privateKeyUri, certificateUri)).thenReturn(intermediateKeyPair);
         doReturn(chain).when(certificateStoreSpy).loadCaCertificateChain(privateKeyUri, certificateUri);
 
+        // When
         givenNucleusRunningWithConfig("config.yaml");
         givenCDAWithCustomCertificateAuthority(privateKeyUri, certificateUri);
 
@@ -297,21 +298,22 @@ public class CustomCaConfigurationTest {
                 ArgumentCaptor.forClass(PutCertificateAuthoritiesRequest.class);
         verify(client, atLeastOnce()).putCertificateAuthorities(requestCaptor.capture());
 
-        List<String> expectedPem = Collections.singletonList(CertificateHelper.toPem(chain[chain.length - 1]));
-        PutCertificateAuthoritiesRequest lastRequest = requestCaptor.getValue();
-        assertEquals(lastRequest.coreDeviceCertificates(), expectedPem);
+        // Then
+        X509Certificate rootCa = chain[chain.length - 1];
+        List<String> expectedPem = Collections.singletonList(CertificateHelper.toPem(rootCa));
+        TestHelpers.eventuallyTrue(() -> {
+            PutCertificateAuthoritiesRequest lastRequest = requestCaptor.getValue();
+            return lastRequest.coreDeviceCertificates().equals(expectedPem);
+        });
     }
 
-    @Disabled("TODO - fix flaky test")
     @Test
     void GIVEN_managedCAConfiguration_WHEN_updatedToCustomCAConfiguration_THEN_serverCertificatesAreRotated() throws
             InterruptedException, CertificateGenerationException, CertificateException, NoSuchAlgorithmException,
             OperatorCreationException, IOException, URISyntaxException, KeyLoadingException,
-            ServiceUnavailableException, CertificateChainLoadingException, ServiceLoadException, ExecutionException,
-            TimeoutException {
+            ServiceUnavailableException, CertificateChainLoadingException, ServiceLoadException {
         Pair<X509Certificate[], KeyPair[]> credentials = givenRootAndIntermediateCA();
         X509Certificate[] chain = credentials.getLeft();
-        X509Certificate intermediateCA =  chain[0];
         KeyPair[] certificateKeys = credentials.getRight();
         KeyPair intermediateKeyPair = certificateKeys[0];
 
@@ -321,22 +323,21 @@ public class CustomCaConfigurationTest {
         doReturn(chain).when(certificateStoreSpy).loadCaCertificateChain(privateKeyUri, certificateUri);
 
         AtomicReference<CertificateUpdateEvent> eventRef = new AtomicReference<>();
-        Pair<CompletableFuture<Void>, Consumer<CertificateUpdateEvent>> asyncCall =
-                TestUtils.asyncAssertOnConsumer(eventRef::set, 2);
         GetCertificateRequest request = buildCertificateUpdateRequest(
-                GetCertificateRequestOptions.CertificateType.SERVER, asyncCall.getRight());
+                GetCertificateRequestOptions.CertificateType.SERVER, eventRef::set);
 
         givenNucleusRunningWithConfig("config.yaml");
         subscribeToCertificateUpdates(request);
         givenCDAWithCustomCertificateAuthority(privateKeyUri, certificateUri);
 
-        // Called 2 times. 1 for initial managed CA and then after the config is changes to use custom CA
-        asyncCall.getLeft().get(5, TimeUnit.SECONDS);
-        CertificateUpdateEvent event = eventRef.get();
-        X509Certificate issuedClientCertificate = event.getCertificate();
-        assertTrue(
-            CertificateTestHelpers.wasCertificateIssuedBy(intermediateCA, issuedClientCertificate), String.format(
-                "Certificate not was not issued by intermediate CA %s", CertificateHelper.toPem(issuedClientCertificate)
-        ));
+        TestHelpers.eventuallyTrue(() -> {
+            try {
+                X509Certificate intermediateCA =  chain[0];
+                X509Certificate issuedClientCertificate = eventRef.get().getCertificate();
+                return CertificateTestHelpers.wasCertificateIssuedBy(intermediateCA, issuedClientCertificate);
+            } catch (CertificateException e) {
+                return  false;
+            }
+        });
     }
 }

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/helpers/TestHelpers.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/helpers/TestHelpers.java
@@ -5,6 +5,9 @@
 
 package com.aws.greengrass.clientdevices.auth.helpers;
 
+
+import java.time.Duration;
+import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -15,18 +18,25 @@ public final class TestHelpers {
     public static final long DEFAULT_GENERIC_POLLING_TIMEOUT_MILLIS =
             TimeUnit.SECONDS.toMillis(10);
 
+    public static final long DEFAULT_POLLING_INTERVAL_MILLIS = 500;
+
     private TestHelpers() {
     }
 
-    public static boolean eventuallyTrue(Supplier<Boolean> condition, long... optional) throws InterruptedException {
-        long timeoutInMillis = optional.length >= 1 ? optional[0] : DEFAULT_GENERIC_POLLING_TIMEOUT_MILLIS;
-        long pollingIntervalInMillis = optional.length >= 2 ? optional[1] : 500;
-        final long startTime = System.currentTimeMillis();
-        while ((System.currentTimeMillis() - startTime) < timeoutInMillis) {
+    public static boolean eventuallyTrue(Supplier<Boolean> condition) throws InterruptedException {
+        return eventuallyTrue(condition, DEFAULT_GENERIC_POLLING_TIMEOUT_MILLIS, DEFAULT_POLLING_INTERVAL_MILLIS);
+    }
+
+    public static boolean eventuallyTrue(Supplier<Boolean> condition, long pollingTimeoutMillis,
+                                         long pollingIntervalMillis) throws InterruptedException {
+        final Instant tryUntil = Instant.now().plus(Duration.ofMillis(pollingTimeoutMillis));
+
+        while (Instant.now().isBefore(tryUntil)) {
             if (condition.get()) {
                 return true;
             }
-            Thread.sleep(pollingIntervalInMillis);
+
+            Thread.sleep(pollingIntervalMillis);
         }
         return false;
     }

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/helpers/TestHelpers.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/helpers/TestHelpers.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.helpers;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+/**
+ * Helpers for generic assertion tooling
+ */
+public final class TestHelpers {
+    public static final long DEFAULT_GENERIC_POLLING_TIMEOUT_MILLIS =
+            TimeUnit.SECONDS.toMillis(10);
+
+    private TestHelpers() {
+    }
+
+    public static boolean eventuallyTrue(Supplier<Boolean> condition, long... optional) throws InterruptedException {
+        long timeoutInMillis = optional.length >= 1 ? optional[0] : DEFAULT_GENERIC_POLLING_TIMEOUT_MILLIS;
+        long pollingIntervalInMillis = optional.length >= 2 ? optional[1] : 500;
+        final long startTime = System.currentTimeMillis();
+        while ((System.currentTimeMillis() - startTime) < timeoutInMillis) {
+            if (condition.get()) {
+                return true;
+            }
+            Thread.sleep(pollingIntervalInMillis);
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
**Description of changes:**
Some tests had been disabled because they were flaky due to the fact that they where just waiting for a call count to be met and not for the actual configuration changes to have take effect. This PR fixes that by introducing a test utility (which we have in other code bases) to wait for an expectation to be eventually true.

**Why is this change necessary:**
Re enable the flaky tests