### PR TITLE
fix: use non-blocking MQTT client connection status

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/infra/NetworkStateProvider.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/infra/NetworkStateProvider.java
@@ -79,7 +79,7 @@ public interface NetworkStateProvider {
          */
         @Override
         public NetworkStateProvider.ConnectionState getConnectionState() {
-            if (mqttClient.connected()) {
+            if (mqttClient.getMqttOnline().get()) {
                 return NetworkStateProvider.ConnectionState.NETWORK_UP;
             } else {
                 return NetworkStateProvider.ConnectionState.NETWORK_DOWN;


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
MQTT client connected method calls a synchronized method which can cause the caller to block. Use the non-blocking connected flag instead.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
