### PR TITLE
fix: ensure we only refresh if the network was previously down

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/CertificateRegistry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/CertificateRegistry.java
@@ -13,6 +13,7 @@ import com.aws.greengrass.logging.impl.LogManager;
 import software.amazon.awssdk.utils.ImmutableMap;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
@@ -31,15 +32,19 @@ public class CertificateRegistry {
     private static final Logger logger = LogManager.getLogger(CertificateRegistry.class);
 
     private final ClientCertificateStore pemStore;
+    private final Clock clock;
 
     /**
      * Creates a certificate registry.
      *
      * @param runtimeConfiguration Runtime configuration
      * @param pemStore             An instance of ClientCertificateStore
+     * @param clock                A clock instance
      */
     @Inject
-    public CertificateRegistry(RuntimeConfiguration runtimeConfiguration, ClientCertificateStore pemStore) {
+    public CertificateRegistry(
+            RuntimeConfiguration runtimeConfiguration, ClientCertificateStore pemStore, Clock clock) {
+        this.clock = clock;
         this.runtimeConfiguration = runtimeConfiguration;
         this.pemStore = pemStore;
     }
@@ -120,7 +125,7 @@ public class CertificateRegistry {
     }
 
     private Certificate certificateV1DTOToCert(CertificateV1DTO dto) {
-        Certificate cert = new Certificate(dto.getCertificateId());
+        Certificate cert = new Certificate(dto.getCertificateId(), clock);
         cert.setStatus(dto2domainStatus.get(dto.getStatus()), Instant.ofEpochMilli(dto.getStatusUpdated()));
         return cert;
     }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/usecases/VerifyThingAttachedToCertificate.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/usecases/VerifyThingAttachedToCertificate.java
@@ -43,13 +43,13 @@ public class VerifyThingAttachedToCertificate
     }
 
     private boolean verifyLocally(Thing thing, String certificateId) {
-        logger.atInfo().kv("thing", thing.getThingName()).kv("certificate", certificateId)
+        logger.atDebug().kv("thing", thing.getThingName()).kv("certificate", certificateId)
                 .log("Network down, verifying thing attached to certificate locally");
         return thing.isCertificateAttached(certificateId);
     }
 
     private boolean verifyFromCloud(Thing thing, String certificateId) {
-        logger.atInfo().kv("thing", thing.getThingName()).kv("certificate", certificateId)
+        logger.atDebug().kv("thing", thing.getThingName()).kv("certificate", certificateId)
                 .log("Network up, verifying thing attached to certificate from cloud");
 
         if (iotAuthClient.isThingAttachedToCertificate(thing, certificateId)) {

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/helpers/ClockFake.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/helpers/ClockFake.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.helpers;
+
+import lombok.Setter;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+public class ClockFake extends Clock {
+    @Setter
+    private Instant currentInstant;
+
+    public ClockFake() {
+        super();
+        currentInstant = Instant.now();
+    }
+
+    @Override
+    public ZoneId getZone() {
+        return ZoneId.systemDefault();
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+        return Clock.fixed(currentInstant, ZoneId.systemDefault());
+    }
+
+    @Override
+    public Instant instant() {
+        return currentInstant;
+    }
+}

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/CertificateRegistryTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/CertificateRegistryTest.java
@@ -25,10 +25,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.security.KeyPair;
-import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.time.Clock;
 import java.time.Instant;
 import java.util.Optional;
 
@@ -62,10 +62,10 @@ class CertificateRegistryTest {
     }
 
     @BeforeEach
-    void beforeEach() throws KeyStoreException {
+    void beforeEach() {
         configTopic = Topics.of(new Context(), "config", null);
         ClientCertificateStore store = new ClientCertificateStore(workDir);
-        registry = new CertificateRegistry(RuntimeConfiguration.from(configTopic), store);
+        registry = new CertificateRegistry(RuntimeConfiguration.from(configTopic), store, Clock.systemUTC());
     }
 
     @AfterEach

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClientFake.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClientFake.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.core.pagination.sync.SdkIterable;
 import software.amazon.awssdk.core.pagination.sync.SyncPageFetcher;
 import software.amazon.awssdk.services.greengrassv2.model.AssociatedClientDevice;
 
+import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -33,6 +34,15 @@ public class IotAuthClientFake implements IotAuthClient {
     private final Map<String, Set<String>> thingToCerts = new HashMap<>();
     private final Set<String> activeCertIds = new HashSet<>();
     private final Set<String> inactiveCertIds = new HashSet<>();
+    private final Clock clock;
+
+    public IotAuthClientFake(Clock clock) {
+        this.clock = clock;
+    }
+
+    public IotAuthClientFake() {
+        this(Clock.systemUTC());
+    }
 
     public void activateCert(String certPem) throws InvalidCertificateException {
         Certificate cert = Certificate.fromPem(certPem);
@@ -89,11 +99,11 @@ public class IotAuthClientFake implements IotAuthClient {
         Certificate cert = Certificate.fromPem(certificatePem);
 
         if (activeCertIds.contains(cert.getCertificateId())) {
-            cert.setStatus(Certificate.Status.ACTIVE);
+            cert.setStatus(Certificate.Status.ACTIVE, clock);
             return Optional.of(cert);
         }
         if (inactiveCertIds.contains(cert.getCertificateId())) {
-            cert.setStatus(Certificate.Status.UNKNOWN);
+            cert.setStatus(Certificate.Status.UNKNOWN, clock);
             return Optional.of(cert);
         }
 

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/usecases/VerifyThingAttachedToCertificateTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/usecases/VerifyThingAttachedToCertificateTest.java
@@ -26,6 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
+import java.time.Clock;
 
 import static com.aws.greengrass.clientdevices.auth.helpers.CertificateTestHelpers.createClientCertificate;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -48,7 +49,8 @@ class VerifyThingAttachedToCertificateTest {
     void beforeEach() {
         iotAuthClientFake = new IotAuthClientFake();
         verifyThingAttachedToCertificate =
-                new VerifyThingAttachedToCertificate(iotAuthClientFake, mockThingRegistry, mockNetworkState);
+                new VerifyThingAttachedToCertificate(iotAuthClientFake, mockThingRegistry, mockNetworkState,
+                        Clock.systemUTC());
     }
 
     @Test
@@ -111,7 +113,8 @@ class VerifyThingAttachedToCertificateTest {
         doThrow(CloudServiceInteractionException.class).when(mockIotAuthClient)
                 .isThingAttachedToCertificate(any(), anyString());
         VerifyThingAttachedToCertificate verifyThingAttachedToCertificate =
-                new VerifyThingAttachedToCertificate(mockIotAuthClient, mockThingRegistry, mockNetworkState);
+                new VerifyThingAttachedToCertificate(mockIotAuthClient, mockThingRegistry, mockNetworkState,
+                        Clock.systemUTC());
 
         when(mockNetworkState.getConnectionState()).thenReturn(NetworkStateProvider.ConnectionState.NETWORK_UP);
         when(mockThingRegistry.getThing(thing.getThingName())).thenReturn(thing);

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactoryTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactoryTest.java
@@ -32,6 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.utils.ImmutableMap;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.util.Map;
 import java.util.Optional;
 
@@ -68,7 +69,8 @@ public class MqttSessionFactoryTest {
         CreateIoTThingSession createIoTThingSession =
                 new CreateIoTThingSession(mockThingRegistry, mockCertificateRegistry, useCases);
         VerifyThingAttachedToCertificate verifyThingAttachedToCertificate =
-                new VerifyThingAttachedToCertificate(iotAuthClientMock, mockThingRegistry, mockNetworkState);
+                new VerifyThingAttachedToCertificate(iotAuthClientMock, mockThingRegistry, mockNetworkState,
+                        Clock.systemUTC());
         context.put(NetworkStateProvider.class, mockNetworkState);
         context.put(CreateIoTThingSession.class, createIoTThingSession);
         context.put(VerifyThingAttachedToCertificate.class, verifyThingAttachedToCertificate);


### PR DESCRIPTION
**Description of changes:**
When the device boots up it will receive a network up event. That causes the background refresh to be immediately triggered. This PR ensures that it only gets triggered if the network was previously down and has not been triggered in the last 24h