### PR TITLE
test: background refresh when pem corrupted

### DIFF
--- a/src/test/java/com/aws/greengrass/clientdevices/auth/helpers/CertificateTestHelpers.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/helpers/CertificateTestHelpers.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.clientdevices.auth.helpers;
 
+import com.aws.greengrass.clientdevices.auth.certificate.CertificateStore;
 import com.aws.greengrass.util.EncryptionUtils;
 import com.aws.greengrass.util.Pair;
 import com.aws.greengrass.util.Utils;
@@ -225,6 +226,22 @@ public final class CertificateTestHelpers {
         } catch (CertPathValidatorException | InvalidAlgorithmParameterException | NoSuchAlgorithmException  e) {
             return false;
         }
+    }
+
+    public static List<X509Certificate> createClientCertificates(int amount) throws Exception {
+        KeyPair rootKeyPair = CertificateStore.newRSAKeyPair(2048);
+        X509Certificate rootCA = CertificateTestHelpers.createRootCertificateAuthority("root", rootKeyPair);
+
+        List<X509Certificate> clientCertificates = new ArrayList<>();
+
+        for (int i = 0; i < amount; i++) {
+            KeyPair clientKeyPair = CertificateStore.newRSAKeyPair(2048);
+
+            clientCertificates.add(createClientCertificate(
+                    rootCA, "AWS IoT Certificate", clientKeyPair.getPublic(), rootKeyPair.getPrivate()));
+        }
+
+        return clientCertificates;
     }
 
     public static List<X509Certificate> loadX509Certificate(String pem)


### PR DESCRIPTION
**Description of changes:**
* Extract the background refresh tests into their own file on integration tests
* Extract the helper to client client certificates into the helpers
* Test to ensure that a corrupted PEM won't break the background refresh and only refresh the ones that are not corrupted
