### PR TITLE
fix(sdk-clients): use http client builder to avoid leaks

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/GreengrassV2DataClientFactory.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/GreengrassV2DataClientFactory.java
@@ -53,8 +53,9 @@ public class GreengrassV2DataClientFactory {
 
         GreengrassV2DataClientBuilder clientBuilder =
                 GreengrassV2DataClient.builder().credentialsProvider(AnonymousCredentialsProvider.create())
-                        .httpClient(httpClient.build()).overrideConfiguration(
-                                ClientOverrideConfiguration.builder().retryPolicy(RetryPolicy.none()).build());
+                        .httpClientBuilder(httpClient.useIdleConnectionReaper(false))
+                        .overrideConfiguration(ClientOverrideConfiguration.builder()
+                                .retryPolicy(RetryPolicy.none()).build());
 
         clientBuilder.region(Region.of(awsRegion));
         clientBuilder.endpointOverride(URI.create(ggServiceEndpoint));

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClient.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClient.java
@@ -202,7 +202,8 @@ public interface IotAuthClient {
         private GreengrassV2Client getGGV2Client() {
             String awsRegion = Coerce.toString(deviceConfiguration.getAWSRegion());
             GreengrassV2ClientBuilder clientBuilder =
-                    GreengrassV2Client.builder().httpClient(ProxyUtils.getSdkHttpClient())
+                    GreengrassV2Client.builder().httpClientBuilder(ProxyUtils.getSdkHttpClientBuilder()
+                                    .useIdleConnectionReaper(false))
                             .credentialsProvider(lazyCredentialProvider).overrideConfiguration(
                                     ClientOverrideConfiguration.builder().retryPolicy(RetryMode.STANDARD).build());
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Using `.httpClient` will create a non-managed SDK HTTP client which means that when the SDK client is closed the HTTP client will NOT close. This is absolutely not what we want in these cases because the SDK client is used and then immediately thrown away. This in turn, causes us to leak HTTP connection managers which are kept alive by the idle connection reaper which will never remove them from tracking because they're never closed.

Using `.httpClientBuilder` instead, will create a managed HTTP client which is properly closed at the same time the SDK client is closed. We are doubtless making this same mistake in the Nucleus and in our other plugins leading to increased memory usage and ultimately leaks.

Also disabling the idle connection reaper for these because we aren't using pooled HTTP clients, so there's no reason to keep the idle connection alive.

**Why is this change necessary:**

**How was this change tested:**
Verified by stepping through with a debugger, that closing the SDK client will close the HTTP client when using `httpClientBuilder`. @Nelsonochoam verified in his own testing that the heap stays small when using these changes.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
