### PR TITLE
feat(uat): added subscribe and unsubscribe to MQTT5 test client

### DIFF
--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -9,6 +9,8 @@ import com.aws.greengrass.testing.mqtt5.client.exceptions.MqttException;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import java.util.List;
+
 /**
  * Interface of MQTT5 connection.
  */
@@ -30,8 +32,41 @@ public interface MqttConnection {
         // TODO: add user's properties
     }
 
+
     /**
-     * Close MQTT connection.
+     * Information about single subscription.
+     */
+    @Data
+    @AllArgsConstructor
+    class Subscription {
+        /** Topic filter. */
+        String filter;
+
+        /** Maximum QoS. */
+        int qos;
+
+        /** No local subscription. */
+        boolean noLocal;
+
+        boolean retainAsPublished;
+        int retainHandling;
+    }
+
+    /**
+     * Useful information from SUBACK and UNSUBACK packets.
+     */
+    @Data
+    @AllArgsConstructor
+    class SubAckInfo {
+        /** Reason codes. */
+        private List<Integer> reasonCodes;
+
+        private String reasonString;
+        // TODO: add user's properties
+    }
+
+    /**
+     * Closes MQTT connection.
      *
      * @param reasonCode reason why connection is closed
      * @param timeout disconnect operation timeout in seconds
@@ -41,7 +76,7 @@ public interface MqttConnection {
 
 
     /**
-     * Publish MQTT message.
+     * Publishes MQTT message.
      *
      * @param retain if set message will retained
      * @param qos QoS value to publish message
@@ -52,4 +87,25 @@ public interface MqttConnection {
      * @throws MqttException on errors
      */
     PubAckInfo publish(boolean retain, int qos, long timeout, String topic, byte[] content) throws MqttException;
+
+    /**
+     * Subscribes to topics.
+     *
+     * @param timeout subscribe operation timeout in seconds
+     * @param subscriptionId optional subscription identificator
+     * @param subscriptions list of subscriptions
+     * @return useful information from SUBACK packet
+     * @throws MqttException on errors
+     */
+    SubAckInfo subscribe(long timeout, Integer subscriptionId, List<Subscription> subscriptions) throws MqttException;
+
+    /**
+     * Unsubscribes from topics.
+     *
+     * @param timeout subscribe operation timeout in seconds
+     * @param filters list of topic filter to unsubscribe
+     * @return useful information from UNSUBACK packet
+     * @throws MqttException on errors
+     */
+    SubAckInfo unsubscribe(long timeout, List<String> filters) throws MqttException;
 }

--- a/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.testing.mqtt5.client.grpc;
 
 import com.aws.greengrass.testing.mqtt.client.Mqtt5Message;
+import com.aws.greengrass.testing.mqtt.client.Mqtt5Subscription;
 import com.aws.greengrass.testing.mqtt.client.MqttClientControlGrpc;
 import com.aws.greengrass.testing.mqtt.client.MqttCloseRequest;
 import com.aws.greengrass.testing.mqtt.client.MqttConnectRequest;
@@ -13,6 +14,9 @@ import com.aws.greengrass.testing.mqtt.client.MqttConnectionId;
 import com.aws.greengrass.testing.mqtt.client.MqttProtoVersion;
 import com.aws.greengrass.testing.mqtt.client.MqttPublishReply;
 import com.aws.greengrass.testing.mqtt.client.MqttPublishRequest;
+import com.aws.greengrass.testing.mqtt.client.MqttSubscribeReply;
+import com.aws.greengrass.testing.mqtt.client.MqttSubscribeRequest;
+import com.aws.greengrass.testing.mqtt.client.MqttUnsubscribeRequest;
 import com.aws.greengrass.testing.mqtt.client.ShutdownRequest;
 import com.aws.greengrass.testing.mqtt.client.TLSSettings;
 import com.aws.greengrass.testing.mqtt5.client.MqttConnection;
