### PR TITLE
fix: inject domain events in SessionManager

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/session/SessionManager.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/session/SessionManager.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
+import javax.inject.Inject;
 
 /**
  * Singleton class for managing AuthN and AuthZ sessions.
@@ -24,7 +25,7 @@ import java.util.UUID;
 public class SessionManager {
     private static final Logger logger = LogManager.getLogger(SessionManager.class);
     private static final String SESSION_ID = "SessionId";
-    private final DomainEvents domainEvents = new DomainEvents();
+    private final DomainEvents domainEvents;
 
     // Thread-safe LRU Session Cache that evicts the eldest entry (based on access order) upon reaching its size.
     // TODO: Support time-based cache eviction (Session timeout) and Session deduping.
@@ -44,6 +45,11 @@ public class SessionManager {
             });
 
     private SessionConfig sessionConfig;
+
+    @Inject
+    public SessionManager(DomainEvents domainEvents) {
+        this.domainEvents = domainEvents;
+    }
 
     /**
      * Looks up a session by id.

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/session/SessionManagerTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/session/SessionManagerTest.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.clientdevices.auth.session;
 
 
+import com.aws.greengrass.clientdevices.auth.api.DomainEvents;
 import com.aws.greengrass.clientdevices.auth.exception.AuthenticationException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.junit.jupiter.api.AfterEach;
@@ -36,6 +37,7 @@ class SessionManagerTest {
     private static final int MOCK_SESSION_CAPACITY = 10;
 
     private SessionManager sessionManager;
+    private DomainEvents domainEvents;
     @Mock
     private MqttSessionFactory mockSessionFactory;
     @Mock
@@ -54,7 +56,8 @@ class SessionManagerTest {
     @BeforeEach
     void beforeEach() throws AuthenticationException {
         lenient().when(mockSessionConfig.getSessionCapacity()).thenReturn(MOCK_SESSION_CAPACITY);
-        sessionManager = new SessionManager();
+        domainEvents = new DomainEvents();
+        sessionManager = new SessionManager(domainEvents);
         sessionManager.setSessionConfig(mockSessionConfig);
         SessionCreator.registerSessionFactory(CREDENTIAL_TYPE, mockSessionFactory);
         lenient().when(mockSessionFactory.createSession(credentialMap)).thenReturn(mockSession);
@@ -126,7 +129,7 @@ class SessionManagerTest {
 
         int mockSessionCapacity = 3;
         when(mockSessionConfig.getSessionCapacity()).thenReturn(mockSessionCapacity);
-        SessionManager sessionManager = new SessionManager();
+        SessionManager sessionManager = new SessionManager(domainEvents);
         sessionManager.setSessionConfig(mockSessionConfig);
 
         // fill session cache to its capacity


### PR DESCRIPTION
**Description of changes:**
Injecting Domain Events into the Session Manager instead of creating a new domain events object with the class.

**Why is this change necessary:**
By creating a new domain events object, the session manager was overriding all of the existing handlers that had been registered in domain events. This caused an issue with the GetClientDeviceAuthToken metrics, since they could not be emitted when domain events was being cleared out.

**How was this change tested:**
Updated unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
