### PR TITLE
fix: return local result when cloud call fails

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/usecases/VerifyThingAttachedToCertificate.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/usecases/VerifyThingAttachedToCertificate.java
@@ -89,7 +89,7 @@ public class VerifyThingAttachedToCertificate
 
             return verifyLocally(thing, dto.getCertificateId());
         } catch (CloudServiceInteractionException e) {
-            return false;
+            return verifyLocally(thing, dto.getCertificateId());
         }
     }
 }

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/usecases/VerifyThingAttachedToCertificateTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/usecases/VerifyThingAttachedToCertificateTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.iot.usecases;
+
+import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
+import com.aws.greengrass.clientdevices.auth.infra.NetworkState;
+import com.aws.greengrass.clientdevices.auth.iot.IotAuthClient;
+import com.aws.greengrass.clientdevices.auth.iot.Thing;
+import com.aws.greengrass.clientdevices.auth.iot.dto.VerifyThingAttachedToCertificateDTO;
+import com.aws.greengrass.clientdevices.auth.iot.infra.ThingRegistry;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({MockitoExtension.class, GGExtension.class})
+class VerifyThingAttachedToCertificateTest {
+    @Mock
+    private IotAuthClient mockIotAuthClient;
+    @Mock
+    private NetworkState mockNetworkState;
+    @Mock
+    private ThingRegistry mockThingRegistry;
+    private VerifyThingAttachedToCertificate verifyThingAttachedToCertificate;
+
+    @BeforeEach
+    void beforeEach() {
+        verifyThingAttachedToCertificate = new VerifyThingAttachedToCertificate(mockIotAuthClient,
+                mockThingRegistry, mockNetworkState);
+    }
+
+    @Test
+    void GIVEN_validDtoAndNetworkUp_WHEN_verifyThingAttachedToCertificate_THEN_returnCloudResult() {
+        Boolean expectedCloudResult = true;
+        Thing mockThing = Thing.of("mock-thing");
+        String mockCertId = "cert-id";
+        VerifyThingAttachedToCertificateDTO dto =
+                new VerifyThingAttachedToCertificateDTO(mockThing.getThingName(), mockCertId);
+
+        when(mockNetworkState.getConnectionStateFromMqtt()).thenReturn(NetworkState.ConnectionState.NETWORK_UP);
+        when(mockIotAuthClient.isThingAttachedToCertificate(any(), anyString())).thenReturn(expectedCloudResult);
+        when(mockThingRegistry.getThing(mockThing.getThingName())).thenReturn(mockThing);
+
+        assertThat(verifyThingAttachedToCertificate.apply(dto), is(expectedCloudResult));
+        verify(mockIotAuthClient, times(1)).isThingAttachedToCertificate(mockThing, mockCertId);
+    }
+
+    @Test
+    void GIVEN_validDtoAndNetworkDown_WHEN_verifyThingAttachedToCertificate_THEN_returnLocalResult() {
+        Thing mockThing = Thing.of("mock-thing");
+        String mockCertId = "cert-id";
+        mockThing.attachCertificate(mockCertId);
+        VerifyThingAttachedToCertificateDTO dto =
+                new VerifyThingAttachedToCertificateDTO(mockThing.getThingName(), mockCertId);
+
+        when(mockNetworkState.getConnectionStateFromMqtt()).thenReturn(NetworkState.ConnectionState.NETWORK_DOWN);
+        when(mockThingRegistry.getThing(mockThing.getThingName())).thenReturn(mockThing);
+
+        assertThat(verifyThingAttachedToCertificate.apply(dto), is(true));
+        verify(mockIotAuthClient, times(0)).isThingAttachedToCertificate(any(), anyString());
+    }
+
+    @Test
+    void GIVEN_networkUpButFailedCloudCall_WHEN_verifyThingAttachedToCertificate_THEN_returnLocalResult() {
+        Thing mockThing = Thing.of("mock-thing");
+        String mockCertId = "cert-id";
+        mockThing.attachCertificate(mockCertId);
+        VerifyThingAttachedToCertificateDTO dto =
+                new VerifyThingAttachedToCertificateDTO(mockThing.getThingName(), mockCertId);
+
+        when(mockNetworkState.getConnectionStateFromMqtt()).thenReturn(NetworkState.ConnectionState.NETWORK_UP);
+        doThrow(CloudServiceInteractionException.class)
+                .when(mockIotAuthClient).isThingAttachedToCertificate(any(), anyString());
+        when(mockThingRegistry.getThing(mockThing.getThingName())).thenReturn(mockThing);
+
+        assertThat(verifyThingAttachedToCertificate.apply(dto), is(true));
+        verify(mockIotAuthClient, times(1)).isThingAttachedToCertificate(mockThing, mockCertId);
+    }
+}

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/usecases/VerifyThingAttachedToCertificateTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/usecases/VerifyThingAttachedToCertificateTest.java
@@ -5,9 +5,14 @@
 
 package com.aws.greengrass.clientdevices.auth.iot.usecases;
 
