### PR TITLE
feat: add metrics for the Authorize Client Device Actions API

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -20,6 +20,7 @@ import com.aws.greengrass.clientdevices.auth.configuration.GroupManager;
 import com.aws.greengrass.clientdevices.auth.configuration.RuntimeConfiguration;
 import com.aws.greengrass.clientdevices.auth.connectivity.CISShadowMonitor;
 import com.aws.greengrass.clientdevices.auth.infra.NetworkStateProvider;
+import com.aws.greengrass.clientdevices.auth.metrics.handlers.AuthorizeClientDeviceActionsMetricHandler;
 import com.aws.greengrass.clientdevices.auth.metrics.handlers.CertificateSubscriptionHandler;
 import com.aws.greengrass.clientdevices.auth.metrics.handlers.VerifyClientDeviceIdentityHandler;
 import com.aws.greengrass.clientdevices.auth.session.MqttSessionFactory;
@@ -141,6 +142,7 @@ public class ClientDevicesAuthService extends PluginService {
         context.get(SecurityConfigurationChangedHandler.class).listen();
         context.get(CertificateSubscriptionHandler.class).listen();
         context.get(VerifyClientDeviceIdentityHandler.class).listen();
+        context.get(AuthorizeClientDeviceActionsMetricHandler.class).listen();
     }
 
     private void subscribeToConfigChanges() {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/api/AuthorizeClientDeviceActionEvent.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/api/AuthorizeClientDeviceActionEvent.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+public class AuthorizeClientDeviceActionEvent implements DomainEvent {
+    @Getter
+    private AuthorizationStatus status;
+
+    public enum AuthorizationStatus {
+        SUCCESS,
+        FAIL
+    }
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/api/ClientDevicesAuthServiceApi.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/api/ClientDevicesAuthServiceApi.java
@@ -102,13 +102,10 @@ public class ClientDevicesAuthServiceApi {
             throws AuthorizationException {
         boolean isAuthorized = deviceAuthClient.canDevicePerform(authorizationRequest);
 
-        if (isAuthorized) {
-            domainEvents.emit(new AuthorizeClientDeviceActionEvent(AuthorizeClientDeviceActionEvent
-                    .AuthorizationStatus.SUCCESS));
-        } else {
-            domainEvents.emit(new AuthorizeClientDeviceActionEvent(AuthorizeClientDeviceActionEvent
-                    .AuthorizationStatus.FAIL));
-        }
+        domainEvents.emit(new AuthorizeClientDeviceActionEvent(isAuthorized
+                ? AuthorizeClientDeviceActionEvent.AuthorizationStatus.SUCCESS :
+                AuthorizeClientDeviceActionEvent.AuthorizationStatus.FAIL));
+
         return isAuthorized;
     }
 

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/api/ClientDevicesAuthServiceApi.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/api/ClientDevicesAuthServiceApi.java
@@ -100,7 +100,16 @@ public class ClientDevicesAuthServiceApi {
      */
     public boolean authorizeClientDeviceAction(AuthorizationRequest authorizationRequest)
             throws AuthorizationException {
-        return deviceAuthClient.canDevicePerform(authorizationRequest);
+        boolean isAuthorized = deviceAuthClient.canDevicePerform(authorizationRequest);
+
+        if (isAuthorized) {
+            domainEvents.emit(new AuthorizeClientDeviceActionEvent(AuthorizeClientDeviceActionEvent
+                    .AuthorizationStatus.SUCCESS));
+        } else {
+            domainEvents.emit(new AuthorizeClientDeviceActionEvent(AuthorizeClientDeviceActionEvent
+                    .AuthorizationStatus.FAIL));
+        }
+        return isAuthorized;
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/ClientDeviceAuthMetrics.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/ClientDeviceAuthMetrics.java
@@ -128,7 +128,7 @@ public class ClientDeviceAuthMetrics {
         verifyClientDeviceIdentityFailure.incrementAndGet();
     }
 
-     /**
+    /**
      * Increments the AuthorizeClientDeviceAction.Success metric.
      */
     public void authorizeActionSuccess() {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/ClientDeviceAuthMetrics.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/ClientDeviceAuthMetrics.java
@@ -22,6 +22,8 @@ public class ClientDeviceAuthMetrics {
     private final AtomicLong subscribeToCertificateUpdatesFailure = new AtomicLong();
     private final AtomicLong verifyClientDeviceIdentitySuccess = new AtomicLong();
     private final AtomicLong verifyClientDeviceIdentityFailure = new AtomicLong();
+    private final AtomicLong authorizeClientDeviceActionSuccess = new AtomicLong();
+    private final AtomicLong authorizeClientDeviceActionFailure = new AtomicLong();
     private final MetricFactory mf = new MetricFactory(NAMESPACE);
     private final Clock clock;
     private static final String NAMESPACE = "aws.greengrass.clientdevices.Auth";
@@ -33,6 +35,10 @@ public class ClientDeviceAuthMetrics {
             "VerifyClientDeviceIdentity.Success";
     public static final String METRIC_VERIFY_CLIENT_DEVICE_IDENTITY_FAILURE =
             "VerifyClientDeviceIdentity.Failure";
+    public static final String METRIC_AUTHORIZE_CLIENT_DEVICE_ACTIONS_SUCCESS =
+            "AuthorizeClientDeviceActions.Success";
+    public static final String METRIC_AUTHORIZE_CLIENT_DEVICE_ACTIONS_FAILURE =
+            "AuthorizeClientDeviceActions.Failure";
 
     /**
      * Constructor for Client Device Auth Metrics.
@@ -63,49 +69,98 @@ public class ClientDeviceAuthMetrics {
     public List<Metric> collectMetrics() {
         List<Metric> metricsList = new ArrayList<>();
 
+        metricsList.add(buildMetric(METRIC_SUBSCRIBE_TO_CERTIFICATE_UPDATES_SUCCESS,
+                subscribeToCertificateUpdatesSuccess));
+        metricsList.add(buildMetric(METRIC_SUBSCRIBE_TO_CERTIFICATE_UPDATES_FAILURE,
+                subscribeToCertificateUpdatesFailure));
+        metricsList.add(buildMetric(METRIC_VERIFY_CLIENT_DEVICE_IDENTITY_SUCCESS,
+                verifyClientDeviceIdentitySuccess));
+        metricsList.add(buildMetric(METRIC_VERIFY_CLIENT_DEVICE_IDENTITY_FAILURE,
+                verifyClientDeviceIdentityFailure));
+        metricsList.add(buildMetric(METRIC_AUTHORIZE_CLIENT_DEVICE_ACTIONS_SUCCESS,
+                authorizeClientDeviceActionSuccess));
+        metricsList.add(buildMetric(METRIC_AUTHORIZE_CLIENT_DEVICE_ACTIONS_FAILURE,
+                authorizeClientDeviceActionFailure));
+
+
+//        long timestamp = Instant.now(clock).toEpochMilli();
+//
+//        Metric metric = Metric.builder()
+//                .namespace(NAMESPACE)
+//                .name(METRIC_SUBSCRIBE_TO_CERTIFICATE_UPDATES_SUCCESS)
+//                .unit(TelemetryUnit.Count)
+//                .aggregation(TelemetryAggregation.Sum)
+//                .value(subscribeToCertificateUpdatesSuccess.getAndSet(0L))
+//                .timestamp(timestamp)
+//                .build();
+//        metricsList.add(metric);
+//
+//        metric = Metric.builder()
+//                .namespace(NAMESPACE)
+//                .name(METRIC_SUBSCRIBE_TO_CERTIFICATE_UPDATES_FAILURE)
+//                .unit(TelemetryUnit.Count)
+//                .aggregation(TelemetryAggregation.Sum)
+//                .value(subscribeToCertificateUpdatesFailure.getAndSet(0L))
+//                .timestamp(timestamp)
+//                .build();
+//        metricsList.add(metric);
+//
+//        metric = Metric.builder()
+//                .namespace(NAMESPACE)
+//                .name(METRIC_VERIFY_CLIENT_DEVICE_IDENTITY_SUCCESS)
+//                .unit(TelemetryUnit.Count)
+//                .aggregation(TelemetryAggregation.Sum)
+//                .value(verifyClientDeviceIdentitySuccess.getAndSet(0L))
+//                .timestamp(timestamp)
+//                .build();
+//        metricsList.add(metric);
+//
+//        metric = Metric.builder()
+//                .namespace(NAMESPACE)
+//                .name(METRIC_VERIFY_CLIENT_DEVICE_IDENTITY_FAILURE)
+//                .unit(TelemetryUnit.Count)
+//                .aggregation(TelemetryAggregation.Sum)
+//                .value(verifyClientDeviceIdentityFailure.getAndSet(0L))
+//                .timestamp(timestamp)
+//                .build();
+//        metricsList.add(metric);
+//
+//        metric = Metric.builder()
+//                .namespace(NAMESPACE)
+//                .name(METRIC_AUTHORIZE_CLIENT_DEVICE_ACTIONS_SUCCESS)
+//                .unit(TelemetryUnit.Count)
+//                .aggregation(TelemetryAggregation.Sum)
+//                .value(authorizeClientDeviceActionSuccess.getAndSet(0L))
+//                .timestamp(timestamp)
+//                .build();
+//        metricsList.add(metric);
+//
+//        metric = Metric.builder()
+//                .namespace(NAMESPACE)
+//                .name(METRIC_AUTHORIZE_CLIENT_DEVICE_ACTIONS_FAILURE)
+//                .unit(TelemetryUnit.Count)
+//                .aggregation(TelemetryAggregation.Sum)
+//                .value(authorizeClientDeviceActionFailure.getAndSet(0L))
+//                .timestamp(timestamp)
+//                .build();
+//        metricsList.add(metric);
+
+        return metricsList;
+    }
+
+    private Metric buildMetric(String metricName, AtomicLong metricValue) {
         long timestamp = Instant.now(clock).toEpochMilli();
 
         Metric metric = Metric.builder()
                 .namespace(NAMESPACE)
-                .name(METRIC_SUBSCRIBE_TO_CERTIFICATE_UPDATES_SUCCESS)
+                .name(metricName)
                 .unit(TelemetryUnit.Count)
                 .aggregation(TelemetryAggregation.Sum)
-                .value(subscribeToCertificateUpdatesSuccess.getAndSet(0L))
+                .value(metricValue.getAndSet(0L))
                 .timestamp(timestamp)
                 .build();
-        metricsList.add(metric);
 
-        metric = Metric.builder()
-                .namespace(NAMESPACE)
-                .name(METRIC_SUBSCRIBE_TO_CERTIFICATE_UPDATES_FAILURE)
-                .unit(TelemetryUnit.Count)
-                .aggregation(TelemetryAggregation.Sum)
-                .value(subscribeToCertificateUpdatesFailure.getAndSet(0L))
-                .timestamp(timestamp)
-                .build();
-        metricsList.add(metric);
-
-        metric = Metric.builder()
-                .namespace(NAMESPACE)
-                .name(METRIC_VERIFY_CLIENT_DEVICE_IDENTITY_SUCCESS)
-                .unit(TelemetryUnit.Count)
-                .aggregation(TelemetryAggregation.Sum)
-                .value(verifyClientDeviceIdentitySuccess.getAndSet(0L))
-                .timestamp(timestamp)
-                .build();
-        metricsList.add(metric);
-
-        metric = Metric.builder()
-                .namespace(NAMESPACE)
-                .name(METRIC_VERIFY_CLIENT_DEVICE_IDENTITY_FAILURE)
-                .unit(TelemetryUnit.Count)
-                .aggregation(TelemetryAggregation.Sum)
-                .value(verifyClientDeviceIdentityFailure.getAndSet(0L))
-                .timestamp(timestamp)
-                .build();
-        metricsList.add(metric);
-
-        return metricsList;
+        return metric;
     }
 
     /**
@@ -134,5 +189,19 @@ public class ClientDeviceAuthMetrics {
      */
     public void verifyDeviceIdentityFailure() {
         verifyClientDeviceIdentityFailure.incrementAndGet();
+    }
+
+     /**
+     * Increments the AuthorizeClientDeviceAction.Success metric.
+     */
+    public void authorizeActionSuccess() {
+        authorizeClientDeviceActionSuccess.incrementAndGet();
+    }
+
+    /**
+     * Increments the AuthorizeClientDeviceAction.Failure metric.
+     */
+    public void authorizeActionFailure() {
+        authorizeClientDeviceActionFailure.incrementAndGet();
     }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/ClientDeviceAuthMetrics.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/ClientDeviceAuthMetrics.java
@@ -68,36 +68,69 @@ public class ClientDeviceAuthMetrics {
      */
     public List<Metric> collectMetrics() {
         List<Metric> metricsList = new ArrayList<>();
-
-        metricsList.add(buildMetric(METRIC_SUBSCRIBE_TO_CERTIFICATE_UPDATES_SUCCESS,
-                subscribeToCertificateUpdatesSuccess));
-        metricsList.add(buildMetric(METRIC_SUBSCRIBE_TO_CERTIFICATE_UPDATES_FAILURE,
-                subscribeToCertificateUpdatesFailure));
-        metricsList.add(buildMetric(METRIC_VERIFY_CLIENT_DEVICE_IDENTITY_SUCCESS,
-                verifyClientDeviceIdentitySuccess));
-        metricsList.add(buildMetric(METRIC_VERIFY_CLIENT_DEVICE_IDENTITY_FAILURE,
-                verifyClientDeviceIdentityFailure));
-        metricsList.add(buildMetric(METRIC_AUTHORIZE_CLIENT_DEVICE_ACTIONS_SUCCESS,
-                authorizeClientDeviceActionSuccess));
-        metricsList.add(buildMetric(METRIC_AUTHORIZE_CLIENT_DEVICE_ACTIONS_FAILURE,
-                authorizeClientDeviceActionFailure));
-
-        return metricsList;
-    }
-
-    private Metric buildMetric(String metricName, AtomicLong metricValue) {
         long timestamp = Instant.now(clock).toEpochMilli();
 
         Metric metric = Metric.builder()
                 .namespace(NAMESPACE)
-                .name(metricName)
+                .name(METRIC_SUBSCRIBE_TO_CERTIFICATE_UPDATES_SUCCESS)
                 .unit(TelemetryUnit.Count)
                 .aggregation(TelemetryAggregation.Sum)
-                .value(metricValue.getAndSet(0L))
+                .value(subscribeToCertificateUpdatesSuccess.getAndSet(0L))
                 .timestamp(timestamp)
                 .build();
+        metricsList.add(metric);
 
-        return metric;
+        metric = Metric.builder()
+                .namespace(NAMESPACE)
+                .name(METRIC_SUBSCRIBE_TO_CERTIFICATE_UPDATES_FAILURE)
+                .unit(TelemetryUnit.Count)
+                .aggregation(TelemetryAggregation.Sum)
+                .value(subscribeToCertificateUpdatesFailure.getAndSet(0L))
+                .timestamp(timestamp)
+                .build();
+        metricsList.add(metric);
+
+        metric = Metric.builder()
+                .namespace(NAMESPACE)
+                .name(METRIC_VERIFY_CLIENT_DEVICE_IDENTITY_SUCCESS)
+                .unit(TelemetryUnit.Count)
+                .aggregation(TelemetryAggregation.Sum)
+                .value(verifyClientDeviceIdentitySuccess.getAndSet(0L))
+                .timestamp(timestamp)
+                .build();
+        metricsList.add(metric);
+
+        metric = Metric.builder()
+                .namespace(NAMESPACE)
+                .name(METRIC_VERIFY_CLIENT_DEVICE_IDENTITY_FAILURE)
+                .unit(TelemetryUnit.Count)
+                .aggregation(TelemetryAggregation.Sum)
+                .value(verifyClientDeviceIdentityFailure.getAndSet(0L))
+                .timestamp(timestamp)
+                .build();
+        metricsList.add(metric);
+
+        metric = Metric.builder()
+                .namespace(NAMESPACE)
+                .name(METRIC_AUTHORIZE_CLIENT_DEVICE_ACTIONS_SUCCESS)
+                .unit(TelemetryUnit.Count)
+                .aggregation(TelemetryAggregation.Sum)
+                .value(authorizeClientDeviceActionSuccess.getAndSet(0L))
+                .timestamp(timestamp)
+                .build();
+        metricsList.add(metric);
+
+        metric = Metric.builder()
+                .namespace(NAMESPACE)
+                .name(METRIC_AUTHORIZE_CLIENT_DEVICE_ACTIONS_FAILURE)
+                .unit(TelemetryUnit.Count)
+                .aggregation(TelemetryAggregation.Sum)
+                .value(authorizeClientDeviceActionFailure.getAndSet(0L))
+                .timestamp(timestamp)
+                .build();
+        metricsList.add(metric);
+
+        return metricsList;
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/ClientDeviceAuthMetrics.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/ClientDeviceAuthMetrics.java
@@ -82,69 +82,6 @@ public class ClientDeviceAuthMetrics {
         metricsList.add(buildMetric(METRIC_AUTHORIZE_CLIENT_DEVICE_ACTIONS_FAILURE,
                 authorizeClientDeviceActionFailure));
 
-
-//        long timestamp = Instant.now(clock).toEpochMilli();
-//
-//        Metric metric = Metric.builder()
-//                .namespace(NAMESPACE)
-//                .name(METRIC_SUBSCRIBE_TO_CERTIFICATE_UPDATES_SUCCESS)
-//                .unit(TelemetryUnit.Count)
-//                .aggregation(TelemetryAggregation.Sum)
-//                .value(subscribeToCertificateUpdatesSuccess.getAndSet(0L))
-//                .timestamp(timestamp)
-//                .build();
-//        metricsList.add(metric);
-//
-//        metric = Metric.builder()
-//                .namespace(NAMESPACE)
-//                .name(METRIC_SUBSCRIBE_TO_CERTIFICATE_UPDATES_FAILURE)
-//                .unit(TelemetryUnit.Count)
-//                .aggregation(TelemetryAggregation.Sum)
-//                .value(subscribeToCertificateUpdatesFailure.getAndSet(0L))
-//                .timestamp(timestamp)
-//                .build();
-//        metricsList.add(metric);
-//
-//        metric = Metric.builder()
-//                .namespace(NAMESPACE)
-//                .name(METRIC_VERIFY_CLIENT_DEVICE_IDENTITY_SUCCESS)
-//                .unit(TelemetryUnit.Count)
-//                .aggregation(TelemetryAggregation.Sum)
-//                .value(verifyClientDeviceIdentitySuccess.getAndSet(0L))
-//                .timestamp(timestamp)
-//                .build();
-//        metricsList.add(metric);
-//
-//        metric = Metric.builder()
-//                .namespace(NAMESPACE)
-//                .name(METRIC_VERIFY_CLIENT_DEVICE_IDENTITY_FAILURE)
-//                .unit(TelemetryUnit.Count)
-//                .aggregation(TelemetryAggregation.Sum)
-//                .value(verifyClientDeviceIdentityFailure.getAndSet(0L))
-//                .timestamp(timestamp)
-//                .build();
-//        metricsList.add(metric);
-//
-//        metric = Metric.builder()
-//                .namespace(NAMESPACE)
-//                .name(METRIC_AUTHORIZE_CLIENT_DEVICE_ACTIONS_SUCCESS)
-//                .unit(TelemetryUnit.Count)
-//                .aggregation(TelemetryAggregation.Sum)
-//                .value(authorizeClientDeviceActionSuccess.getAndSet(0L))
-//                .timestamp(timestamp)
-//                .build();
-//        metricsList.add(metric);
-//
-//        metric = Metric.builder()
-//                .namespace(NAMESPACE)
-//                .name(METRIC_AUTHORIZE_CLIENT_DEVICE_ACTIONS_FAILURE)
-//                .unit(TelemetryUnit.Count)
-//                .aggregation(TelemetryAggregation.Sum)
-//                .value(authorizeClientDeviceActionFailure.getAndSet(0L))
-//                .timestamp(timestamp)
-//                .build();
-//        metricsList.add(metric);
-
         return metricsList;
     }
 

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/handlers/AuthorizeClientDeviceActionsMetricHandler.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/handlers/AuthorizeClientDeviceActionsMetricHandler.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.metrics.handlers;
+
+import com.aws.greengrass.clientdevices.auth.api.AuthorizeClientDeviceActionEvent;
+import com.aws.greengrass.clientdevices.auth.api.DomainEvents;
+import com.aws.greengrass.clientdevices.auth.metrics.ClientDeviceAuthMetrics;
+
+import java.util.function.Consumer;
+import javax.inject.Inject;
+
+public class AuthorizeClientDeviceActionsMetricHandler implements Consumer<AuthorizeClientDeviceActionEvent> {
+    private final DomainEvents domainEvents;
+    private final ClientDeviceAuthMetrics metrics;
+
+    /**
+     * Create metric handler for the Authorize Client Device Actions API
+     *
+     * @param domainEvents Domain event router
+     * @param metrics      Client Device Auth metrics
+     */
+    @Inject
+    public AuthorizeClientDeviceActionsMetricHandler(DomainEvents domainEvents, ClientDeviceAuthMetrics metrics) {
+        this.domainEvents = domainEvents;
+        this.metrics = metrics;
+    }
+
+    /**
+     * Listen for metric events.
+     */
+    public void listen() {
+        domainEvents.registerListener(this, AuthorizeClientDeviceActionEvent.class);
+    }
+
+    @Override
+    public void accept(AuthorizeClientDeviceActionEvent event) {
+        if (event.getStatus() == AuthorizeClientDeviceActionEvent.AuthorizationStatus.SUCCESS) {
+            metrics.authorizeActionSuccess();
+        } else if (event.getStatus() == AuthorizeClientDeviceActionEvent.AuthorizationStatus.FAIL) {
+            metrics.authorizeActionFailure();
+        }
+    }
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/handlers/AuthorizeClientDeviceActionsMetricHandler.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/metrics/handlers/AuthorizeClientDeviceActionsMetricHandler.java
@@ -17,7 +17,7 @@ public class AuthorizeClientDeviceActionsMetricHandler implements Consumer<Autho
     private final ClientDeviceAuthMetrics metrics;
 
     /**
-     * Create metric handler for the Authorize Client Device Actions API
+     * Create metric handler for the Authorize Client Device Actions API.
      *
      * @param domainEvents Domain event router
      * @param metrics      Client Device Auth metrics


### PR DESCRIPTION
Created the AuthorizeClientDeviceActions.Success and AuthorizeClientDeviceActions.Failure metrics. When a client device action is successfully or unsuccessfully authorized, an event is emitted and handled by incrementing its respective metric. Both the event and handler are specific to the Authorize Client Device Actions API. 

This change is necessary to allow for tracking the operational status of the Authorize Client Device Actions API. The change was tested by writing unit tests which ensure that the metric is correctly incremented upon events being emitted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