@@ -28,12 +32,22 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Implementation of gRPC server handles requests of OTF.
  */
 class GRPCControlServer {
     private static final Logger logger = LogManager.getLogger(GRPCControlServer.class);
+
+    private static final String CONNECTION_WITH_DOES_NOT_FOUND = "connection with id {} doesn't found";
+    private static final String CONNECTION_DOES_NOT_FOUND = "connection doesn't found";
+
+    private static final int TIMEOUT_MIN = 1;
+
+    private static final int QOS_MIN = 0;
+    private static final int QOS_MAX = 3;
 
     private static final int PORT_MIN = 1;
     private static final int PORT_MAX = 65_535;
@@ -45,8 +59,12 @@ class GRPCControlServer {
     private static final int REASON_MIN = 0;
     private static final int REASON_MAX = 255;
 
-    private static final int TIMEOUT_MIN = 1;
 
+    private static final int SIBSCRIPTION_ID_MIN = 1;
+    private static final int SIBSCRIPTION_ID_MAX = 268_435_455;
+
+    private static final int RETAIN_HANDLING_MIN = 0;
+    private static final int RETAIN_HANDLING_MAX = 2;
 
     @SuppressWarnings("PMD.UnusedPrivateField") // TODO: remove after use client
     private final GRPCDiscoveryClient client;
@@ -132,9 +150,9 @@ class GRPCControlServer {
 
             int timeout = request.getTimeout();
             if (timeout < TIMEOUT_MIN) {
-                logger.atWarn().log("invalid timeout, must be >= {}", TIMEOUT_MIN);
+                logger.atWarn().log("invalid connect timeout, must be >= {} but {}", TIMEOUT_MIN, timeout);
                 responseObserver.onError(Status.INVALID_ARGUMENT
-                                            .withDescription("invalid timeout, must be >= 1")
+                                            .withDescription("invalid connect timeout, must be >= 1")
                                             .asRuntimeException());
                 return;
             }
@@ -214,18 +232,18 @@ class GRPCControlServer {
 
             int timeout = request.getTimeout();
             if (timeout < TIMEOUT_MIN) {
-                logger.atWarn().log("invalid timeout, must be >= {}", TIMEOUT_MIN);
+                logger.atWarn().log("invalid disconnect timeout, must be >= {} but {}", TIMEOUT_MIN, timeout);
                 responseObserver.onError(Status.INVALID_ARGUMENT
-                                            .withDescription("invalid timeout, must be >= 1")
+                                            .withDescription("invalid disconnect timeout, must be >= 1")
                                             .asRuntimeException());
                 return;
             }
 
             MqttConnection connection = mqttLib.unregisterConnection(connectionId);
             if (connection == null) {
-                logger.atWarn().log("connection with id {} doesn't found", connectionId);
+                logger.atWarn().log(CONNECTION_WITH_DOES_NOT_FOUND, connectionId);
                 responseObserver.onError(Status.NOT_FOUND
-                                            .withDescription("connection doesn't found")
+                                            .withDescription(CONNECTION_DOES_NOT_FOUND)
                                             .asRuntimeException());
                 return;
             }
@@ -246,16 +264,12 @@ class GRPCControlServer {
 
         @Override
         public void publishMqtt(MqttPublishRequest request, StreamObserver<MqttPublishReply> responseObserver) {
-
-            int connectionId = request.getConnectionId().getConnectionId();
             Mqtt5Message message = request.getMsg();
-            String topic = message.getTopic();
-            int qos = message.getQos().getNumber();
 
-            logger.atInfo().log("publishMqtt: connectionId {} QoS {} topic {}", connectionId, qos, topic);
+            logger.atDebug().log("publishMqtt");
 
-
-            if (qos < 0 || qos > 3) {
+            int qos = message.getQosValue();
+            if (qos < QOS_MIN || qos > QOS_MAX) {
                 logger.atWarn().log("qos is invalid can be in range [0,3] but is {}", qos);
                 responseObserver.onError(Status.INVALID_ARGUMENT
                                             .withDescription("qos is invalid can be in range [0,3]")
@@ -263,6 +277,7 @@ class GRPCControlServer {
                 return;
             }
 
+            String topic = message.getTopic();
             if (topic == null || topic.isEmpty()) {
                 logger.atWarn().log("topic can't be empty");
                 responseObserver.onError(Status.INVALID_ARGUMENT
@@ -273,33 +288,217 @@ class GRPCControlServer {
 
             int timeout = request.getTimeout();
             if (timeout < TIMEOUT_MIN) {
-                logger.atWarn().log("invalid timeout, must be >= {}", TIMEOUT_MIN);
+                logger.atWarn().log("invalid publish timeout, must be >= {} but {}", TIMEOUT_MIN, timeout);
                 responseObserver.onError(Status.INVALID_ARGUMENT
-                                            .withDescription("invalid timeout, must be >= 1")
+                                            .withDescription("invalid publish timeout, must be >= 1")
                                             .asRuntimeException());
                 return;
             }
 
+            int connectionId = request.getConnectionId().getConnectionId();
             MqttConnection connection = mqttLib.getConnection(connectionId);
             if (connection == null) {
-                logger.atWarn().log("connection with id {} doesn't found", connectionId);
+                logger.atWarn().log(CONNECTION_WITH_DOES_NOT_FOUND, connectionId);
                 responseObserver.onError(Status.NOT_FOUND
-                                            .withDescription("connection doesn't found")
+                                            .withDescription(CONNECTION_DOES_NOT_FOUND)
                                             .asRuntimeException());
                 return;
             }
+
+            boolean isRetain = message.getRetain();
+            logger.atInfo().log("Publish: connectionId {} topic {} QOS {} retain {}",
+                                    connectionId, topic, qos, isRetain);
 
             MqttPublishReply.Builder builder = MqttPublishReply.newBuilder();
             try {
                 // TODO: pass also user's properties
-                MqttConnection.PubAckInfo pubAckInfo = connection.publish(message.getRetain(), qos, timeout, topic,
+                MqttConnection.PubAckInfo pubAckInfo = connection.publish(isRetain, qos, timeout, topic,
                                                             message.getPayload().toByteArray());
                 if (pubAckInfo != null) {
-                    builder.setReasonCode(pubAckInfo.getReasonCode());
+                    int reasonCode = pubAckInfo.getReasonCode();
+                    builder.setReasonCode(reasonCode);
                     String reasonString = pubAckInfo.getReasonString();
                     if (reasonString != null) {
                         builder.setReasonString(reasonString);
                     }
+                    logger.atInfo().log("Publish response: reason code {} reason string {}", reasonCode, reasonString);
+                }
+            } catch (MqttException ex) {
+                logger.atError().withThrowable(ex).log("exception during publish");
+                responseObserver.onError(ex);
+                return;
+            }
+
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        }
+
+        @Override
+        public void subscribeMqtt(MqttSubscribeRequest request, StreamObserver<MqttSubscribeReply> responseObserver) {
+
+            logger.atDebug().log("subscribeMqtt");
+
+            int timeout = request.getTimeout();
+            if (timeout < TIMEOUT_MIN) {
+                logger.atWarn().log("invalid subscribe timeout, must be >= {} but {}", TIMEOUT_MIN, timeout);
+                responseObserver.onError(Status.INVALID_ARGUMENT
+                                            .withDescription("invalid subscribe timeout, must be >= 1")
+                                            .asRuntimeException());
+                return;
+            }
+
+            Integer subscriptionId = null;
+            if (request.hasSubscriptionId()) {
+                subscriptionId = request.getSubscriptionId();
+                if (subscriptionId < SIBSCRIPTION_ID_MIN || subscriptionId > SIBSCRIPTION_ID_MAX) {
+                    logger.atWarn().log("invalid subscription id, must be >= {} <= {} but {}", SIBSCRIPTION_ID_MIN,
+                                            SIBSCRIPTION_ID_MAX,
+                                            subscriptionId);
+                    responseObserver.onError(Status.INVALID_ARGUMENT
+                                    .withDescription("invalid subscription id, must be >= 1 and <= 268435455")
+                                    .asRuntimeException());
+                    return;
+                }
+            }
+
+            List<Mqtt5Subscription> subscriptions = request.getSubscriptionsList();
+            if (subscriptions.isEmpty()) {
+                logger.atWarn().log("empty subscriptions list");
+                responseObserver.onError(Status.INVALID_ARGUMENT
+                                            .withDescription("empty subscriptions list")
+                                            .asRuntimeException());
+                return;
+            }
+
+            List<MqttConnection.Subscription> outSubscriptions = new ArrayList<>();
+            int index = 0;
+            for (Mqtt5Subscription subscription : subscriptions) {
+                String filter = subscription.getFilter();
+                if (filter == null || filter.isEmpty()) {
+                    logger.atWarn().log("filter can't be empty but missing at index {}", index);
+                    responseObserver.onError(Status.INVALID_ARGUMENT
+                                                .withDescription("filter can't be empty")
+                                                .asRuntimeException());
+                    return;
+                }
+
+                int qos = subscription.getQosValue();
+                if (qos < QOS_MIN || qos > QOS_MAX) {
+                    logger.atWarn().log("qos is invalid can be in range [0,3] but is {} at index {}", qos, index);
+                    responseObserver.onError(Status.INVALID_ARGUMENT
+                                                .withDescription("qos is invalid can be in range [0,3]")
+                                                .asRuntimeException());
+                    return;
+                }
+
+                int retainHandling = subscription.getRetainHandlingValue();
+                if (retainHandling < RETAIN_HANDLING_MIN || retainHandling > RETAIN_HANDLING_MAX) {
+                    logger.atWarn().log("qos is invalid can be in range [0,3] but is {} at index {}", qos, index);
+                    responseObserver.onError(Status.INVALID_ARGUMENT
+                                                .withDescription("qos is invalid can be in range [0,3]")
+                                                .asRuntimeException());
+                    return;
+                }
+
+                boolean noLocal = subscription.getNoLocal();
+                boolean retainAsLocal = subscription.getRetainAsPublished();
+                MqttConnection.Subscription tmp = new MqttConnection.Subscription(filter, qos, noLocal, retainAsLocal,
+                                                                                    retainHandling);
+                logger.atInfo().log("Subscription: filter {} QoS {} noLocal {} retainAsLocal {} retainHandling {}",
+                                        filter, qos, noLocal, retainAsLocal, retainHandling);
+                outSubscriptions.add(tmp);
+                index++;
+            }
+
+            int connectionId = request.getConnectionId().getConnectionId();
+            MqttConnection connection = mqttLib.getConnection(connectionId);
+            if (connection == null) {
+                logger.atWarn().log(CONNECTION_WITH_DOES_NOT_FOUND, connectionId);
+                responseObserver.onError(Status.NOT_FOUND
+                                            .withDescription(CONNECTION_DOES_NOT_FOUND)
+                                            .asRuntimeException());
+                return;
+            }
+
+            logger.atInfo().log("Subscribe: connectionId {} subscriptionId {} for {} filters",
+                                    connectionId, subscriptionId, outSubscriptions.size());
+            MqttSubscribeReply.Builder builder = MqttSubscribeReply.newBuilder();
+            try {
+                // TODO: pass also user's properties
+                MqttConnection.SubAckInfo subAckInfo = connection.subscribe(timeout, subscriptionId, outSubscriptions);
+                if (subAckInfo != null) {
+                    List<Integer> codes = subAckInfo.getReasonCodes();
+                    if (codes != null) {
+                        builder.addAllReasonCodes(codes);
+                    }
+
+                    String reasonString = subAckInfo.getReasonString();
+                    if (reasonString != null) {
+                         builder.setReasonString(reasonString);
+                    }
+                    logger.atInfo().log("Subscribe response: reason codes {} reason string {}", codes, reasonString);
+                }
+            } catch (MqttException ex) {
+                logger.atError().withThrowable(ex).log("exception during publish");
+                responseObserver.onError(ex);
+                return;
+            }
+
+            responseObserver.onNext(builder.build());
+            responseObserver.onCompleted();
+        }
+
+        @Override
+        public void unsubscribeMqtt(MqttUnsubscribeRequest request,
+                                        StreamObserver<MqttSubscribeReply> responseObserver) {
+
+            logger.atDebug().log("unsubscribeMqtt");
+
+            int timeout = request.getTimeout();
+            if (timeout < TIMEOUT_MIN) {
+                logger.atWarn().log("invalid unsubscribe timeout, must be >= {} but {}", TIMEOUT_MIN, timeout);
+                responseObserver.onError(Status.INVALID_ARGUMENT
+                                            .withDescription("invalid unsubscribe timeout, must be >= 1")
+                                            .asRuntimeException());
+                return;
+            }
+
+            List<String> filters = request.getFiltersList();
+            if (filters.isEmpty()) {
+                logger.atWarn().log("empty filters list");
+                responseObserver.onError(Status.INVALID_ARGUMENT
+                                            .withDescription("empty filters list")
+                                            .asRuntimeException());
+                return;
+            }
+
+            int connectionId = request.getConnectionId().getConnectionId();
+            MqttConnection connection = mqttLib.getConnection(connectionId);
+            if (connection == null) {
+                logger.atWarn().log(CONNECTION_WITH_DOES_NOT_FOUND, connectionId);
+                responseObserver.onError(Status.NOT_FOUND
+                                            .withDescription(CONNECTION_DOES_NOT_FOUND)
+                                            .asRuntimeException());
+                return;
+            }
+
+            logger.atInfo().log("Unsubscribe: connectionId {} for {} filters",
+                                    connectionId, filters);
+            MqttSubscribeReply.Builder builder = MqttSubscribeReply.newBuilder();
+            try {
+                // TODO: pass also user's properties
+                MqttConnection.SubAckInfo subAckInfo = connection.unsubscribe(timeout, filters);
+                if (subAckInfo != null) {
+                    List<Integer> codes = subAckInfo.getReasonCodes();
+                    if (codes != null) {
+                        builder.addAllReasonCodes(codes);
+                    }
+
+                    String reasonString = subAckInfo.getReasonString();
+                    if (reasonString != null) {
+                         builder.setReasonString(reasonString);
+                    }
+                    logger.atInfo().log("Unsubscribe response: reason codes {} reason string {}", codes, reasonString);
                 }
             } catch (MqttException ex) {
                 logger.atError().withThrowable(ex).log("exception during publish");

--- a/uat/src/main/proto/mqtt_client_control.proto
+++ b/uat/src/main/proto/mqtt_client_control.proto
@@ -76,10 +76,10 @@ service MqttClientControl {
     rpc CloseMqttConnection(MqttCloseRequest) returns (google.protobuf.Empty) {}
 
     // MQTT subscribe
-    rpc SubscribeMqtt(MqttSubscribeRequest) returns (google.protobuf.Empty) {}
+    rpc SubscribeMqtt(MqttSubscribeRequest) returns (MqttSubscribeReply) {}
 
     // MQTT unsubscribe
-    rpc UnsubscribeMqtt(MqttUnsubscribeRequest) returns (google.protobuf.Empty) {}
+    rpc UnsubscribeMqtt(MqttUnsubscribeRequest) returns (MqttSubscribeReply) {}
 
     // publish MQTT message
     rpc PublishMqtt(MqttPublishRequest) returns (MqttPublishReply) {}
@@ -101,6 +101,14 @@ enum MqttQoS {
     MQTT_QOS_3 = 3;
 };
 
+// Retain handling values
+enum Mqtt5RetainHandling {
+    MQTT5_RETAIN_SEND_AT_SUBSCRIPTION = 0;
+    MQTT5_RETAIN_SEND_AT_NEW_SUBSCRIPTION = 1;
+    MQTT5_RETAIN_DO_NOT_SEND_AT_SUBSCRIPTION = 2;
+    MQTT5_RETAIN_RESERVED = 4;
+};
+
 // logical Id of MQTT connection, unique for a agent, but not over
 message MqttConnectionId {
     int32 connectionId = 1;
@@ -120,6 +128,15 @@ message Mqtt5Message {
     bool retain = 4;
     Mqtt5Properties properties = 5;
 };
+
+// One item of subscription contains filter and options
+message Mqtt5Subscription {
+    string filter = 1;                                  // topic filter
+    MqttQoS qos = 2;                                    // Maximum QoS field
+    bool noLocal = 3;                                   // No Local option
+    bool retainAsPublished = 4;                         // Retain As Published option
+    Mqtt5RetainHandling retainHandling = 5;             // Retain Handling option
+}
 
 // Optional TLS settings for MQTT connection
 message TLSSettings {
@@ -152,8 +169,8 @@ message MqttConnectRequest {
 // Request to close MQTT connection
 message MqttCloseRequest {
     MqttConnectionId connectionId = 1;                  // id of connection to disconnect
-    int32 reason = 2;
-    int32 timeout = 3;                                  // disconnect timeout in seconds
+    int32 timeout = 2;                                  // disconnect timeout in seconds
+    int32 reason = 3;                                   // MQTT disconnect reason
     optional Mqtt5Properties properties = 4;            // DISCONNECT packet MQTT v5.0 properties
 }
 
@@ -167,19 +184,31 @@ message ReceivedMqttMessage {
 // Request to subscribe to MQTT topic(s)
 message MqttSubscribeRequest {
     MqttConnectionId connectionId = 1;                  // id of connection to subscribe
-    // TODO: topics and other parameters
+    int32 timeout = 2;                                  // subscribe timeout in seconds
+    optional int32 subscriptionId = 3;                  // optional subscription id
+    repeated Mqtt5Subscription subscriptions = 4;       // list of filter with options
+    // TODO: add user properties
+}
+
+// Response to subscribe request
+message MqttSubscribeReply {
+    repeated int32 reasonCodes = 1;                     // MQTT v5.0 SUBBACK reason codes
+    optional string reasonString = 2;                   // MQTT v5.0 SUBACK  reason string
+    optional Mqtt5Properties properties = 3;            // MQTT v5.0 SUBBACK user's properties
 }
 
 // Request to unsubscribe from MQTT topic(s)
 message MqttUnsubscribeRequest {
-    MqttConnectionId connectionId = 1;
-    // TODO: id of subscription inside connection
+    MqttConnectionId connectionId = 1;                  // id of connection to unsubscribe
+    int32 timeout = 2;                                  // unsubscribe timeout in seconds
+    repeated string filters = 3;                        // list of filter to unsubscribe
+    // TODO: add user properties
 }
 
 // Request to publish MQTT message
 message MqttPublishRequest {
     MqttConnectionId connectionId = 1;                  // id of connection to publish
-    int32 timeout = 2;                                  // publish timeout in seconds\
+    int32 timeout = 2;                                  // publish timeout in seconds
     Mqtt5Message msg = 3;
 }
 


### PR DESCRIPTION
**Issue #, if available:**
Implement subscribe.
Implement unsubscribe.

**Description of changes:**
- Update protocol to send actual subscribe and unsubscribe requests and responses
- Implement subscribe and unsubscribe

**Why is this change necessary:**
MQTT5 test client should be able to subscribe on topics and unsubscribe.

**How was this change tested:**
At the moment manually, in phase 2 we are going to cover code with unit tests.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
