### PR TITLE
feat: skip cert rotation if connectivity info hasn't changed

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitor.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitor.java
@@ -31,13 +31,16 @@ import software.amazon.awssdk.services.greengrassv2data.model.InternalServerExce
 import software.amazon.awssdk.services.greengrassv2data.model.ThrottlingException;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
@@ -221,7 +224,7 @@ public class CISShadowMonitor implements Consumer<NetworkStateProvider.Connectio
         // to avoid blocking other MQTT subscribers in the Nucleus
         CompletableFuture.runAsync(() -> {
 
-            List<String> prevCachedHostAddresses = connectivityInformation.getCachedHostAddresses();
+            Set<String> prevCachedHostAddresses = new HashSet<>(connectivityInformation.getCachedHostAddresses());
 
             Optional<List<ConnectivityInfo>> connectivityInfo;
             try {
@@ -259,7 +262,7 @@ public class CISShadowMonitor implements Consumer<NetworkStateProvider.Connectio
             }
 
             // skip cert rotation if connectivity info hasn't changed
-            List<String> cachedHostAddresses = connectivityInformation.getCachedHostAddresses();
+            Set<String> cachedHostAddresses = new HashSet<>(connectivityInformation.getCachedHostAddresses());
             if (Objects.equals(prevCachedHostAddresses, cachedHostAddresses)) {
                 try {
                     LOGGER.atInfo().kv(VERSION, version)
@@ -276,7 +279,7 @@ public class CISShadowMonitor implements Consumer<NetworkStateProvider.Connectio
 
             try {
                 for (CertificateGenerator cg : monitoredCertificateGenerators) {
-                    cg.generateCertificate(() -> cachedHostAddresses, "connectivity info was updated");
+                    cg.generateCertificate(() -> new ArrayList<>(cachedHostAddresses), "connectivity info was updated");
                 }
             } catch (CertificateGenerationException e) {
                 LOGGER.atError().kv(VERSION, version).cause(e).log("Failed to generate new certificates");

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/ConnectivityInformation.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/ConnectivityInformation.java
@@ -58,7 +58,7 @@ public class ConnectivityInformation {
     }
 
     /**
-     * Get cached connectivity info.
+     * Get cached connectivity info. Items in this list are unique.
      *
      * @return list of cached connectivity info items
      */

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/ConnectivityInformation.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/ConnectivityInformation.java
@@ -10,6 +10,8 @@ import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.GreengrassServiceClientFactory;
+import lombok.AccessLevel;
+import lombok.Getter;
 import software.amazon.awssdk.services.greengrassv2data.model.ConnectivityInfo;
 import software.amazon.awssdk.services.greengrassv2data.model.GetConnectivityInfoRequest;
 import software.amazon.awssdk.services.greengrassv2data.model.GetConnectivityInfoResponse;
@@ -33,6 +35,7 @@ public class ConnectivityInformation {
 
     private final DeviceConfiguration deviceConfiguration;
     private final GreengrassServiceClientFactory clientFactory;
+    @Getter(AccessLevel.PACKAGE) // unit testing
     private final ConnectivityInfoCache connectivityInfoCache;
 
     private final Map<String, Set<HostAddress>> connectivityInformationMap = new ConcurrentHashMap<>();


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Before rotating certificates, check that CIS info has actually changed.

**Why is this change necessary:**
To prevent unnecessary rotations

**How was this change tested:**
Unit test
**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
