### PR TITLE
fix: synchronize CIS shadow processing

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitor.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitor.java
@@ -280,7 +280,6 @@ public class CISShadowMonitor implements Consumer<NetworkStateProvider.Connectio
     /**
      * Task for processing the CIS shadow. The goal is to rotate
      * certificates if we detect that connectivity info has changed.
-     * This task is triggered by
      */
     private class ProcessCISShadowTask implements Runnable {
 

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitorTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitorTest.java
@@ -538,15 +538,6 @@ public class CISShadowMonitorTest {
         verifyCertsRotatedWhenConnectivityChanges();
     }
 
-    private void waitForSubscriptionToShadowTopics() throws InterruptedException {
-        AtomicInteger numSubscriptions = new AtomicInteger();
-        when(shadowClientConnection.subscribe(any(), any(), any())).thenAnswer(invocation -> {
-            numSubscriptions.incrementAndGet();
-            return DUMMY_PACKET_ID;
-        });
-        TestHelpers.eventuallyTrue(() -> numSubscriptions.get() == 2);
-    }
-
     @Test
     void GIVEN_CISShadowMonitor_WHEN_stop_monitor_THEN_unsubscribe() throws InterruptedException {
         AtomicInteger numSubscriptions = new AtomicInteger();


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Adds synchronization when processing CIS shadows, as we may receive concurrent requests for processing (e.g. getting shadow deltas).

The approach is as follows:
* "queue" incoming requests using an atomic reference
* we replace the queued item based on most recent shadow version, as we can ignore outdated information
* a separate thread polls the queue and submits a task for processing the shadow

❗ This change also adds in a retry mechanism in the case of certificate generation failures, or cloud call fails.

The code for thread waiting is heavily inspired from shadow manager's RequestBlockingQueue.  This approach is a lot of code, but it avoids busy-waiting entirely.

**Why is this change necessary:**

Shadow processing is not synchronized.  There's a chance that connectivity info could be different between concurrent shadow processing tasks, and certificate generation could interleave, causing certs to be generated with inconsistent connectivity information.

**How was this change tested:**

Unit tests

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
