### PR TITLE
test: certificate rotation on ca config change for ipc subscribers

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/certificateauthority/CustomCATest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/certificateauthority/CustomCATest.java
@@ -281,8 +281,8 @@ public class CustomCATest {
 
                 @Override
                 public boolean onStreamError(Throwable error) {
-                                                            return false;
-                                                                         }
+                    return false;
+                }
 
                 @Override
                 public void onStreamClosed() {
@@ -502,10 +502,5 @@ public class CustomCATest {
                 }
             });
         }
-
-
-
-
-
     }
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/certificateauthority/CustomCATest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/certificateauthority/CustomCATest.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.integrationtests.certificateauthority;
 
 import com.aws.greengrass.clientdevices.auth.ClientDevicesAuthService;
 import com.aws.greengrass.clientdevices.auth.api.CertificateUpdateEvent;
+
 import com.aws.greengrass.clientdevices.auth.api.ClientDevicesAuthServiceApi;
 import com.aws.greengrass.clientdevices.auth.api.GetCertificateRequest;
 import com.aws.greengrass.clientdevices.auth.api.GetCertificateRequestOptions;
@@ -23,6 +24,7 @@ import com.aws.greengrass.clientdevices.auth.iot.IotAuthClientFake;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
+import com.aws.greengrass.integrationtests.ipc.IPCTestUtils;
 import com.aws.greengrass.lifecyclemanager.Kernel;
 import com.aws.greengrass.lifecyclemanager.exceptions.ServiceLoadException;
 import com.aws.greengrass.mqttclient.spool.SpoolerStoreException;
@@ -41,11 +43,19 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCClient;
+import software.amazon.awssdk.aws.greengrass.model.CertificateOptions;
+import software.amazon.awssdk.aws.greengrass.model.CertificateType;
+import software.amazon.awssdk.aws.greengrass.model.CertificateUpdate;
+import software.amazon.awssdk.aws.greengrass.model.SubscribeToCertificateUpdatesRequest;
+import software.amazon.awssdk.eventstreamrpc.EventStreamRPCConnection;
+import software.amazon.awssdk.eventstreamrpc.StreamResponseHandler;
 import software.amazon.awssdk.services.greengrassv2data.GreengrassV2DataClient;
 import software.amazon.awssdk.services.greengrassv2data.model.PutCertificateAuthoritiesRequest;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.security.KeyPair;
 import java.security.KeyStoreException;
@@ -59,6 +69,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -231,7 +242,7 @@ public class CustomCATest {
         });
     }
 
-    private Map<String, URI> givenCAStoredOnFilesystem(PrivateKey pk, X509Certificate... chain) throws IOException,
+    private Map<String, URI> storeCAOnFileSystem(PrivateKey pk, X509Certificate... chain) throws IOException,
             CertificateEncodingException {
         Path pkPath = rootDir.resolve("private.key").toAbsolutePath();
         CertificateTestHelpers.writeToPath(
@@ -253,11 +264,37 @@ public class CustomCATest {
         }};
     }
 
