### PR TITLE
feat(uat): pass information from CONNACK to control

### DIFF
--- a/uat/custom-components/client-java-sdk/pom.xml
+++ b/uat/custom-components/client-java-sdk/pom.xml
@@ -148,7 +148,7 @@
                         <configuration>
                             <overWriteReleases>false</overWriteReleases>
                             <includeScope>runtime</includeScope>
-                            <outputDirectory>target/lib</outputDirectory>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -8,7 +8,7 @@ package com.aws.greengrass.testing.mqtt5.client;
 import com.aws.greengrass.testing.mqtt5.client.exceptions.MqttException;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 
 import java.util.List;
 
@@ -19,65 +19,70 @@ public interface MqttConnection {
     int DEFAULT_DISCONNECT_REASON = 4;
     long DEFAULT_DISCONNECT_TIMEOUT = 10;
 
-    /**
-     * Contains information about publishing MQTT v5.0 message.
-     */
-    @Data
-    @Builder
-    class Message {
-        /** QoS value. */
-        int qos;
-
-        /** Retain flag. */
-        boolean retain;
-
-        /** Topic of message. */
-        String topic;
-
-        /** Payload of message. */
-        byte[] payload;
-
-        // TODO: add user's properties and so one
-    }
 
     /**
-     * Useful information from PUBACK packet.
+     * Useful information from CONNACK packet.
      */
-    @Data
+    @Getter
     @AllArgsConstructor
-    class PubAckInfo {
-        /** MQTT v5.0 Reason code of PUBACK packet. */
-        private int reasonCode;
-
-        /** MQTT v5.0 Reason string of PUBACK packet. */
+    class ConnAckInfo {
+        private Boolean sessionPresent;
+        private Integer reasonCode;
+        private Integer sessionExpiryInterval;
+        private Integer receiveMaximum;
+        private Integer maximumQoS;
+        private Boolean retainAvailable;
+        private Integer maximumPacketSize;
+        private String assignedClientId;
         private String reasonString;
-        // TODO: add user's properties
+        private Boolean wildcardSubscriptionsAvailable;
+        private Boolean subscriptionIdentifiersAvailable;
+        private Boolean sharedSubscriptionsAvailable;
+        private Integer serverKeepAlive;
+        private String responseInformation;
+        private String serverReference;
+
+        // TODO: int topicAliasMaximum;          // miss for AWS IoT device SDK MQTT5 client ?
+        // TODO: Authentication Method
+        // TODO: Authentication Data
+        // TODO: user's Properties
     }
 
+    /**
+     * Information about start (connect) result.
+     */
+    @Getter
+    @AllArgsConstructor
+    class ConnectResult {
+        /** Useful information from CONNACK packet. Can missed. */
+        private boolean connected;
+        private ConnAckInfo connAckInfo;
+        private String error;
+    }
 
     /**
      * Information about single subscription.
      */
-    @Data
+    @Getter
     @AllArgsConstructor
     class Subscription {
         /** Topic filter. */
-        String filter;
+        private String filter;
 
         /** Maximum QoS. */
-        int qos;
+        private int qos;
 
         /** No local subscription. */
-        boolean noLocal;
+        private boolean noLocal;
 
-        boolean retainAsPublished;
-        int retainHandling;
+        private boolean retainAsPublished;
+        private int retainHandling;
     }
 
     /**
      * Useful information from SUBACK packet.
      */
-    @Data
+    @Getter
     @AllArgsConstructor
     class SubAckInfo {
         /** Reason codes. */
@@ -87,6 +92,40 @@ public interface MqttConnection {
         // TODO: add user's properties
     }
 
+    /**
+     * Contains information about publishing MQTT v5.0 message.
+     */
+    @Getter
+    @Builder
+    class Message {
+        /** QoS value. */
+        private int qos;
+
+        /** Retain flag. */
+        private boolean retain;
+
+        /** Topic of message. */
+        private String topic;
+
+        /** Payload of message. */
+        private byte[] payload;
+
+        // TODO: add user's properties and so one
+    }
+
+    /**
+     * Useful information from PUBACK packet.
+     */
+    @Getter
+    @AllArgsConstructor
+    class PubAckInfo {
+        /** MQTT v5.0 Reason code of PUBACK packet. */
+        private Integer reasonCode;
+
+        /** MQTT v5.0 Reason string of PUBACK packet. */
+        private String reasonString;
+        // TODO: add user's properties
+    }
 
     /**
      * Useful information from UNSUBACK packet.
@@ -98,14 +137,16 @@ public interface MqttConnection {
         }
     }
 
+
     /**
      * Starts MQTT connection.
      *
      * @param timeout connect operation timeout in seconds
      * @param connectionId connection id as assigned by MQTT library
+     * @return ConnectResult on success
      * @throws MqttException on errors
      */
-    void start(long timeout, int connectionId) throws MqttException;
+    ConnectResult start(long timeout, int connectionId) throws MqttException;
 
     /**
      * Subscribes to topics.

--- a/uat/custom-components/client-java-sdk/src/main/proto/mqtt_client_control.proto
+++ b/uat/custom-components/client-java-sdk/src/main/proto/mqtt_client_control.proto
@@ -75,7 +75,7 @@ service MqttClientControl {
     rpc ShutdownAgent(ShutdownRequest) returns (google.protobuf.Empty) {}
 
     // create MQTT connection
-    rpc CreateMqttConnection(MqttConnectRequest) returns (MqttConnectionId) {}
+    rpc CreateMqttConnection(MqttConnectRequest) returns (MqttConnectReply) {}
 
     // close MQTT connection
     rpc CloseMqttConnection(MqttCloseRequest) returns (google.protobuf.Empty) {}
@@ -117,6 +117,29 @@ enum Mqtt5RetainHandling {
 // logical Id of MQTT connection, unique for a agent, but not over
 message MqttConnectionId {
     int32 connectionId = 1;
+};
+
+message Mqtt5ConnAck {
+    optional bool sessionPresent = 1;
+    optional int32 reasonCode = 2;
+    optional int32 sessionExpiryInterval = 3;
+    optional int32 receiveMaximum = 4;
+    optional int32 maximumQoS = 5;
+    optional bool retainAvailable = 6;
+    optional int32 maximumPacketSize = 7;
+    optional string assignedClientId = 8;
+    optional string reasonString = 9;
+    optional bool wildcardSubscriptionsAvailable = 10;
+    optional bool subscriptionIdentifiersAvailable = 11;
+    optional bool sharedSubscriptionsAvailable = 12;
+    optional int32 serverKeepAlive = 13;
+    optional string responseInformation = 14;
+    optional string serverReference = 15;
+
+    // TODO: int32 topicAliasMaximum;
+    // TODO: Authentication Method
+    // TODO: Authentication Data
+    // TODO: user's Properties
 };
 
 // MQTT 5.0 user's properties used in most of packets
@@ -170,6 +193,14 @@ message MqttConnectRequest {
     optional Mqtt5Message willMessage = 10;             // will message to set
 }
 
+// Response to connect request
+message MqttConnectReply {
+    bool connected = 1;                                 // true when connection has been established
+    MqttConnectionId connectionId = 2;                  // id of establisted connection
+    optional Mqtt5ConnAck connAck = 3;                  // information from CONNACK packet
+    string error = 4;                                   // on TCP/TLS error contains error string
+    // TODO: add user properties
+}
 
 // Request to close MQTT connection
 message MqttCloseRequest {
@@ -178,7 +209,6 @@ message MqttCloseRequest {
     int32 reason = 3;                                   // MQTT disconnect reason
     optional Mqtt5Properties properties = 4;            // DISCONNECT packet MQTT v5.0 properties
 }
-
 
 // Request to subscribe to MQTT topic(s)
 message MqttSubscribeRequest {


### PR DESCRIPTION
**Issue #, if available:**
Update SDK-based client to pass information from CONNACK packet to the control

**Description of changes:**
- Extend gRPC protocol by returns MqttConnectReply from CreateMqttConnection call
- Extend protocol by adding Mqtt5ConnAck message
- Added MqttConnection.ConnAckInfo with optional fields
- Added MqttConnection.ConnectResult 
- Update createMqttConnection server side handler to produce response.
- Move objects conversion to separate methods
- Tune existing messages and code to handle fields like optional


**Why is this change necessary:**
In some test scenarios information from CONNACK can be required.

**How was this change tested:**
At the moment manually. In phase 2 we are going to add unit and integration tests.
With success test run with IoT Core as broker result from control looks like:
`[INFO ] 2023-03-20 14:47:08.593 [Thread-2] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
reasonCode: 0
receiveMaximum: 100
maximumQoS: 1
retainAvailable: true
maximumPacketSize: 149504
wildcardSubscriptionsAvailable: true
subscriptionIdentifiersAvailable: false
sharedSubscriptionsAvailable: false
serverKeepAlive: 60
'
`


**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
