### PR TITLE
feat: use BCFIPS library, but not BCFIPS provider to avoid failing hash

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,8 +103,8 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.66</version>
+            <artifactId>bcpkix-fips</artifactId>
+            <version>1.0.7</version>
         </dependency>
     </dependencies>
     <pluginRepositories>

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/CertificateHelper.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/CertificateHelper.java
@@ -22,7 +22,7 @@ import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.OperatorCreationException;
@@ -76,10 +76,10 @@ public final class CertificateHelper {
     }
 
     static {
-        // If not added "BC" is not recognized as the security provider
-        Security.addProvider(new BouncyCastleProvider());
+        // If not added "BCFIPS" is not recognized as the security provider
+        Security.addProvider(new BouncyCastleFipsProvider());
         // Configure the default provider
-        providers.put(ProviderType.DEFAULT, "BC");
+        providers.put(ProviderType.DEFAULT, "BCFIPS");
     }
 
     public enum ProviderType {

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/certificate/ClientCertificateGeneratorTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/certificate/ClientCertificateGeneratorTest.java
@@ -6,12 +6,13 @@
 package com.aws.greengrass.clientdevices.auth.certificate;
 
 import com.aws.greengrass.clientdevices.auth.api.DomainEvents;
+import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationException;
 import com.aws.greengrass.componentmanager.KernelConfigResolver;
 import com.aws.greengrass.config.Topics;
 import com.aws.greengrass.dependency.Context;
-import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationException;
 import com.aws.greengrass.security.SecurityService;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.KeyPurposeId;
 import org.junit.jupiter.api.AfterEach;
@@ -82,7 +83,8 @@ public class ClientCertificateGeneratorTest {
 
         X509Certificate generatedCert = certificateGenerator.getCertificate();
         assertThat(generatedCert.getSubjectX500Principal().getName(), is(SUBJECT_PRINCIPAL));
-        assertThat(new KeyPurposeId(generatedCert.getExtendedKeyUsage().get(0)), is(KeyPurposeId.id_kp_clientAuth));
+        assertThat(KeyPurposeId.getInstance(new ASN1ObjectIdentifier(generatedCert.getExtendedKeyUsage().get(0))),
+                is(KeyPurposeId.id_kp_clientAuth));
         assertThat(generatedCert.getPublicKey(), is(publicKey));
         verify(mockCallback, times(1)).accept(generatedCert, certificateStore.getCaCertificateChain());
 

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/helpers/CertificateTestHelpers.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/helpers/CertificateTestHelpers.java
@@ -17,14 +17,14 @@ import org.bouncycastle.asn1.x509.BasicConstraints;
 import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.KeyPurposeId;
+import org.bouncycastle.asn1.x509.KeyUsage;
 import org.bouncycastle.cert.CertIOException;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
-import org.bouncycastle.jce.X509KeyUsage;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
@@ -76,8 +76,8 @@ public final class CertificateTestHelpers {
     }
 
     static {
-        // If not added "BC" is not recognized as the security provider
-        Security.addProvider(new BouncyCastleProvider());
+        // If not added "BCFIPS" is not recognized as the security provider
+        Security.addProvider(new BouncyCastleFipsProvider());
     }
 
     private enum CertificateTypes {
@@ -124,14 +124,14 @@ public final class CertificateTestHelpers {
 
         buildCertificateExtensions(builder, caCert, publicKey, type);
         X509CertificateHolder certHolder = signCertificate(builder, caPrivateKey);
-        return new JcaX509CertificateConverter().setProvider("BC").getCertificate(certHolder);
+        return new JcaX509CertificateConverter().setProvider("BCFIPS").getCertificate(certHolder);
     }
 
     private static X509CertificateHolder signCertificate(X509v3CertificateBuilder certBuilder, PrivateKey privateKey)
             throws OperatorCreationException {
         String signingAlgorithm = CERTIFICATE_SIGNING_ALGORITHM.get(privateKey.getAlgorithm());
         final ContentSigner contentSigner =
-                new JcaContentSignerBuilder(signingAlgorithm).setProvider("BC").build(privateKey);
+                new JcaContentSignerBuilder(signingAlgorithm).setProvider("BCFIPS").build(privateKey);
 
         return certBuilder.build(contentSigner);
     }
@@ -151,8 +151,8 @@ public final class CertificateTestHelpers {
         if (type == CertificateTypes.INTERMEDIATE_CA) {
             builder.addExtension(Extension.authorityKeyIdentifier, false, extUtils.createAuthorityKeyIdentifier(caCert))
                     .addExtension(Extension.basicConstraints, true, new BasicConstraints(true))
-                    .addExtension(Extension.keyUsage, true, new X509KeyUsage(
-                            X509KeyUsage.digitalSignature | X509KeyUsage.keyCertSign | X509KeyUsage.cRLSign));
+                    .addExtension(Extension.keyUsage, true, new KeyUsage(
+                            KeyUsage.digitalSignature | KeyUsage.keyCertSign | KeyUsage.cRLSign));
         }
 
         if (type == CertificateTypes.SERVER_CERTIFICATE) {
@@ -179,7 +179,7 @@ public final class CertificateTestHelpers {
         // TODO: caller should pass a clock or date range in instead
         Date notBefore = Date.from(now.minusSeconds(1));
         Date notAfter = Date.from(now.plusSeconds(DEFAULT_TEST_CA_DURATION_SECONDS));
-        return new Pair(notBefore, notAfter);
+        return new Pair<>(notBefore, notAfter);
     }
 
     private static X500Name getX500Name(String commonName) {

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/helpers/CertificateTestHelpers.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/helpers/CertificateTestHelpers.java
@@ -24,7 +24,6 @@ import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
-import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
@@ -43,7 +42,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SecureRandom;
-import java.security.Security;
 import java.security.cert.CertPath;
 import java.security.cert.CertPathValidator;
 import java.security.cert.CertPathValidatorException;
@@ -55,7 +53,6 @@ import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -73,11 +70,6 @@ public final class CertificateTestHelpers {
             ImmutableMap.of(KEY_TYPE_RSA, RSA_SIGNING_ALGORITHM, KEY_TYPE_EC, ECDSA_SIGNING_ALGORITHM);
 
     private CertificateTestHelpers() {
-    }
-
-    static {
-        // If not added "BCFIPS" is not recognized as the security provider
-        Security.addProvider(new BouncyCastleFipsProvider());
     }
 
     private enum CertificateTypes {
@@ -124,14 +116,14 @@ public final class CertificateTestHelpers {
 
         buildCertificateExtensions(builder, caCert, publicKey, type);
         X509CertificateHolder certHolder = signCertificate(builder, caPrivateKey);
-        return new JcaX509CertificateConverter().setProvider("BCFIPS").getCertificate(certHolder);
+        return new JcaX509CertificateConverter().getCertificate(certHolder);
     }
 
     private static X509CertificateHolder signCertificate(X509v3CertificateBuilder certBuilder, PrivateKey privateKey)
             throws OperatorCreationException {
         String signingAlgorithm = CERTIFICATE_SIGNING_ALGORITHM.get(privateKey.getAlgorithm());
         final ContentSigner contentSigner =
-                new JcaContentSignerBuilder(signingAlgorithm).setProvider("BCFIPS").build(privateKey);
+                new JcaContentSignerBuilder(signingAlgorithm).build(privateKey);
 
         return certBuilder.build(contentSigner);
     }
@@ -204,7 +196,7 @@ public final class CertificateTestHelpers {
     public static boolean wasCertificateIssuedBy(X509Certificate issuerCA, X509Certificate certificate)
             throws CertificateException {
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
-        List<X509Certificate> leafCertificate = Arrays.asList(certificate);
+        List<X509Certificate> leafCertificate = Collections.singletonList(certificate);
         CertPath leafCertPath = cf.generateCertPath(leafCertificate);
 
         try {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Revert the revert of FIPS changes and change code to not actually use the "BCFIPS" provider which would trigger the hash verification which we know fails. We now use "" as the provider which will use Java's default provider. Customers can (and must) configure Java's default provider to be in FIPS mode if they want FIPS compliance.

Although BC isn't actually doing any crypto now because of this change, I am still switching to BCFIPS to avoid any possible confusion about the FIPS compliance of this module.

**Why is this change necessary:**

**How was this change tested:**
Ran cert generation tests with a breakpoint in `FipsStatus.isReady()` to verify it is never called (which would trigger the hash check and subsequent failure).

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
