### PR TITLE
feat: cache connectivity info

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/connectivity/ConnectivityTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/connectivity/ConnectivityTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.integrationtests.connectivity;
+
+import com.aws.greengrass.clientdevices.auth.ClientDevicesAuthService;
+import com.aws.greengrass.clientdevices.auth.api.UseCases;
+import com.aws.greengrass.clientdevices.auth.connectivity.HostAddress;
+import com.aws.greengrass.clientdevices.auth.connectivity.RecordConnectivityChangesRequest;
+import com.aws.greengrass.clientdevices.auth.connectivity.usecases.RecordConnectivityChangesUseCase;
+import com.aws.greengrass.clientdevices.auth.helpers.CertificateTestHelpers;
+import com.aws.greengrass.clientdevices.auth.infra.NetworkStateProvider;
+import com.aws.greengrass.clientdevices.auth.iot.IotAuthClient;
+import com.aws.greengrass.clientdevices.auth.iot.IotAuthClientFake;
+import com.aws.greengrass.clientdevices.auth.iot.NetworkStateFake;
+import com.aws.greengrass.dependency.Crashable;
+import com.aws.greengrass.dependency.State;
+import com.aws.greengrass.integrationtests.ipc.IPCTestUtils;
+import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
+import com.aws.greengrass.lifecyclemanager.GreengrassService;
+import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.logging.impl.config.LogConfig;
+import com.aws.greengrass.mqttclient.spool.SpoolerStoreException;
+import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.testcommons.testutilities.UniqueRootPathExtension;
+import com.aws.greengrass.util.CrashableFunction;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCClient;
+import software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCClientV2;
+import software.amazon.awssdk.aws.greengrass.model.CertificateOptions;
+import software.amazon.awssdk.aws.greengrass.model.CertificateType;
+import software.amazon.awssdk.aws.greengrass.model.SubscribeToCertificateUpdatesRequest;
+import software.amazon.awssdk.eventstreamrpc.EventStreamRPCConnection;
+
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.security.cert.X509Certificate;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith({GGExtension.class, UniqueRootPathExtension.class, MockitoExtension.class})
+public class ConnectivityTest {
+
+    NetworkStateFake networkState;
+    @TempDir
+    Path rootDir;
+    Kernel kernel;
+
+    @BeforeEach
+    void beforeEach(ExtensionContext context) {
+        ignoreExceptionOfType(context, SpoolerStoreException.class);
+        // expected when creating the keystore for the first time
+        ignoreExceptionOfType(context, NoSuchFileException.class);
+        networkState = new NetworkStateFake();
+        setupNewKernel();
+    }
+
+    @AfterEach
+    void afterEach() {
+        LogConfig.getRootLogConfig().reset();
+        kernel.shutdown();
+    }
+
+    @Test
+    @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
+    void GIVEN_cda_starts_up_and_connectivity_information_is_acquired_WHEN_cda_restarts_offline_THEN_cached_connectivity_information_is_used() throws Exception {
+        String confFile = "config.yaml";
+        String serviceNameIpc = "BrokerSubscribingToCertUpdates";
+
+        Set<HostAddress> updatedConnectivityInfo = new HashSet<>();
+        updatedConnectivityInfo.add(HostAddress.of("123.123.123.123"));
+
+        Set<String> expectedSANs = updatedConnectivityInfo.stream()
+                .map(HostAddress::getHost)
+                .collect(Collectors.toSet());
+        expectedSANs.add("localhost");
+
+        // start up nucleus
+        startNucleusWithConfig(confFile);
+
+        // update connectivity info
+        // TODO replace with CIS shadow update to make this more of an integration test
+        kernel.getContext().get(UseCases.class).get(RecordConnectivityChangesUseCase.class)
+                .apply(new RecordConnectivityChangesRequest("source", updatedConnectivityInfo));
+
+        // wait until server certificate is generated.
+        // ensure that it has the ip address we configure
+        withServerCert(serviceNameIpc, cert ->
+                () -> assertEquals(expectedSANs, dnsNamesFromSAN(cert.getSubjectAlternativeNames())));
+
+        // shutdown the nucleus
+        kernel.shutdown();
+
+        // take greengrass offline
+        networkState.goOffline();
+        kernel.getContext().put(NetworkStateProvider.class, networkState);
+
+        // start the nucleus offline
+        restartNucleus();
+
+        // verify that server cert is still generated with the proper SANs
+        withServerCert(serviceNameIpc, cert ->
+                () -> assertEquals(expectedSANs, dnsNamesFromSAN(cert.getSubjectAlternativeNames())));
+    }
+
+    private void setupNewKernel() {
+        // Set this property for kernel to scan its own classpath to find plugins
+        System.setProperty("aws.greengrass.scanSelfClasspath", "true");
+        kernel = new Kernel();
+
+        // Set up Iot auth client
+        IotAuthClientFake iotAuthClientFake = new IotAuthClientFake();
+        kernel.getContext().put(IotAuthClient.class, iotAuthClientFake);
+    }
+
+    private void startNucleusWithConfig(String configFileName) throws InterruptedException {
+        startNucleusWithConfig(configFileName, ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME, State.RUNNING);
+    }
+
+    private void restartNucleus() throws InterruptedException {
+        setupNewKernel();
+        startNucleusWithConfig(null, ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME, State.RUNNING);
+    }
+
+    private void startNucleusWithConfig(String configFileName, String serviceName, State desiredServiceState)
+            throws InterruptedException {
+        CountDownLatch serviceReachedDesiredState = new CountDownLatch(1);
+
+        String[] args = configFileName == null
+                ? new String[]{"-r", rootDir.toAbsolutePath().toString()}
+                : new String[]{"-r", rootDir.toAbsolutePath().toString(),
+                "-i", getClass().getResource(configFileName).toString()};
+
+        kernel.parseArgs(args);
+
+        GlobalStateChangeListener listener = (GreengrassService service, State was, State newState) -> {
+            if (service.getName().equals(serviceName) && service.getState().equals(desiredServiceState)) {
+                serviceReachedDesiredState.countDown();
+            }
+        };
+        kernel.getContext().addGlobalStateChangeListener(listener);
+        try {
+            kernel.launch();
+            assertThat(serviceReachedDesiredState.await(30L, TimeUnit.SECONDS), is(true));
+        } finally {
+            kernel.getContext().removeGlobalStateChangeListener(listener);
+        }
+    }
+
+    @SuppressWarnings("PMD.AvoidCatchingThrowable")
+    private void withServerCert(String serviceNameIpc, CrashableFunction<X509Certificate, Crashable, Exception> operation)
+            throws Exception {
+        withIPCClient(serviceNameIpc, client -> {
+            CountDownLatch operationComplete = new CountDownLatch(1);
+
+            SubscribeToCertificateUpdatesRequest subscribeRequest = new SubscribeToCertificateUpdatesRequest()
+                    .withCertificateOptions(new CertificateOptions().withCertificateType(CertificateType.SERVER));
+            client.subscribeToCertificateUpdates(
+                    subscribeRequest,
+                    certUpdate -> {
+                        try {
+                            List<X509Certificate>  cert = CertificateTestHelpers.loadX509Certificate(
+                                    certUpdate.getCertificateUpdate().getCertificate());
+                            assertFalse(cert.isEmpty());
+                            operation.apply(cert.get(0)).run();
+                            operationComplete.countDown();
+                        } catch (Throwable e) {
+                            throw new RuntimeException(e);
+                        }
+                    },
+                    Optional.of((ignore) -> null),
+                    Optional.of(() -> {})
+            );
+
+            assertTrue(operationComplete.await(10L, TimeUnit.SECONDS));
+            return null;
+        });
+    }
+
+    private void withIPCClient(String serviceName, CrashableFunction<GreengrassCoreIPCClientV2, Void, Exception> action)
+            throws Exception {
+        try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
+                serviceName);
+             GreengrassCoreIPCClientV2 client = GreengrassCoreIPCClientV2.builder()
+                     .withClient(new GreengrassCoreIPCClient(connection))
+                     .build()) {
+            action.apply(client);
+        }
+    }
+
+    private static Set<String> dnsNamesFromSAN(Collection<List<?>> sans) {
+        if (sans == null) {
+            return Collections.emptySet();
+        }
+        return sans.stream()
+                .filter(entry -> {
+                    int dnsNameKey = 2;
+                    int ipAddressKey = 7;
+                    return entry.size() >= 2
+                            && (Objects.equals(entry.get(0), dnsNameKey) || Objects.equals(entry.get(0), ipAddressKey));
+                })
+                .flatMap(entry -> entry.subList(1, entry.size()).stream())
+                .map(String::valueOf)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/connectivity/config.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/connectivity/config.yaml
@@ -1,0 +1,64 @@
+---
+services:
+  aws.greengrass.Nucleus:
+    configuration:
+      runWithDefault:
+        posixUser: nobody
+        windowsUser: integ-tester
+      logging:
+        level: "DEBUG"
+  aws.greengrass.clientdevices.Auth:
+    configuration:
+      deviceGroups:
+        formatVersion: "2021-03-05"
+        definitions:
+          myTemperatureSensors:
+            selectionRule: "thingName:mySensor1 OR thingName:mySensor2"
+            policyName: "sensorAccessPolicy"
+          myHumiditySensors:
+            selectionRule: "thingName:mySensor3 OR thingName:mySensor4"
+            policyName: "sensorAccessPolicy"
+        policies:
+          sensorAccessPolicy:
+            policyStatement1:
+              statementDescription: "mqtt connect"
+              effect: ALLOW
+              operations:
+                - "mqtt:connect"
+              resources:
+                - "mqtt:clientId:foo"
+            policyStatement2:
+              statementDescription: "mqtt publish"
+              operations:
+                - "mqtt:publish"
+              resources:
+                - "mqtt:topic:temperature"
+                - "mqtt:topic:humidity"
+  main:
+    dependencies:
+      - BrokerSubscribingToCertUpdates
+  BrokerSubscribingToCertUpdates:
+    dependencies:
+      - aws.greengrass.clientdevices.Auth
+    lifecycle:
+      run:
+        windows:
+          powershell -command sleep 1
+        posix:
+          sleep 1
+    configuration:
+      accessControl:
+        aws.greengrass.clientdevices.Auth:
+          policyId1:
+            policyDescription: access to certificate updates
+            operations:
+              - '*'
+            resources:
+              - '*'
+        aws.greengrass.ipc.pubsub:
+          policyId2:
+            policyDescription: access to pubsub topics for ServiceName
+            operations:
+              - '*'
+            resources:
+              - '*'

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -20,6 +20,7 @@ import com.aws.greengrass.clientdevices.auth.configuration.GroupManager;
 import com.aws.greengrass.clientdevices.auth.configuration.MetricsConfiguration;
 import com.aws.greengrass.clientdevices.auth.configuration.RuntimeConfiguration;
 import com.aws.greengrass.clientdevices.auth.connectivity.CISShadowMonitor;
+import com.aws.greengrass.clientdevices.auth.connectivity.ConnectivityInfoCache;
 import com.aws.greengrass.clientdevices.auth.infra.NetworkStateProvider;
 import com.aws.greengrass.clientdevices.auth.metrics.MetricsEmitter;
 import com.aws.greengrass.clientdevices.auth.metrics.handlers.AuthorizeClientDeviceActionsMetricHandler;
@@ -101,6 +102,8 @@ public class ClientDevicesAuthService extends PluginService {
 
         context.get(UseCases.class).init(context);
         context.get(CertificateManager.class).updateCertificatesConfiguration(new CertificatesConfig(getConfig()));
+        context.get(ConnectivityInfoCache.class)
+                .setRuntimeTopics(getConfig().lookupTopics(RUNTIME_STORE_NAMESPACE_TOPIC));
         initializeInfrastructure();
         initializeHandlers();
         subscribeToConfigChanges();

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -102,8 +102,6 @@ public class ClientDevicesAuthService extends PluginService {
 
         context.get(UseCases.class).init(context);
         context.get(CertificateManager.class).updateCertificatesConfiguration(new CertificatesConfig(getConfig()));
-        context.get(ConnectivityInfoCache.class)
-                .setRuntimeTopics(getConfig().lookupTopics(RUNTIME_STORE_NAMESPACE_TOPIC));
         initializeInfrastructure();
         initializeHandlers();
         subscribeToConfigChanges();
@@ -124,7 +122,9 @@ public class ClientDevicesAuthService extends PluginService {
 
     private void initializeInfrastructure() {
         // Infra setup
-        context.put(RuntimeConfiguration.class, RuntimeConfiguration.from(getRuntimeConfig()));
+        RuntimeConfiguration runtimeConfiguration = RuntimeConfiguration.from(getRuntimeConfig());
+        context.put(RuntimeConfiguration.class, runtimeConfiguration);
+        context.get(ConnectivityInfoCache.class).setRuntimeConfiguration(runtimeConfiguration);
         NetworkStateProvider networkState = context.get(NetworkStateProvider.class);
         networkState.registerHandler(context.get(CISShadowMonitor.class));
         networkState.registerHandler(context.get(BackgroundCertificateRefresh.class));

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/RuntimeConfiguration.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/RuntimeConfiguration.java
@@ -261,7 +261,7 @@ public final class RuntimeConfiguration {
     }
 
     /**
-     * Put hostAddresses config
+     * Put hostAddresses config.
      *
      * @param source         connectivity information source
      * @param hostAddresses  host addresses
@@ -276,7 +276,7 @@ public final class RuntimeConfiguration {
     }
 
     /**
-     * Get aggregated hostAddresses config
+     * Get aggregated hostAddresses config.
      *
      * @return set of host addresses
      */

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/RuntimeConfiguration.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/RuntimeConfiguration.java
@@ -5,19 +5,25 @@
 
 package com.aws.greengrass.clientdevices.auth.configuration;
 
+import com.aws.greengrass.clientdevices.auth.connectivity.HostAddress;
 import com.aws.greengrass.clientdevices.auth.iot.dto.CertificateV1DTO;
 import com.aws.greengrass.clientdevices.auth.iot.dto.ThingV1DTO;
 import com.aws.greengrass.config.Node;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.config.UpdateBehaviorTree;
 import com.aws.greengrass.util.Coerce;
 import lombok.NonNull;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -39,6 +45,9 @@ import java.util.stream.Stream;
  * |                |---- certificateId:
  * |                      |---- "s": status
  * |                      |---- "l": lastUpdated
+ * |    |---- "hostAddresses":
+ *            |---- <source>:
+ *                 |---- [...]
  * </p>
  */
 public final class RuntimeConfiguration {
@@ -52,6 +61,9 @@ public final class RuntimeConfiguration {
     static final String CERTS_V1_KEY = "v1";
     static final String CERTS_STATUS_KEY = "s";
     static final String CERTS_STATUS_UPDATED_KEY = "l";
+    private static final String HOST_ADDRESSES_KEY = "hostAddresses";
+    private static final UpdateBehaviorTree HOST_ADDRESSES_UPDATE_BEHAVIOR =
+            new UpdateBehaviorTree(UpdateBehaviorTree.UpdateBehavior.REPLACE, System.currentTimeMillis());
 
     private final Topics config;
 
@@ -246,5 +258,51 @@ public final class RuntimeConfiguration {
 
         return v1CertTopics.children.keySet().stream().map(Coerce::toString).map(this::getCertificateV1)
                 .map(Optional::get);
+    }
+
+    /**
+     * Put hostAddresses config
+     *
+     * @param source         connectivity information source
+     * @param hostAddresses  host addresses
+     */
+    public void putHostAddressForSource(String source, Set<HostAddress> hostAddresses) {
+        Map<String, Object> hostAddressesToMerge = new HashMap<>();
+        hostAddressesToMerge.put(
+                source,
+                hostAddresses.stream().map(HostAddress::getHost).collect(Collectors.toList()));
+        config.lookupTopics(HOST_ADDRESSES_KEY, source)
+                .updateFromMap(hostAddressesToMerge, HOST_ADDRESSES_UPDATE_BEHAVIOR);
+    }
+
+    /**
+     * Get aggregated hostAddresses config
+     *
+     * @return set of host addresses
+     */
+    public Set<HostAddress> getAggregatedHostAddresses() {
+        Topics hostAddressesTopics = config.lookupTopics(HOST_ADDRESSES_KEY);
+        if (hostAddressesTopics == null) {
+            return Collections.emptySet();
+        }
+
+        Set<HostAddress> connectivityInfo = new HashSet<>();
+        for (Object addrsBySource : hostAddressesTopics.toPOJO().values()) {
+            if (!(addrsBySource instanceof Map)) {
+                continue;
+            }
+            for (Object addrs : ((Map<?,?>) addrsBySource).values()) {
+                if (!(addrs instanceof Collection)) {
+                    continue;
+                }
+                for (Object addr : (Collection<?>) addrs) {
+                    if (!(addr instanceof String)) {
+                        continue;
+                    }
+                    connectivityInfo.add(HostAddress.of((String) addr));
+                }
+            }
+        }
+        return connectivityInfo;
     }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/RuntimeConfiguration.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/RuntimeConfiguration.java
@@ -62,7 +62,6 @@ public final class RuntimeConfiguration {
     static final String CERTS_STATUS_KEY = "s";
     static final String CERTS_STATUS_UPDATED_KEY = "l";
     private static final String HOST_ADDRESSES_KEY = "hostAddresses";
-            ;
 
     private final Topics config;
 

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/RuntimeConfiguration.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/RuntimeConfiguration.java
@@ -62,8 +62,7 @@ public final class RuntimeConfiguration {
     static final String CERTS_STATUS_KEY = "s";
     static final String CERTS_STATUS_UPDATED_KEY = "l";
     private static final String HOST_ADDRESSES_KEY = "hostAddresses";
-    private static final UpdateBehaviorTree HOST_ADDRESSES_UPDATE_BEHAVIOR =
-            new UpdateBehaviorTree(UpdateBehaviorTree.UpdateBehavior.REPLACE, System.currentTimeMillis());
+            ;
 
     private final Topics config;
 
@@ -272,7 +271,9 @@ public final class RuntimeConfiguration {
                 source,
                 hostAddresses.stream().map(HostAddress::getHost).collect(Collectors.toList()));
         config.lookupTopics(HOST_ADDRESSES_KEY, source)
-                .updateFromMap(hostAddressesToMerge, HOST_ADDRESSES_UPDATE_BEHAVIOR);
+                .updateFromMap(hostAddressesToMerge,
+                        new UpdateBehaviorTree(UpdateBehaviorTree.UpdateBehavior.REPLACE,
+                                System.currentTimeMillis()));
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/ConnectivityInfoCache.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/ConnectivityInfoCache.java
@@ -5,25 +5,15 @@
 
 package com.aws.greengrass.clientdevices.auth.connectivity;
 
-import com.aws.greengrass.config.Topics;
-import com.aws.greengrass.config.UpdateBehaviorTree;
+import com.aws.greengrass.clientdevices.auth.configuration.RuntimeConfiguration;
 import lombok.Setter;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class ConnectivityInfoCache {
-    private static final String HOST_ADDRESSES_TOPIC = "hostAddresses";
-    private static final UpdateBehaviorTree HOST_ADDRESSES_UPDATE_BEHAVIOR =
-            new UpdateBehaviorTree(UpdateBehaviorTree.UpdateBehavior.REPLACE, System.currentTimeMillis());
 
     @Setter
-    private Topics runtimeTopics;
+    private RuntimeConfiguration runtimeConfiguration;
 
     /**
      * Cache connectivity information by source.
@@ -32,12 +22,7 @@ public class ConnectivityInfoCache {
      * @param connectivityInfo connectivity information
      */
     public void put(String source, Set<HostAddress> connectivityInfo) {
-        Map<String, Object> hostAddressesToMerge = new HashMap<>();
-        hostAddressesToMerge.put(
-                source,
-                connectivityInfo.stream().map(HostAddress::getHost).collect(Collectors.toList()));
-        runtimeTopics.lookupTopics(HOST_ADDRESSES_TOPIC, source)
-                .updateFromMap(hostAddressesToMerge, HOST_ADDRESSES_UPDATE_BEHAVIOR);
+        runtimeConfiguration.putHostAddressForSource(source, connectivityInfo);
     }
 
     /**
@@ -46,28 +31,6 @@ public class ConnectivityInfoCache {
      * @return connectivity information
      */
     public Set<HostAddress> getAll() {
-        Topics hostAddressesTopics = runtimeTopics.lookupTopics(HOST_ADDRESSES_TOPIC);
-        if (hostAddressesTopics == null) {
-            return Collections.emptySet();
-        }
-
-        Set<HostAddress> connectivityInfo = new HashSet<>();
-        for (Object addrsBySource : hostAddressesTopics.toPOJO().values()) {
-            if (!(addrsBySource instanceof Map)) {
-                continue;
-            }
-            for (Object addrs : ((Map<?,?>) addrsBySource).values()) {
-                if (!(addrs instanceof Collection)) {
-                    continue;
-                }
-                for (Object addr : (Collection<?>) addrs) {
-                    if (!(addr instanceof String)) {
-                        continue;
-                    }
-                    connectivityInfo.add(HostAddress.of((String) addr));
-                }
-            }
-        }
-        return connectivityInfo;
+        return runtimeConfiguration.getAggregatedHostAddresses();
     }
 }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/ConnectivityInfoCache.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/ConnectivityInfoCache.java
@@ -9,8 +9,8 @@ import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.util.Utils;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Setter;
 
-import javax.inject.Inject;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -18,20 +18,14 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.aws.greengrass.lifecyclemanager.GreengrassService.RUNTIME_STORE_NAMESPACE_TOPIC;
-
 public class ConnectivityInfoCache {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private static final String HOST_ADDRESSES_TOPIC = "hostAddresses";
 
-    private final Topics runtimeTopics;
-
-    @Inject
-    public ConnectivityInfoCache(Topics topics) {
-        this.runtimeTopics = topics.lookupTopics(RUNTIME_STORE_NAMESPACE_TOPIC);
-    }
+    @Setter
+    private Topics runtimeTopics;
 
     public void put(String source, Set<HostAddress> connectivityInfo) {
         runtimeTopics.lookupTopics(HOST_ADDRESSES_TOPIC).lookup(source)
@@ -49,7 +43,8 @@ public class ConnectivityInfoCache {
         Map<String, String> hostAddresses;
         try {
             hostAddresses = MAPPER.convertValue(hostAddressesTopics.toPOJO(),
-                    new TypeReference<Map<String, String>>(){});
+                    new TypeReference<Map<String, String>>() {
+                    });
         } catch (IllegalArgumentException e) {
             return Collections.emptySet();
         }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/ConnectivityInfoCache.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/ConnectivityInfoCache.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.connectivity;
+
+import com.aws.greengrass.config.Topics;
+import com.aws.greengrass.util.Utils;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.inject.Inject;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.aws.greengrass.lifecyclemanager.GreengrassService.RUNTIME_STORE_NAMESPACE_TOPIC;
+
+public class ConnectivityInfoCache {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final String HOST_ADDRESSES_TOPIC = "hostAddresses";
+
+    private final Topics runtimeTopics;
+
+    @Inject
+    public ConnectivityInfoCache(Topics topics) {
+        this.runtimeTopics = topics.lookupTopics(RUNTIME_STORE_NAMESPACE_TOPIC);
+    }
+
+    public void put(String source, Set<HostAddress> connectivityInfo) {
+        runtimeTopics.lookupTopics(HOST_ADDRESSES_TOPIC).lookup(source)
+                .withValue(connectivityInfo.stream()
+                        .map(HostAddress::getHost)
+                        .collect(Collectors.joining(",")));
+    }
+
+    public Set<HostAddress> getAll() {
+        Topics hostAddressesTopics = runtimeTopics.lookupTopics(HOST_ADDRESSES_TOPIC);
+        if (hostAddressesTopics == null) {
+            return Collections.emptySet();
+        }
+
+        Map<String, String> hostAddresses;
+        try {
+            hostAddresses = MAPPER.convertValue(hostAddressesTopics.toPOJO(),
+                    new TypeReference<Map<String, String>>(){});
+        } catch (IllegalArgumentException e) {
+            return Collections.emptySet();
+        }
+
+        return hostAddresses.values().stream()
+                .filter(Utils::isNotEmpty)
+                .map(addrs -> Arrays.asList(addrs.split(",")))
+                .flatMap(List::stream)
+                .map(HostAddress::of)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/ConnectivityInfoCache.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/ConnectivityInfoCache.java
@@ -23,17 +23,29 @@ public class ConnectivityInfoCache {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private static final String HOST_ADDRESSES_TOPIC = "hostAddresses";
+    private static final String HOST_ADDRESSES_DELIMITER = ",";
 
     @Setter
     private Topics runtimeTopics;
 
+    /**
+     * Cache connectivity information by source.
+     *
+     * @param source           source
+     * @param connectivityInfo connectivity information
+     */
     public void put(String source, Set<HostAddress> connectivityInfo) {
         runtimeTopics.lookupTopics(HOST_ADDRESSES_TOPIC).lookup(source)
                 .withValue(connectivityInfo.stream()
                         .map(HostAddress::getHost)
-                        .collect(Collectors.joining(",")));
+                        .collect(Collectors.joining(HOST_ADDRESSES_DELIMITER)));
     }
 
+    /**
+     * Get aggregated connectivity information from cache.
+     *
+     * @return connectivity information
+     */
     public Set<HostAddress> getAll() {
         Topics hostAddressesTopics = runtimeTopics.lookupTopics(HOST_ADDRESSES_TOPIC);
         if (hostAddressesTopics == null) {
@@ -51,7 +63,7 @@ public class ConnectivityInfoCache {
 
         return hostAddresses.values().stream()
                 .filter(Utils::isNotEmpty)
-                .map(addrs -> Arrays.asList(addrs.split(",")))
+                .map(addrs -> Arrays.asList(addrs.split(HOST_ADDRESSES_DELIMITER)))
                 .flatMap(List::stream)
                 .map(HostAddress::of)
                 .collect(Collectors.toSet());

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/ConnectivityInformation.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/ConnectivityInformation.java
@@ -34,9 +34,6 @@ public class ConnectivityInformation {
     private final GreengrassServiceClientFactory clientFactory;
     private final ConnectivityInfoCache connectivityInfoCache;
 
-    // TODO: Legacy structure to be removed later
-    protected volatile List<String> cachedHostAddresses = Collections.emptyList();
-
     private final Map<String, Set<HostAddress>> connectivityInformationMap = new ConcurrentHashMap<>();
 
 

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/ConnectivityInformation.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/ConnectivityInformation.java
@@ -16,7 +16,6 @@ import software.amazon.awssdk.services.greengrassv2data.model.GetConnectivityInf
 import software.amazon.awssdk.services.greengrassv2data.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.greengrassv2data.model.ValidationException;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +32,7 @@ public class ConnectivityInformation {
 
     private final DeviceConfiguration deviceConfiguration;
     private final GreengrassServiceClientFactory clientFactory;
+    private final ConnectivityInfoCache connectivityInfoCache;
 
     // TODO: Legacy structure to be removed later
     protected volatile List<String> cachedHostAddresses = Collections.emptyList();
@@ -43,14 +43,17 @@ public class ConnectivityInformation {
     /**
      * Constructor.
      *
-     * @param deviceConfiguration client to get the device details
-     * @param clientFactory       factory to get data plane client
+     * @param deviceConfiguration   client to get the device details
+     * @param clientFactory         factory to get data plane client
+     * @param connectivityInfoCache connectivity info cache
      */
     @Inject
     public ConnectivityInformation(DeviceConfiguration deviceConfiguration,
-                                   GreengrassServiceClientFactory clientFactory) {
+                                   GreengrassServiceClientFactory clientFactory,
+                                   ConnectivityInfoCache connectivityInfoCache) {
         this.deviceConfiguration = deviceConfiguration;
         this.clientFactory = clientFactory;
+        this.connectivityInfoCache = connectivityInfoCache;
     }
 
     /**
@@ -59,7 +62,7 @@ public class ConnectivityInformation {
      * @return list of cached connectivity info items
      */
     public List<String> getCachedHostAddresses() {
-        return cachedHostAddresses;
+        return connectivityInfoCache.getAll().stream().map(HostAddress::getHost).collect(Collectors.toList());
     }
 
     /**
@@ -79,8 +82,6 @@ public class ConnectivityInformation {
             if (getConnectivityInfoResponse.hasConnectivityInfo()) {
                 // Filter out port and metadata since it is not needed
                 connectivityInfoList = getConnectivityInfoResponse.connectivityInfo();
-                cachedHostAddresses = new ArrayList<>(
-                        connectivityInfoList.stream().map(ci -> ci.hostAddress()).collect(Collectors.toSet()));
             }
         } catch (ValidationException | ResourceNotFoundException e) {
             LOGGER.atWarn().cause(e).log("Connectivity info doesn't exist");
@@ -120,5 +121,6 @@ public class ConnectivityInformation {
         LOGGER.atInfo().kv("source", source).kv("connectivityInformation", sourceConnectivityInfo)
                 .log("Updating connectivity information");
         connectivityInformationMap.put(source, sourceConnectivityInfo);
+        connectivityInfoCache.put(source, sourceConnectivityInfo);
     }
 }

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitorTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitorTest.java
@@ -525,6 +525,7 @@ public class CISShadowMonitorTest {
         }
     }
 
+
     static class FakeConnectivityInformation extends ConnectivityInformation {
 
         private final AtomicReference<List<ConnectivityInfo>> CONNECTIVITY_INFO_SAMPLE =
@@ -532,6 +533,7 @@ public class CISShadowMonitorTest {
         private final Set<Integer> responseHashes = new CopyOnWriteArraySet<>();
         private final AtomicReference<Mode> mode = new AtomicReference<>(Mode.RANDOM);
         private final AtomicBoolean failed = new AtomicBoolean();
+        private List<String> cachedHostAddresses;
 
         enum Mode {
             /**

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitorTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitorTest.java
@@ -550,7 +550,7 @@ public class CISShadowMonitorTest {
         }
 
         FakeConnectivityInformation() {
-            super(null, null);
+            super(null, null, null);
         }
 
         void setMode(Mode mode) {

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/ConnectivityInformationTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/ConnectivityInformationTest.java
@@ -67,7 +67,8 @@ public class ConnectivityInformationTest {
         Topic thingNameTopic = Topic.of(context, DEVICE_PARAM_THING_NAME, "testThing");
         lenient().doReturn(thingNameTopic).when(deviceConfiguration).getThingName();
         lenient().when(clientFactory.getGreengrassV2DataClient()).thenReturn(greengrassV2DataClient);
-        connectivityInfoCache = new ConnectivityInfoCache(Topics.of(context, "", null));
+        connectivityInfoCache = new ConnectivityInfoCache();
+        connectivityInfoCache.setRuntimeTopics(Topics.of(context, "runtime", null));
         connectivityInformation = new ConnectivityInformation(deviceConfiguration, clientFactory, connectivityInfoCache);
     }
 

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/ConnectivityInformationTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/ConnectivityInformationTest.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.clientdevices.auth.connectivity;
 
+import com.aws.greengrass.clientdevices.auth.configuration.RuntimeConfiguration;
 import com.aws.greengrass.config.Topic;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.Context;
@@ -68,7 +69,7 @@ public class ConnectivityInformationTest {
         lenient().doReturn(thingNameTopic).when(deviceConfiguration).getThingName();
         lenient().when(clientFactory.getGreengrassV2DataClient()).thenReturn(greengrassV2DataClient);
         connectivityInfoCache = new ConnectivityInfoCache();
-        connectivityInfoCache.setRuntimeTopics(Topics.of(context, "runtime", null));
+        connectivityInfoCache.setRuntimeConfiguration(RuntimeConfiguration.from(Topics.of(context, "runtime", null)));
         connectivityInformation = new ConnectivityInformation(deviceConfiguration, clientFactory, connectivityInfoCache);
     }
 

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/ConnectivityInformationTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/ConnectivityInformationTest.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.clientdevices.auth.connectivity;
 
 import com.aws.greengrass.config.Topic;
+import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.Context;
 import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
@@ -56,6 +57,8 @@ public class ConnectivityInformationTest {
     @Mock
     private GreengrassServiceClientFactory clientFactory;
 
+    private ConnectivityInfoCache connectivityInfoCache;
+
     @Mock
     protected Context context;
 
@@ -64,7 +67,8 @@ public class ConnectivityInformationTest {
         Topic thingNameTopic = Topic.of(context, DEVICE_PARAM_THING_NAME, "testThing");
         lenient().doReturn(thingNameTopic).when(deviceConfiguration).getThingName();
         lenient().when(clientFactory.getGreengrassV2DataClient()).thenReturn(greengrassV2DataClient);
-        connectivityInformation = new ConnectivityInformation(deviceConfiguration, clientFactory);
+        connectivityInfoCache = new ConnectivityInfoCache(Topics.of(context, "", null));
+        connectivityInformation = new ConnectivityInformation(deviceConfiguration, clientFactory, connectivityInfoCache);
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/usecases/ConnectivityInformationUseCasesTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/usecases/ConnectivityInformationUseCasesTest.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.clientdevices.auth.connectivity.usecases;
 
 import com.aws.greengrass.clientdevices.auth.api.UseCases;
+import com.aws.greengrass.clientdevices.auth.connectivity.ConnectivityInfoCache;
 import com.aws.greengrass.clientdevices.auth.connectivity.HostAddress;
 import com.aws.greengrass.clientdevices.auth.connectivity.RecordConnectivityChangesRequest;
 import com.aws.greengrass.clientdevices.auth.connectivity.RecordConnectivityChangesResponse;
@@ -56,6 +57,8 @@ public class ConnectivityInformationUseCasesTest {
         Topics topics = Topics.of(context, CONFIGURATION_CONFIG_KEY, null);
         this.useCases = new UseCases(topics.getContext());
         this.useCases.init(topics.getContext());
+
+        context.get(ConnectivityInfoCache.class).setRuntimeTopics(Topics.of(context, "runtime", null));
     }
 
     @Test

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/usecases/ConnectivityInformationUseCasesTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/usecases/ConnectivityInformationUseCasesTest.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.clientdevices.auth.connectivity.usecases;
 
 import com.aws.greengrass.clientdevices.auth.api.UseCases;
+import com.aws.greengrass.clientdevices.auth.configuration.RuntimeConfiguration;
 import com.aws.greengrass.clientdevices.auth.connectivity.ConnectivityInfoCache;
 import com.aws.greengrass.clientdevices.auth.connectivity.HostAddress;
 import com.aws.greengrass.clientdevices.auth.connectivity.RecordConnectivityChangesRequest;
@@ -58,7 +59,7 @@ public class ConnectivityInformationUseCasesTest {
         this.useCases = new UseCases(topics.getContext());
         this.useCases.init(topics.getContext());
 
-        context.get(ConnectivityInfoCache.class).setRuntimeTopics(Topics.of(context, "runtime", null));
+        context.get(ConnectivityInfoCache.class).setRuntimeConfiguration(RuntimeConfiguration.from(Topics.of(context, "runtime", null)));
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Cache connectivity information so that it persists across restarts.

**Why is this change necessary:**
If greengrass is restarted offline, previous connectivity information is currently wiped out. This means the server will receive a cert with SAN for `localhost` only, missing other addresses.

**How was this change tested:**
Integration test

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
