### PR TITLE
feat: adding the ability to emit metrics

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/CertificateManager.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/CertificateManager.java
@@ -187,7 +187,7 @@ public class CertificateManager {
                 };
                 subscribeToClientCertificateUpdatesNoCSR(getCertificateRequest, keyPair.getPublic(), consumer);
             }
-            metrics.incrementSubscribeSuccess();
+            metrics.subscribeSuccess();
         } catch (NoSuchAlgorithmException e) {
             throw new CertificateGenerationException(e);
         }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/CertificateManager.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/CertificateManager.java
@@ -24,6 +24,7 @@ import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationExce
 import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
 import com.aws.greengrass.clientdevices.auth.exception.InvalidCertificateAuthorityException;
 import com.aws.greengrass.clientdevices.auth.exception.InvalidConfigurationException;
+import com.aws.greengrass.clientdevices.auth.metrics.ClientDeviceAuthMetrics;
 import com.aws.greengrass.deployment.exceptions.DeviceConfigurationException;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
@@ -71,7 +72,7 @@ public class CertificateManager {
     private CertificatesConfig certificatesConfig;
     private static final Logger logger = LogManager.getLogger(CertificateManager.class);
     private static final String pkcs11Scheme = "pkcs11";
-
+    private ClientDeviceAuthMetrics metrics;
 
     /**
      * Construct a new CertificateManager.
@@ -183,6 +184,7 @@ public class CertificateManager {
                 };
                 subscribeToClientCertificateUpdatesNoCSR(getCertificateRequest, keyPair.getPublic(), consumer);
             }
+            metrics.incrementSubscribeSuccess();
         } catch (NoSuchAlgorithmException e) {
             throw new CertificateGenerationException(e);
         }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/CertificateManager.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/CertificateManager.java
@@ -72,7 +72,7 @@ public class CertificateManager {
     private CertificatesConfig certificatesConfig;
     private static final Logger logger = LogManager.getLogger(CertificateManager.class);
     private static final String pkcs11Scheme = "pkcs11";
-    private ClientDeviceAuthMetrics metrics;
+    private final ClientDeviceAuthMetrics metrics;
 
     /**
      * Construct a new CertificateManager.
@@ -85,12 +85,14 @@ public class CertificateManager {
      * @param clientFactory           Greengrass cloud service client factory
      * @param securityService         Security Service
      * @param caConfigurationMonitor  CA Configuration Monitor
+     * @param metrics                 Client Device Auth Metrics
      */
     @Inject
     public CertificateManager(CertificateStore certificateStore, ConnectivityInformation connectivityInformation,
                               CertificateExpiryMonitor certExpiryMonitor, CISShadowMonitor cisShadowMonitor,
                               Clock clock, GreengrassServiceClientFactory clientFactory,
-                              SecurityService securityService, CertificateRotationHandler caConfigurationMonitor) {
+                              SecurityService securityService, CertificateRotationHandler caConfigurationMonitor,
+                              ClientDeviceAuthMetrics metrics) {
         this.certificateStore = certificateStore;
         this.connectivityInformation = connectivityInformation;
         this.certExpiryMonitor = certExpiryMonitor;
@@ -99,6 +101,7 @@ public class CertificateManager {
         this.clock = clock;
         this.clientFactory = clientFactory;
         this.securityService = securityService;
+        this.metrics = metrics;
     }
 
     public void updateCertificatesConfiguration(CertificatesConfig certificatesConfig) {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/ClientDeviceAuthMetrics.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/ClientDeviceAuthMetrics.java
@@ -1,0 +1,40 @@
+package com.aws.greengrass.clientdevices.auth.metrics;
+
+
+import com.aws.greengrass.telemetry.impl.Metric;
+import com.aws.greengrass.telemetry.models.TelemetryAggregation;
+import com.aws.greengrass.telemetry.models.TelemetryUnit;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class ClientDeviceAuthMetrics {
+
+    private static AtomicLong certSubscribeSuccess = new AtomicLong();
+    private static final String NAMESPACE = "ClientDeviceAuth";
+
+    public List<Metric> collectMetrics() {
+        List<Metric> metricsList = new ArrayList<>();
+
+        long timestamp = Instant.now().toEpochMilli();
+
+        Metric metric = Metric.builder()
+                .namespace(NAMESPACE)
+                .name("Cert.SubscribeSuccess")
+                .unit(TelemetryUnit.Count)
+                .aggregation(TelemetryAggregation.Count)
+                .value(certSubscribeSuccess)
+                .timestamp(timestamp)
+                .build();
+        metricsList.add(metric);
+
+        return metricsList;
+    }
+
+    public void incrementSubscribeSuccess() {
+        certSubscribeSuccess.incrementAndGet();
+    }
+
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/ClientDeviceAuthMetrics.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/ClientDeviceAuthMetrics.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.clientdevices.auth.metrics;
 
 
@@ -15,6 +20,10 @@ public class ClientDeviceAuthMetrics {
     private static AtomicLong certSubscribeSuccess = new AtomicLong();
     private static final String NAMESPACE = "ClientDeviceAuth";
 
+    /**
+     * Builds the CDA metrics.
+     * @return a list of {@link Metric}
+     */
     public List<Metric> collectMetrics() {
         List<Metric> metricsList = new ArrayList<>();
 
@@ -33,6 +42,9 @@ public class ClientDeviceAuthMetrics {
         return metricsList;
     }
 
+    /**
+     * Increments the Cert.SubscribeSuccess metric.
+     */
     public void incrementSubscribeSuccess() {
         certSubscribeSuccess.incrementAndGet();
     }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/ClientDeviceAuthMetrics.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/ClientDeviceAuthMetrics.java
@@ -34,7 +34,7 @@ public class ClientDeviceAuthMetrics {
                 .name("Cert.SubscribeSuccess")
                 .unit(TelemetryUnit.Count)
                 .aggregation(TelemetryAggregation.Count)
-                .value(certSubscribeSuccess)
+                .value(certSubscribeSuccess.getAndSet(0))
                 .timestamp(timestamp)
                 .build();
         metricsList.add(metric);

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/ClientDeviceAuthMetrics.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/ClientDeviceAuthMetrics.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class ClientDeviceAuthMetrics {
 
-    private static AtomicLong certSubscribeSuccess = new AtomicLong();
+    private final AtomicLong certSubscribeSuccess = new AtomicLong();
     private static final String NAMESPACE = "ClientDeviceAuth";
 
     /**
@@ -33,7 +33,7 @@ public class ClientDeviceAuthMetrics {
                 .namespace(NAMESPACE)
                 .name("Cert.SubscribeSuccess")
                 .unit(TelemetryUnit.Count)
-                .aggregation(TelemetryAggregation.Count)
+                .aggregation(TelemetryAggregation.Sum)
                 .value(certSubscribeSuccess.getAndSet(0))
                 .timestamp(timestamp)
                 .build();
@@ -45,7 +45,7 @@ public class ClientDeviceAuthMetrics {
     /**
      * Increments the Cert.SubscribeSuccess metric.
      */
-    public void incrementSubscribeSuccess() {
+    public void subscribeSuccess() {
         certSubscribeSuccess.incrementAndGet();
     }
 

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/MetricsEmitter.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/MetricsEmitter.java
@@ -5,27 +5,16 @@
 
 package com.aws.greengrass.clientdevices.auth.metrics;
 
-import com.aws.greengrass.logging.api.Logger;
-import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.telemetry.PeriodicMetricsEmitter;
 import com.aws.greengrass.telemetry.impl.Metric;
 import com.aws.greengrass.telemetry.impl.MetricFactory;
 
+import java.util.ArrayList;
 import java.util.List;
-import javax.inject.Inject;
 
 public class MetricsEmitter extends PeriodicMetricsEmitter {
-    public static final Logger logger = LogManager.getLogger(MetricsEmitter.class);
-    public static final String NAMESPACE = "ClientDeviceAuth";
+    private static final String NAMESPACE = "ClientDeviceAuth";
     private final MetricFactory mf = new MetricFactory(NAMESPACE);
-
-    /**
-     * Constructor for metrics emitter.
-     */
-    @Inject
-    public MetricsEmitter() {
-        super();
-    }
 
     /**
      * Emit CDA metrics.
@@ -45,6 +34,6 @@ public class MetricsEmitter extends PeriodicMetricsEmitter {
     @Override
     public List<Metric> getMetrics() {
         //implementation pending
-        return null; 
+        return new ArrayList<>();
     }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/MetricsEmitter.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/MetricsEmitter.java
@@ -34,13 +34,14 @@ public class MetricsEmitter extends PeriodicMetricsEmitter {
     @Override
     public void emitMetrics() {
         List<Metric> retrievedMetrics = getMetrics();
-        for (Metric retrievedMetric: retrievedMetrics) {
+        for (Metric retrievedMetric : retrievedMetrics) {
             mf.putMetricData(retrievedMetric);
         }
     }
 
     /**
      * Retrieve CDA metrics.
+     *
      * @return a list of {@link Metric}
      */
     @Override

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/MetricsEmitter.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/MetricsEmitter.java
@@ -14,13 +14,13 @@ import com.aws.greengrass.telemetry.impl.MetricFactory;
 import java.util.List;
 import javax.inject.Inject;
 
-public class MetricsEmitter extends PeriodicMetricsEmitter{
+public class MetricsEmitter extends PeriodicMetricsEmitter {
     public static final Logger logger = LogManager.getLogger(MetricsEmitter.class);
     public static final String NAMESPACE = "ClientDeviceAuth";
     private final MetricFactory mf = new MetricFactory(NAMESPACE);
 
     /**
-     * Constructor for metrics emitter
+     * Constructor for metrics emitter.
      */
     @Inject
     public MetricsEmitter() {
@@ -28,24 +28,23 @@ public class MetricsEmitter extends PeriodicMetricsEmitter{
     }
 
     /**
-     * Emit CDA metrics
+     * Emit CDA metrics.
      */
     @Override
     public void emitMetrics() {
         List<Metric> retrievedMetrics = getMetrics();
-        for(Metric retrievedMetric: retrievedMetrics) {
+        for (Metric retrievedMetric: retrievedMetrics) {
             mf.putMetricData(retrievedMetric);
         }
     }
 
     /**
-     * Retrieve CDA metrics
+     * Retrieve CDA metrics.
      * @return a list of {@link Metric}
-     * 
-     * implementation pending
      */
     @Override
     public List<Metric> getMetrics() {
+        //implementation pending
         return null; 
     }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/MetricsEmitter.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/MetricsEmitter.java
@@ -9,12 +9,24 @@ import com.aws.greengrass.telemetry.PeriodicMetricsEmitter;
 import com.aws.greengrass.telemetry.impl.Metric;
 import com.aws.greengrass.telemetry.impl.MetricFactory;
 
-import java.util.ArrayList;
 import java.util.List;
+import javax.inject.Inject;
 
 public class MetricsEmitter extends PeriodicMetricsEmitter {
     private static final String NAMESPACE = "ClientDeviceAuth";
     private final MetricFactory mf = new MetricFactory(NAMESPACE);
+    private final ClientDeviceAuthMetrics metrics;
+
+    /**
+     * Constructor for metrics emitter.
+     *
+     * @param metrics {@link ClientDeviceAuthMetrics}
+     */
+    @Inject
+    public MetricsEmitter(ClientDeviceAuthMetrics metrics) {
+        super();
+        this.metrics = metrics;
+    }
 
     /**
      * Emit CDA metrics.
@@ -33,7 +45,6 @@ public class MetricsEmitter extends PeriodicMetricsEmitter {
      */
     @Override
     public List<Metric> getMetrics() {
-        //implementation pending
-        return new ArrayList<>();
+        return metrics.collectMetrics();
     }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/MetricsEmitter.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/MetricsEmitter.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.clientdevices.auth.metrics;
 
 import com.aws.greengrass.logging.api.Logger;

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/MetricsEmitter.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/MetricsEmitter.java
@@ -1,0 +1,46 @@
+package com.aws.greengrass.clientdevices.auth.metrics;
+
+import com.aws.greengrass.logging.api.Logger;
+import com.aws.greengrass.logging.impl.LogManager;
+import com.aws.greengrass.telemetry.PeriodicMetricsEmitter;
+import com.aws.greengrass.telemetry.impl.Metric;
+import com.aws.greengrass.telemetry.impl.MetricFactory;
+
+import java.util.List;
+import javax.inject.Inject;
+
+public class MetricsEmitter extends PeriodicMetricsEmitter{
+    public static final Logger logger = LogManager.getLogger(MetricsEmitter.class);
+    public static final String NAMESPACE = "ClientDeviceAuth";
+    private final MetricFactory mf = new MetricFactory(NAMESPACE);
+
+    /**
+     * Constructor for metrics emitter
+     */
+    @Inject
+    public MetricsEmitter() {
+        super();
+    }
+
+    /**
+     * Emit CDA metrics
+     */
+    @Override
+    public void emitMetrics() {
+        List<Metric> retrievedMetrics = getMetrics();
+        for(Metric retrievedMetric: retrievedMetrics) {
+            mf.putMetricData(retrievedMetric);
+        }
+    }
+
+    /**
+     * Retrieve CDA metrics
+     * @return a list of {@link Metric}
+     * 
+     * implementation pending
+     */
+    @Override
+    public List<Metric> getMetrics() {
+        return null; 
+    }
+}

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/CertificateManagerTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/CertificateManagerTest.java
@@ -20,6 +20,7 @@ import com.aws.greengrass.clientdevices.auth.connectivity.CISShadowMonitor;
 import com.aws.greengrass.clientdevices.auth.connectivity.ConnectivityInformation;
 import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationException;
 import com.aws.greengrass.clientdevices.auth.helpers.CertificateTestHelpers;
+import com.aws.greengrass.clientdevices.auth.metrics.ClientDeviceAuthMetrics;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.security.SecurityService;
@@ -98,6 +99,8 @@ public class CertificateManagerTest {
     GreengrassServiceClientFactory clientFactoryMock;
     @Mock
     SecurityService securityServiceMock;
+    @Mock
+    ClientDeviceAuthMetrics metricsMock;
     @TempDir
     Path rootDir;
 
@@ -119,7 +122,7 @@ public class CertificateManagerTest {
         certificateManager =
                 new CertificateManager(certificateStore, mockConnectivityInformation, mockCertExpiryMonitor,
                         mockShadowMonitor, Clock.systemUTC(), clientFactoryMock, securityServiceMock,
-                        certRotationMonitor);
+                        certRotationMonitor, metricsMock);
 
         CertificatesConfig certificatesConfig =
                 new CertificatesConfig(Topics.of(new Context(), CONFIGURATION_CONFIG_KEY, null));


### PR DESCRIPTION
Added a metrics folder and the MetricsEmitter class. Wrote a function to enable emitting metrics.

This class can be used to emit the metrics for phase 1 of CDA metrics ingestion.

The metrics themselves will be implemented later.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
