### PR TITLE
feat: add componentName session attribute

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/DeviceAuthClient.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/DeviceAuthClient.java
@@ -71,7 +71,7 @@ public class DeviceAuthClient {
                 List<X509Certificate> leafCertificate;
 
                 // Note: We are just reading the leaf certificate (the one that CDA signed and provided to the
-                // client/server component) and checking that one against out leaf level core CA certificate.
+                // client/server component) and checking that one against our leaf level core CA certificate.
                 if (is.available() > 0) {
                     try {
                         leafCertificate = Arrays.asList((X509Certificate) cf.generateCertificate(is));
@@ -135,6 +135,7 @@ public class DeviceAuthClient {
         if (session == null) {
             throw new InvalidSessionException(String.format("Invalid session ID (%s)", request.getSessionId()));
         }
+        // TODO: This can also be removed once we have proper authZ for components
         // Allow all operations from internal components
         // Keep the workaround above (ALLOW_ALL_SESSION) for Moquette since it is using the older session management
         if (session.getSessionAttribute(Component.NAMESPACE, "component") != null) {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Component.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Component.java
@@ -7,15 +7,30 @@ package com.aws.greengrass.clientdevices.auth.iot;
 
 import com.aws.greengrass.clientdevices.auth.session.attribute.AttributeProvider;
 import com.aws.greengrass.clientdevices.auth.session.attribute.DeviceAttribute;
+import com.aws.greengrass.clientdevices.auth.session.attribute.StringLiteralAttribute;
 import lombok.Value;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 @Value
-public class Component implements AttributeProvider {
+public final class Component implements AttributeProvider {
     public static final String NAMESPACE = "Component";
-    private static final Map<String, DeviceAttribute> ATTRIBUTES = Collections.singletonMap("component", expr -> true);
+    private final Map<String, DeviceAttribute> attributeMap;
+    private final String componentName;
+
+    public static Component of(String componentName) {
+        return new Component(componentName);
+    }
+
+    private Component(String componentName) {
+        Map<String, DeviceAttribute> attributes = new HashMap<>();
+        attributes.put("componentName", new StringLiteralAttribute(componentName));
+        attributes.put("component", expr -> true);
+        this.attributeMap = Collections.unmodifiableMap(attributes);
+        this.componentName = componentName;
+    }
 
     @Override
     public String getNamespace() {
@@ -24,6 +39,6 @@ public class Component implements AttributeProvider {
 
     @Override
     public Map<String, DeviceAttribute> getDeviceAttributes() {
-        return ATTRIBUTES;
+        return attributeMap;
     }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactory.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactory.java
@@ -33,7 +33,6 @@ public class MqttSessionFactory implements SessionFactory {
 
     @Override
     public Session createSession(Map<String, String> credentialMap) throws AuthenticationException {
-        // TODO: replace with jackson object mapper
         MqttCredential mqttCredential = new MqttCredential(credentialMap);
 
         boolean isGreengrassComponent = deviceAuthClient.isGreengrassComponent(mqttCredential.certificatePem);
@@ -53,7 +52,8 @@ public class MqttSessionFactory implements SessionFactory {
     }
 
     private Session createGreengrassComponentSession() {
-        return new SessionImpl(new Component());
+        // TODO: Need to extract this from the certificate
+        return new SessionImpl(Component.of("aws.greengrass.clientdevices.mqtt.Bridge"));
     }
 
     private static class MqttCredential {

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/DeviceAuthClientTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/DeviceAuthClientTest.java
@@ -35,6 +35,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith({MockitoExtension.class, GGExtension.class})
 public class DeviceAuthClientTest {
+    private static final String componentName = "aws.greengrass.clientdevices.testComponent";
 
     @InjectMocks
     private DeviceAuthClient authClient;
@@ -96,7 +97,7 @@ public class DeviceAuthClientTest {
 
     @Test
     void GIVEN_internalClientSession_WHEN_canDevicePerform_THEN_authorizationReturnTrue() throws Exception {
-        Session session = new SessionImpl(new Component());
+        Session session = new SessionImpl(Component.of(componentName));
         when(sessionManager.findSession("sessionId")).thenReturn(session);
 
         boolean authorized = authClient.canDevicePerform(constructAuthorizationRequest());


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adds componentName attribute to the Component session object. This will enable us to look up authZ policies based on component name in the future.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
