### PR TITLE
fix: prevent hostAddresses from being cleared

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitor.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitor.java
@@ -241,9 +241,13 @@ public class CISShadowMonitor implements Consumer<NetworkStateProvider.Connectio
             }
 
             if (!connectivityInfo.isPresent()) {
+                // CIS call failed for either ValidationException or ResourceNotFoundException.
+                // We won't retry in this case, but we will update the CIS shadow reported state
+                // to signal that we have fully processed this version.
                 try {
                     updateCISShadowReportedState(desiredState);
                 } finally {
+                    // Don't process the same version again
                     lastVersion = version;
                 }
                 return;

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/ConnectivityInformation.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/ConnectivityInformation.java
@@ -13,8 +13,6 @@ import com.aws.greengrass.util.GreengrassServiceClientFactory;
 import software.amazon.awssdk.services.greengrassv2data.model.ConnectivityInfo;
 import software.amazon.awssdk.services.greengrassv2data.model.GetConnectivityInfoRequest;
 import software.amazon.awssdk.services.greengrassv2data.model.GetConnectivityInfoResponse;
-import software.amazon.awssdk.services.greengrassv2data.model.ResourceNotFoundException;
-import software.amazon.awssdk.services.greengrassv2data.model.ValidationException;
 
 import java.util.Collections;
 import java.util.List;
@@ -66,6 +64,8 @@ public class ConnectivityInformation {
      * Get connectivity info.
      *
      * @return list of connectivity info items
+     * @throws software.amazon.awssdk.services.greengrassv2data.model.GreengrassV2DataException
+     * if getConnectivityInfo call fails
      */
     public List<ConnectivityInfo> getConnectivityInfo() {
         GetConnectivityInfoRequest getConnectivityInfoRequest =
@@ -73,15 +73,11 @@ public class ConnectivityInformation {
                         .build();
         List<ConnectivityInfo> connectivityInfoList = Collections.emptyList();
 
-        try {
-            GetConnectivityInfoResponse getConnectivityInfoResponse =
-                    clientFactory.getGreengrassV2DataClient().getConnectivityInfo(getConnectivityInfoRequest);
-            if (getConnectivityInfoResponse.hasConnectivityInfo()) {
-                // Filter out port and metadata since it is not needed
-                connectivityInfoList = getConnectivityInfoResponse.connectivityInfo();
-            }
-        } catch (ValidationException | ResourceNotFoundException e) {
-            LOGGER.atWarn().cause(e).log("Connectivity info doesn't exist");
+        GetConnectivityInfoResponse getConnectivityInfoResponse =
+                clientFactory.getGreengrassV2DataClient().getConnectivityInfo(getConnectivityInfoRequest);
+        if (getConnectivityInfoResponse.hasConnectivityInfo()) {
+            // Filter out port and metadata since it is not needed
+            connectivityInfoList = getConnectivityInfoResponse.connectivityInfo();
         }
 
         // NOTE: Eventually this code will move into infrastructure and connectivity information

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitorTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitorTest.java
@@ -37,6 +37,7 @@ import software.amazon.awssdk.iot.iotshadow.model.ShadowDeltaUpdatedEvent;
 import software.amazon.awssdk.iot.iotshadow.model.ShadowStateWithDelta;
 import software.amazon.awssdk.iot.iotshadow.model.UpdateShadowRequest;
 import software.amazon.awssdk.services.greengrassv2data.model.ConnectivityInfo;
+import software.amazon.awssdk.services.greengrassv2data.model.ValidationException;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -107,6 +108,49 @@ public class CISShadowMonitorTest {
     @AfterEach
     void tearDown() {
         cisShadowMonitor.stopMonitor();
+    }
+
+    @Test
+    void GIVEN_CISShadowMonitor_WHEN_connectivity_call_fails_THEN_cert_not_rotated(ExtensionContext context) throws Exception {
+        ignoreExceptionOfType(context, ValidationException.class);
+        connectivityInfoProvider.setMode(FakeConnectivityInformation.Mode.THROW_VALIDATION_EXCEPTION);
+
+        // capture the subscription callback for shadow delta update
+        ArgumentCaptor<Consumer<MqttMessage>> shadowDeltaUpdatedCallback = ArgumentCaptor.forClass(Consumer.class);
+        when(shadowClientConnection.subscribe(eq(SHADOW_DELTA_UPDATED_TOPIC), any(),
+                shadowDeltaUpdatedCallback.capture())).thenReturn(DUMMY_PACKET_ID);
+
+        // generated list of deltas to feed to the shadow monitor
+        List<Map<String, Object>> deltas =
+                IntStream.range(0, 5).mapToObj(i -> Utils.immutableMap("version", (Object) String.valueOf(i)))
+                        .collect(Collectors.toList());
+        Map<String, Object> lastDelta = deltas.get(deltas.size() - 1);
+
+        // notify when last shadow update is published
+        WhenUpdateIsPublished whenUpdateIsPublished = WhenUpdateIsPublished.builder()
+                .expectedReportedState(lastDelta) // reported state updated to desired state
+                .expectedDesiredState(null) // desired state isn't modified
+                .build();
+        when(shadowClientConnection.publish(argThat(new ShadowUpdateRequestMatcher()), any(), anyBoolean())).thenAnswer(
+                whenUpdateIsPublished);
+
+        cisShadowMonitor.startMonitor();
+        cisShadowMonitor.addToMonitor(certificateGenerator);
+
+        // trigger update delta subscription callbacks
+        AtomicInteger version = new AtomicInteger(1);
+        deltas.forEach(delta -> {
+            ShadowDeltaUpdatedEvent deltaUpdatedEvent = new ShadowDeltaUpdatedEvent();
+            deltaUpdatedEvent.version = version.getAndIncrement();
+            deltaUpdatedEvent.state = new HashMap<>(delta);
+
+            // original message
+            wrapInMessage(SHADOW_DELTA_UPDATED_TOPIC, deltaUpdatedEvent, false).ifPresent(
+                    resp -> shadowDeltaUpdatedCallback.getValue().accept(resp));
+        });
+
+        assertTrue(whenUpdateIsPublished.getLatch().await(5L, TimeUnit.SECONDS));
+        verifyCertsRotatedWhenConnectivityChanges();
     }
 
     @Test
@@ -548,7 +592,11 @@ public class CISShadowMonitorTest {
              * Throw a runtime exception only the FIRST time getConnectivityInfo is called. Subsequent calls follow
              * {@link Mode#RANDOM} behavior.
              */
-            FAIL_ONCE
+            FAIL_ONCE,
+            /**
+             * Throw a {@link software.amazon.awssdk.services.greengrassv2data.model.ValidationException}
+             */
+            THROW_VALIDATION_EXCEPTION
         }
 
         FakeConnectivityInformation() {
@@ -588,6 +636,9 @@ public class CISShadowMonitorTest {
                     return Collections.singletonList(connectivityInfoWithRandomHost());
                 case CONSTANT:
                     return CONNECTIVITY_INFO_SAMPLE.get();
+                case THROW_VALIDATION_EXCEPTION:
+                    // ValidationException is private, so mocking
+                    throw mock(ValidationException.class);
                 default:
                     return Collections.emptyList();
             }

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitorTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitorTest.java
@@ -594,7 +594,7 @@ public class CISShadowMonitorTest {
              */
             FAIL_ONCE,
             /**
-             * Throw a {@link software.amazon.awssdk.services.greengrassv2data.model.ValidationException}
+             * Simulate CIS throwing a validation exception.
              */
             THROW_VALIDATION_EXCEPTION
         }
@@ -617,12 +617,14 @@ public class CISShadowMonitorTest {
         }
 
         @Override
-        public List<ConnectivityInfo> getConnectivityInfo() {
+        public Optional<List<ConnectivityInfo>> getConnectivityInfo() {
             List<ConnectivityInfo> connectivityInfo = doGetConnectivityInfo();
-            cachedHostAddresses = connectivityInfo.stream().map(ConnectivityInfo::hostAddress).distinct()
-                    .collect(Collectors.toList());
-            responseHashes.add(cachedHostAddresses.hashCode());
-            return connectivityInfo;
+            if (connectivityInfo != null) {
+                cachedHostAddresses = connectivityInfo.stream().map(ConnectivityInfo::hostAddress).distinct()
+                        .collect(Collectors.toList());
+                responseHashes.add(cachedHostAddresses.hashCode());
+            }
+            return Optional.ofNullable(connectivityInfo);
         }
 
         private List<ConnectivityInfo> doGetConnectivityInfo() {
@@ -637,8 +639,8 @@ public class CISShadowMonitorTest {
                 case CONSTANT:
                     return CONNECTIVITY_INFO_SAMPLE.get();
                 case THROW_VALIDATION_EXCEPTION:
-                    // ValidationException is private, so mocking
-                    throw mock(ValidationException.class);
+                    // represents no info received
+                    return null;
                 default:
                     return Collections.emptyList();
             }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

If CIS call fails for some non-retryable exception (ValidationException/ResourceNotFoundException), the hostAddresses cache will be cleared, this change prevents that from happening

**Why is this change necessary:**

**How was this change tested:**

unit tests

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
