### PR TITLE
feat: add certificate chain config

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfiguration.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfiguration.java
@@ -141,7 +141,7 @@ public final class CAConfiguration {
 
     private static Optional<URI> getCaCertificateChainUriFromConfiguration(Topics certAuthorityTopic)
             throws URISyntaxException {
-        String certificateChainUri = Coerce.toString(certAuthorityTopic.findOrDefault("", CA_CERTIFICATE_CHAIN_URI));
+        String certificateChainUri = Coerce.toString(certAuthorityTopic.find(CA_CERTIFICATE_CHAIN_URI));
 
         if (Utils.isEmpty(certificateChainUri)) {
             return Optional.empty();
@@ -152,7 +152,7 @@ public final class CAConfiguration {
 
     private static Optional<URI> getCaPrivateKeyUriFromConfiguration(Topics certAuthorityTopic)
             throws URISyntaxException {
-        String privateKeyUri = Coerce.toString(certAuthorityTopic.findOrDefault("", CA_PRIVATE_KEY_URI));
+        String privateKeyUri = Coerce.toString(certAuthorityTopic.find(CA_PRIVATE_KEY_URI));
 
         if (Utils.isEmpty(privateKeyUri)) {
             return Optional.empty();
@@ -163,7 +163,7 @@ public final class CAConfiguration {
 
     private static Optional<URI> getCaCertificateUriFromConfiguration(Topics certAuthorityTopic)
             throws URISyntaxException {
-        String certificateUri = Coerce.toString(certAuthorityTopic.findOrDefault("", CA_CERTIFICATE_URI));
+        String certificateUri = Coerce.toString(certAuthorityTopic.find(CA_CERTIFICATE_URI));
 
         if (Utils.isEmpty(certificateUri)) {
             return Optional.empty();

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfiguration.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/CAConfiguration.java
@@ -27,6 +27,7 @@ import java.util.Optional;
  * <p>
  * |---- configuration
  * |    |---- certificateAuthority:
+ * |          |---- certificateChainUri "..."
  * |          |---- privateKeyUri: "..."
  * |          |---- certificateUri: "..."
  * |          |---- caType: [...]
@@ -36,6 +37,7 @@ import java.util.Optional;
 public final class CAConfiguration {
     public static final String CA_CERTIFICATE_URI = "certificateUri";
     public static final String CA_PRIVATE_KEY_URI = "privateKeyUri";
+    public static final String CA_CERTIFICATE_CHAIN_URI = "certificateChainUri";
     public static final String DEPRECATED_CA_TYPE_KEY = "ca_type";
     public static final String CA_TYPE_KEY = "caType";
     public static final String CERTIFICATE_AUTHORITY_TOPIC = "certificateAuthority";
@@ -45,14 +47,17 @@ public final class CAConfiguration {
     private List<String> caTypeList;
     private Optional<URI> privateKeyUri;
     private Optional<URI> certificateUri;
+    private Optional<URI> certificateChainUri;
+
 
 
     private CAConfiguration(List<String> caTypes, CertificateStore.CAType caType, Optional<URI> privateKeyUri,
-                            Optional<URI> certificateUri) {
+                            Optional<URI> certificateUri, Optional<URI> certificateChainUri) {
         this.caType = caType;
         this.caTypeList = caTypes;
         this.privateKeyUri = privateKeyUri;
         this.certificateUri = certificateUri;
+        this.certificateChainUri = certificateChainUri;
     }
 
     /**
@@ -67,7 +72,9 @@ public final class CAConfiguration {
         return new CAConfiguration(getCaTypeListFromConfiguration(configurationTopics),
                 getCaTypeFromConfiguration(configurationTopics),
                 getCaPrivateKeyUriFromConfiguration(certAuthorityTopic),
-                getCaCertificateUriFromConfiguration(certAuthorityTopic));
+                getCaCertificateUriFromConfiguration(certAuthorityTopic),
+                getCaCertificateChainUriFromConfiguration(certAuthorityTopic)
+        );
     }
 
     /**
@@ -130,6 +137,17 @@ public final class CAConfiguration {
         }
 
         return uri;
+    }
+
+    private static Optional<URI> getCaCertificateChainUriFromConfiguration(Topics certAuthorityTopic)
+            throws URISyntaxException {
+        String certificateChainUri = Coerce.toString(certAuthorityTopic.findOrDefault("", CA_CERTIFICATE_CHAIN_URI));
+
+        if (Utils.isEmpty(certificateChainUri)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(getUri(certificateChainUri));
     }
 
     private static Optional<URI> getCaPrivateKeyUriFromConfiguration(Topics certAuthorityTopic)

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/CertificateManagerTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/CertificateManagerTest.java
@@ -210,7 +210,7 @@ public class CertificateManagerTest {
         X509Certificate[] certificateChain = {intermediateCA, rootCA};
         storeCAOnFileSystem(intermediateKeyPair.getPrivate(), certificateChain);
 
-        URI certificateChainUri = new URI("file://" + rootDir.resolve("certificate.pem"));
+        URI certificateChainUri = rootDir.resolve("certificate.pem").toFile().toURI();
         URI privateKeyUri = new URI("pkcs11:object=CustomerIntermediateCA;type=private");
         URI certificateUri = new URI("pkcs11:object=CustomerIntermediateCA;type=cert");
 


### PR DESCRIPTION
**Issue #, if available:**
TPM modules do not support adding certificate chains into a single key. This renders TPM users unavailable from providing intermediate certificates.

**Description of changes:**
Introduces a new configuration called certificateChainUri. When provided we will read the certificate chain from it. We are keeping the old configuration that would behave the same if the certificateChainUri is not provided. This will allow TPM users to use the following configuration

```
    "certificateAuthority": {
      "certificateChainUri": "file:///home/ec2-user/creds/intermediateCA.pem",
      "certificateUri": "pkcs11:object=CustomerIntermediateCA;type=cert",
      "privateKeyUri": "pkcs11:object=CustomerIntermediateCA;type=private"
    }
```

Which effectively allows TPM users to provide intermediate certificate chains.

**Why is this change necessary:**
Allow TPM users to provide certificate chains

**How was this change tested:**
Manual tests