+    private void ipcSubscribeToCertificateAuthorityUpdates(
+            EventStreamRPCConnection connection, Consumer<CertificateUpdate> consumer) throws Exception {
+
+        GreengrassCoreIPCClient ipcClient = new GreengrassCoreIPCClient(connection);
+        SubscribeToCertificateUpdatesRequest request = new SubscribeToCertificateUpdatesRequest();
+        request.setCertificateOptions(new CertificateOptions().withCertificateType(CertificateType.SERVER));
+
+        ipcClient.subscribeToCertificateUpdates(request,
+            Optional.of(new StreamResponseHandler<software.amazon.awssdk.aws.greengrass.model.CertificateUpdateEvent>() {
+                @Override
+                public void onStreamEvent(
+                        software.amazon.awssdk.aws.greengrass.model.CertificateUpdateEvent certificateUpdateEvent) {
+                    consumer.accept(certificateUpdateEvent.getCertificateUpdate());
+                }
+
+                @Override
+                public boolean onStreamError(Throwable error) {
+                                                            return false;
+                                                                         }
+
+                @Override
+                public void onStreamClosed() {
+                }
+        })).getResponse().get(10, TimeUnit.SECONDS);
+    }
+
     @Test
     void Given_customCAConfigurationWithCaChain_WHEN_issuingAClientCertificate_THEN_itsSignedByIntermediateCa() throws
            Exception {
         Pair<X509Certificate[], PrivateKey> credentials = givenRootAndIntermediateCA();
-        Map<String, URI> uris = givenCAStoredOnFilesystem(credentials.getRight(), credentials.getLeft());
+        Map<String, URI> uris = storeCAOnFileSystem(credentials.getRight(), credentials.getLeft());
 
         AtomicReference<CertificateUpdateEvent> eventRef = new AtomicReference<>();
         GetCertificateRequest request = buildCertificateUpdateRequest(
@@ -269,6 +306,10 @@ public class CustomCATest {
 
         TestHelpers.eventuallyTrue(() -> {
             try {
+                if (eventRef.get() == null) {
+                    return false;
+                }
+
                 X509Certificate issuedClientCertificate = eventRef.get().getCertificate();
                 X509Certificate intermediateCA = credentials.getLeft()[0];
                 return CertificateTestHelpers.wasCertificateIssuedBy(intermediateCA, issuedClientCertificate);
@@ -283,7 +324,7 @@ public class CustomCATest {
         Exception {
         Pair<X509Certificate, PrivateKey> credentials = givenRootCA();
         X509Certificate rootCA = credentials.getLeft();
-        Map<String, URI> uris = givenCAStoredOnFilesystem(credentials.getRight(), rootCA);
+        Map<String, URI> uris = storeCAOnFileSystem(credentials.getRight(), rootCA);
 
         AtomicReference<CertificateUpdateEvent> eventRef = new AtomicReference<>();
         GetCertificateRequest request = buildCertificateUpdateRequest(
@@ -295,6 +336,10 @@ public class CustomCATest {
 
         TestHelpers.eventuallyTrue(() -> {
             try {
+                if (eventRef.get() == null) {
+                    return false;
+                }
+
                 X509Certificate issuedClientCertificate = eventRef.get().getCertificate();
                 return CertificateTestHelpers.wasCertificateIssuedBy(rootCA, issuedClientCertificate);
             } catch (CertificateException e) {
@@ -307,7 +352,7 @@ public class CustomCATest {
     void GIVEN_CustomCAConfiguration_WHEN_whenGeneratingClientCerts_THEN_GGComponentIsVerified() throws
             Exception {
         Pair<X509Certificate[], PrivateKey> credentials = givenRootAndIntermediateCA();
-        Map<String, URI> uris = givenCAStoredOnFilesystem(credentials.getRight(), credentials.getLeft());
+        Map<String, URI> uris = storeCAOnFileSystem(credentials.getRight(), credentials.getLeft());
 
         AtomicReference<CertificateUpdateEvent> eventRef = new AtomicReference<>();
         GetCertificateRequest request = buildCertificateUpdateRequest(
@@ -320,6 +365,10 @@ public class CustomCATest {
 
         TestHelpers.eventuallyTrue(() -> {
             try {
+                if (eventRef.get() == null) {
+                    return false;
+                }
+
                 X509Certificate intermediateCA =  credentials.getLeft()[0];
                 X509Certificate issuedClientCertificate = eventRef.get().getCertificate();
                 return CertificateTestHelpers.wasCertificateIssuedBy(intermediateCA, issuedClientCertificate);
@@ -345,7 +394,7 @@ public class CustomCATest {
     void GIVEN_customCAConfigurationWithACAChain_WHEN_registeringCAWithIotCore_THEN_highestTrustCAUploaded() throws
         Exception {
         Pair<X509Certificate[], PrivateKey> credentials = givenRootAndIntermediateCA();
-        Map<String, URI> uris = givenCAStoredOnFilesystem( credentials.getRight(), credentials.getLeft());
+        Map<String, URI> uris = storeCAOnFileSystem( credentials.getRight(), credentials.getLeft());
 
         runNucleusWithConfig("config.yaml");
         configureCustomCertificateAuthorityConfiguration(uris.get("privateKey"), uris.get("certificateAuthority"));
@@ -367,7 +416,7 @@ public class CustomCATest {
     void GIVEN_managedCAConfiguration_WHEN_updatedToCustomCAConfiguration_THEN_serverCertificatesAreRotated() throws
             Exception{
         Pair<X509Certificate[], PrivateKey> credentials = givenRootAndIntermediateCA();
-        Map<String, URI> uris = givenCAStoredOnFilesystem(credentials.getRight(), credentials.getLeft());
+        Map<String, URI> uris = storeCAOnFileSystem(credentials.getRight(), credentials.getLeft());
 
         AtomicReference<CertificateUpdateEvent> eventRef = new AtomicReference<>();
         GetCertificateRequest request = buildCertificateUpdateRequest(
@@ -379,6 +428,10 @@ public class CustomCATest {
 
         TestHelpers.eventuallyTrue(() -> {
             try {
+                if (eventRef.get() == null) {
+                    return false;
+                }
+
                 X509Certificate intermediateCA =  credentials.getLeft()[0];
                 X509Certificate issuedClientCertificate = eventRef.get().getCertificate();
                 return CertificateTestHelpers.wasCertificateIssuedBy(intermediateCA, issuedClientCertificate);
@@ -392,7 +445,7 @@ public class CustomCATest {
     void GIVEN_customCAConfiguration_WHEN_updatedToManagedCAConfiguration_THEN_serverCertificatesAreRotated() throws
             Exception{
         Pair<X509Certificate, PrivateKey> credentials = givenRootCA();
-        Map<String, URI> uris = givenCAStoredOnFilesystem(credentials.getRight(), credentials.getLeft());
+        Map<String, URI> uris = storeCAOnFileSystem(credentials.getRight(), credentials.getLeft());
 
         // Given
         runNucleusWithConfig("config.yaml");
@@ -412,5 +465,47 @@ public class CustomCATest {
                 "CN=Greengrass Core CA,L=Seattle,ST=Washington,OU=Amazon Web Services,O=Amazon.com Inc.,C=US");
         assertEquals(managedCA.getIssuerX500Principal().getName(),
                 "CN=Greengrass Core CA,L=Seattle,ST=Washington,OU=Amazon Web Services,O=Amazon.com Inc.,C=US");
+    }
+
+    @Test
+    void GIVEN_ipcSubscriptionToCAChanges_WHEN_customCaConfigured_THEN_ipcSubscriberReceivesRotatedCert(
+            ExtensionContext context) throws Exception {
+        ignoreExceptionOfType(context, NoSuchFileException.class);
+        // Given
+        Pair<X509Certificate, PrivateKey> credentials = givenRootCA();
+        Map<String, URI> uris = storeCAOnFileSystem(credentials.getRight(), credentials.getLeft());
+
+        runNucleusWithConfig("cda.yaml");
+        AtomicReference<CertificateUpdate> eventRef = new AtomicReference<>();
+
+        try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
+                "BrokerSubscribingToCertUpdates")) {
+            ipcSubscribeToCertificateAuthorityUpdates(connection, eventRef::set);
+
+            // When
+            configureCustomCertificateAuthorityConfiguration(uris.get("privateKey"), uris.get("certificateAuthority"));
+            waitForCertificateAuthorityToBe(credentials.getLeft());
+
+            // Then
+            TestHelpers.eventuallyTrue(() -> {
+                try {
+                    if (eventRef.get() == null) {
+                        return false;
+                    }
+
+                    X509Certificate issuedClientCertificate = CertificateTestHelpers.loadX509Certificate(
+                            eventRef.get().getCertificate()).get(0);
+                    X509Certificate rootCA = credentials.getLeft();
+                    return CertificateTestHelpers.wasCertificateIssuedBy(rootCA, issuedClientCertificate);
+                } catch (CertificateException | IOException e) {
+                    return  false;
+                }
+            });
+        }
+
+
+
+
+
     }
 }

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/certificateauthority/OfflineAuthenticationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/certificateauthority/OfflineAuthenticationTest.java
@@ -149,7 +149,9 @@ public class OfflineAuthenticationTest {
     }
 
     @Test
-    void GIVEN_clientDevice_WHEN_verifyingItsIdentity_THEN_pemStored() throws Exception {
+    void GIVEN_clientDevice_WHEN_verifyingItsIdentity_THEN_pemStored(ExtensionContext context) throws Exception {
+        ignoreExceptionOfType(context, java.nio.file.NoSuchFileException.class);
+
         // Given
         KeyPair rootKeyPair = CertificateStore.newRSAKeyPair(2048);
         X509Certificate rootCA = CertificateTestHelpers.createRootCertificateAuthority("root", rootKeyPair);
@@ -176,7 +178,9 @@ public class OfflineAuthenticationTest {
     }
 
    @Test
-   void GIVEN_storedCertificates_WHEN_refreshEnabled_THEN_storedCertificatesRefreshed() throws Exception {
+   void GIVEN_storedCertificates_WHEN_refreshEnabled_THEN_storedCertificatesRefreshed(ExtensionContext context)
+           throws Exception {
+        ignoreExceptionOfType(context, java.nio.file.NoSuchFileException.class);
        // Given
 
        // Generate some credentials for the fake client devices

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/certificateauthority/cda.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/certificateauthority/cda.yaml
@@ -1,0 +1,129 @@
+---
+services:
+  aws.greengrass.Nucleus:
+    configuration:
+      runWithDefault:
+        posixUser: nobody
+        windowsUser: integ-tester
+      logging:
+        level: "DEBUG"
+  aws.greengrass.clientdevices.Auth:
+    configuration:
+      deviceGroups:
+        formatVersion: "2021-03-05"
+        definitions:
+          myTemperatureSensors:
+            selectionRule: "thingName:mySensor1 OR thingName:mySensor2"
+            policyName: "sensorAccessPolicy"
+          myHumiditySensors:
+            selectionRule: "thingName:mySensor3 OR thingName:mySensor4"
+            policyName: "sensorAccessPolicy"
+        policies:
+          sensorAccessPolicy:
+            policyStatement1:
+              statementDescription: "mqtt connect"
+              effect: ALLOW
+              operations:
+                - "mqtt:connect"
+              resources:
+                - "mqtt:clientId:foo"
+            policyStatement2:
+              statementDescription: "mqtt publish"
+              operations:
+                - "mqtt:publish"
+              resources:
+                - "mqtt:topic:temperature"
+                - "mqtt:topic:humidity"
+  main:
+    dependencies:
+      - BrokerSubscribingToCertUpdates
+      - Broker2SubscribingToCertUpdates
+      - BrokerWithGetClientDeviceAuthTokenPermission
+      - BrokerWithAuthorizeClientDeviceActionPermission
+  BrokerSubscribingToCertUpdates:
+    dependencies:
+      - aws.greengrass.clientdevices.Auth
+    lifecycle:
+      run:
+        windows:
+          powershell -command sleep 1
+        posix:
+          sleep 1
+    configuration:
+      accessControl:
+        aws.greengrass.clientdevices.Auth:
+          policyId1:
+            policyDescription: access to certificate updates
+            operations:
+              - '*'
+            resources:
+              - '*'
+        aws.greengrass.ipc.pubsub:
+          policyId2:
+            policyDescription: access to pubsub topics for ServiceName
+            operations:
+              - '*'
+            resources:
+              - '*'
+  Broker2SubscribingToCertUpdates:
+    dependencies:
+      - aws.greengrass.clientdevices.Auth
+    lifecycle:
+      run:
+        windows:
+          powershell -command sleep 1
+        posix:
+          sleep 1
+    configuration:
+      accessControl:
+        aws.greengrass.clientdevices.Auth:
+          policyId1:Broker2SubscribingToCertUpdates:
+            policyDescription: access to certificate updates
+            operations:
+              - '*'
+            resources:
+              - '*'
+        aws.greengrass.ipc.pubsub:
+          policyId2:Broker2SubscribingToCertUpdates:
+            policyDescription: access to pubsub topics for ServiceName
+            operations:
+              - '*'
+            resources:
+              - '*'
+
+  BrokerWithGetClientDeviceAuthTokenPermission:
+    dependencies:
+      - aws.greengrass.clientdevices.Auth
+    lifecycle:
+      run:
+        windows:
+          powershell -command sleep 1
+        posix:
+          sleep 1
+    configuration:
+      accessControl:
+        aws.greengrass.clientdevices.Auth:
+          GetClientDeviceAuthTokenPolicy:
+            policyDescription: access to certificate updates
+            operations:
+              - 'aws.greengrass#GetClientDeviceAuthToken'
+            resources:
+              - '*'
+  BrokerWithAuthorizeClientDeviceActionPermission:
+    dependencies:
+      - aws.greengrass.clientdevices.Auth
+    lifecycle:
+      run:
+        windows:
+          powershell -command sleep 1
+        posix:
+          sleep 1
+    configuration:
+      accessControl:
+        aws.greengrass.clientdevices.Auth:
+          BrokerWithAuthorizeClientDeviceActionPermission:
+            policyDescription: access to certificate updates
+            operations:
+              - 'aws.greengrass#AuthorizeClientDeviceAction'
+            resources:
+              - '*'

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/helpers/CertificateTestHelpers.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/helpers/CertificateTestHelpers.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.clientdevices.auth.helpers;
 import com.aws.greengrass.util.EncryptionUtils;
 import com.aws.greengrass.util.Pair;
 import com.aws.greengrass.util.Utils;
+import org.apache.commons.io.IOUtils;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.X500NameBuilder;
 import org.bouncycastle.asn1.x500.style.BCStyle;
@@ -31,6 +32,7 @@ import software.amazon.awssdk.utils.ImmutableMap;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -51,7 +53,9 @@ import java.security.cert.PKIXParameters;
 import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
@@ -220,6 +224,17 @@ public final class CertificateTestHelpers {
             return true;
         } catch (CertPathValidatorException | InvalidAlgorithmParameterException | NoSuchAlgorithmException  e) {
             return false;
+        }
+    }
+
+    public static List<X509Certificate> loadX509Certificate(String pem)
+            throws IOException, CertificateException {
+
+        try (InputStream targetStream = IOUtils.toInputStream(pem)) {
+            CertificateFactory factory = CertificateFactory.getInstance("X.509");
+
+            return new ArrayList<>(
+                    (Collection<? extends X509Certificate>) factory.generateCertificates(targetStream));
         }
     }
 

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/helpers/TestHelpers.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/helpers/TestHelpers.java
@@ -39,6 +39,6 @@ public final class TestHelpers {
             Thread.sleep(pollingIntervalMillis);
         }
 
-       throw new AssertionError("Condition was not eventually true");
+        throw new AssertionError("Condition was not eventually true");
     }
 }

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/helpers/TestHelpers.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/helpers/TestHelpers.java
@@ -38,6 +38,7 @@ public final class TestHelpers {
 
             Thread.sleep(pollingIntervalMillis);
         }
-        return false;
+
+       throw new AssertionError("Condition was not eventually true");
     }
 }


### PR DESCRIPTION
**Description of changes:**
Integration test to ensure ipc subscribers get a new cert when it gets rotated