+import com.aws.greengrass.clientdevices.auth.certificate.CertificateHelper;
+import com.aws.greengrass.clientdevices.auth.certificate.CertificateStore;
 import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
+import com.aws.greengrass.clientdevices.auth.helpers.CertificateTestHelpers;
 import com.aws.greengrass.clientdevices.auth.infra.NetworkState;
+import com.aws.greengrass.clientdevices.auth.iot.Certificate;
 import com.aws.greengrass.clientdevices.auth.iot.IotAuthClient;
+import com.aws.greengrass.clientdevices.auth.iot.IotAuthClientFake;
 import com.aws.greengrass.clientdevices.auth.iot.Thing;
 import com.aws.greengrass.clientdevices.auth.iot.dto.VerifyThingAttachedToCertificateDTO;
 import com.aws.greengrass.clientdevices.auth.iot.infra.ThingRegistry;
@@ -16,78 +21,113 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+
+import static com.aws.greengrass.clientdevices.auth.helpers.CertificateTestHelpers.createClientCertificate;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 class VerifyThingAttachedToCertificateTest {
     @Mock
-    private IotAuthClient mockIotAuthClient;
-    @Mock
     private NetworkState mockNetworkState;
     @Mock
     private ThingRegistry mockThingRegistry;
+    private IotAuthClientFake iotAuthClientFake;
     private VerifyThingAttachedToCertificate verifyThingAttachedToCertificate;
 
     @BeforeEach
     void beforeEach() {
-        verifyThingAttachedToCertificate = new VerifyThingAttachedToCertificate(mockIotAuthClient,
+        iotAuthClientFake = new IotAuthClientFake();
+        verifyThingAttachedToCertificate = new VerifyThingAttachedToCertificate(iotAuthClientFake,
                 mockThingRegistry, mockNetworkState);
     }
 
     @Test
-    void GIVEN_validDtoAndNetworkUp_WHEN_verifyThingAttachedToCertificate_THEN_returnCloudResult() {
-        Boolean expectedCloudResult = true;
-        Thing mockThing = Thing.of("mock-thing");
-        String mockCertId = "cert-id";
+    void GIVEN_validDtoAndNetworkUp_WHEN_verifyThingAttachedToCertificate_THEN_returnCloudResult() throws Exception {
+        Thing thing = Thing.of("thing-1");
+        X509Certificate certificate = createTestClientCertificate();
+        String certPem = CertificateHelper.toPem(certificate);
+        Certificate thingCertificate = Certificate.fromPem(certPem);
+        iotAuthClientFake.attachCertificateToThing(thing.getThingName(), certPem);
         VerifyThingAttachedToCertificateDTO dto =
-                new VerifyThingAttachedToCertificateDTO(mockThing.getThingName(), mockCertId);
+                new VerifyThingAttachedToCertificateDTO(thing.getThingName(), thingCertificate.getCertificateId());
 
         when(mockNetworkState.getConnectionStateFromMqtt()).thenReturn(NetworkState.ConnectionState.NETWORK_UP);
-        when(mockIotAuthClient.isThingAttachedToCertificate(any(), anyString())).thenReturn(expectedCloudResult);
-        when(mockThingRegistry.getThing(mockThing.getThingName())).thenReturn(mockThing);
+        when(mockThingRegistry.getThing(thing.getThingName())).thenReturn(thing);
 
-        assertThat(verifyThingAttachedToCertificate.apply(dto), is(expectedCloudResult));
-        verify(mockIotAuthClient, times(1)).isThingAttachedToCertificate(mockThing, mockCertId);
+        // positive result
+        assertThat(verifyThingAttachedToCertificate.apply(dto), is(true));
+
+        // negative result
+        iotAuthClientFake.detachCertificateFromThing(thing.getThingName(), certPem);
+        assertThat(verifyThingAttachedToCertificate.apply(dto), is(false));
+
     }
 
     @Test
-    void GIVEN_validDtoAndNetworkDown_WHEN_verifyThingAttachedToCertificate_THEN_returnLocalResult() {
-        Thing mockThing = Thing.of("mock-thing");
-        String mockCertId = "cert-id";
-        mockThing.attachCertificate(mockCertId);
+    void GIVEN_validDtoAndNetworkDown_WHEN_verifyThingAttachedToCertificate_THEN_returnLocalResult() throws Exception {
+        Thing thing = Thing.of("thing-1");
+        X509Certificate certificate = createTestClientCertificate();
+        String certPem = CertificateHelper.toPem(certificate);
+        Certificate thingCertificate = Certificate.fromPem(certPem);
+        thing.attachCertificate(thingCertificate.getCertificateId());
         VerifyThingAttachedToCertificateDTO dto =
-                new VerifyThingAttachedToCertificateDTO(mockThing.getThingName(), mockCertId);
+                new VerifyThingAttachedToCertificateDTO(thing.getThingName(), thingCertificate.getCertificateId());
 
         when(mockNetworkState.getConnectionStateFromMqtt()).thenReturn(NetworkState.ConnectionState.NETWORK_DOWN);
-        when(mockThingRegistry.getThing(mockThing.getThingName())).thenReturn(mockThing);
+        when(mockThingRegistry.getThing(thing.getThingName())).thenReturn(thing);
 
+        // positive result
         assertThat(verifyThingAttachedToCertificate.apply(dto), is(true));
-        verify(mockIotAuthClient, times(0)).isThingAttachedToCertificate(any(), anyString());
+
+        // negative result
+        thing.detachCertificate(thingCertificate.getCertificateId());
+        assertThat(verifyThingAttachedToCertificate.apply(dto), is(false));
     }
 
     @Test
-    void GIVEN_networkUpButFailedCloudCall_WHEN_verifyThingAttachedToCertificate_THEN_returnLocalResult() {
-        Thing mockThing = Thing.of("mock-thing");
-        String mockCertId = "cert-id";
-        mockThing.attachCertificate(mockCertId);
+    void GIVEN_networkUpButFailedCloudCall_WHEN_verifyThingAttachedToCertificate_THEN_returnLocalResult() throws Exception {
+        Thing thing = Thing.of("thing-1");
+        X509Certificate certificate = createTestClientCertificate();
+        String certPem = CertificateHelper.toPem(certificate);
+        Certificate thingCertificate = Certificate.fromPem(certPem);
+        thing.attachCertificate(thingCertificate.getCertificateId());
         VerifyThingAttachedToCertificateDTO dto =
-                new VerifyThingAttachedToCertificateDTO(mockThing.getThingName(), mockCertId);
+                new VerifyThingAttachedToCertificateDTO(thing.getThingName(), thingCertificate.getCertificateId());
 
-        when(mockNetworkState.getConnectionStateFromMqtt()).thenReturn(NetworkState.ConnectionState.NETWORK_UP);
+        // set up VerifyThingAttachedToCertificate usecase with mock iot auth client
+        // to be able to throw exceptions during cloud calls
+        IotAuthClient mockIotAuthClient = Mockito.mock(IotAuthClient.class);
         doThrow(CloudServiceInteractionException.class)
                 .when(mockIotAuthClient).isThingAttachedToCertificate(any(), anyString());
-        when(mockThingRegistry.getThing(mockThing.getThingName())).thenReturn(mockThing);
+        VerifyThingAttachedToCertificate verifyThingAttachedToCertificate =
+                new VerifyThingAttachedToCertificate(mockIotAuthClient, mockThingRegistry, mockNetworkState);
 
+        when(mockNetworkState.getConnectionStateFromMqtt()).thenReturn(NetworkState.ConnectionState.NETWORK_UP);
+        when(mockThingRegistry.getThing(thing.getThingName())).thenReturn(thing);
+
+        // positive result
         assertThat(verifyThingAttachedToCertificate.apply(dto), is(true));
-        verify(mockIotAuthClient, times(1)).isThingAttachedToCertificate(mockThing, mockCertId);
+
+        // negative result
+        thing.detachCertificate(thingCertificate.getCertificateId());
+        assertThat(verifyThingAttachedToCertificate.apply(dto), is(false));
+    }
+
+    private X509Certificate createTestClientCertificate() throws Exception {
+        KeyPair rootKeyPair = CertificateStore.newRSAKeyPair(2048);
+        X509Certificate rootCA = CertificateTestHelpers.createRootCertificateAuthority("root", rootKeyPair);
+        KeyPair clientKeyPair = CertificateStore.newRSAKeyPair(2048);
+        return createClientCertificate(
+                rootCA, "AWS IoT Certificate", clientKeyPair.getPublic(), rootKeyPair.getPrivate());
     }
 }


### PR DESCRIPTION
**Issue #, if available:** Network state heuristic is not 100% reliable. In case of false positive Network-UP case, `VerifyThingAttachedToCertificate` usecase does not consider local results when cloud requests fails.

**Description of changes:** Returns local result if `VerifyThingAttachedToCertificate` cloud request fails.

**How was this change tested:** unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
