### PR TITLE
feat(uat): added isEngineRunning and getAgent to MQTT client control

### DIFF
--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -30,6 +30,7 @@ jobs:
         run: mvn -ntp -U clean verify
         if: matrix.os != 'windows-latest'
       - name: Build with Maven (Windows)
+        working-directory: uat
         env:
           AWS_REGION: us-west-2
         run: mvn -ntp -U clean verify

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/EngineControl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/EngineControl.java
@@ -54,7 +54,7 @@ public interface EngineControl {
      * @return AgentControl on success
      * @throws NoSuchElementException when agent not found
      */
-    AgentControl getAgent(String agentId);
+    AgentControl getAgent(@NonNull String agentId);
 
     /**
      * Waiting until engine will terminated.

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/EngineControl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/EngineControl.java
@@ -51,8 +51,7 @@ public interface EngineControl {
      * Gets Agent by agentId.
      *
      * @param agentId id of agent
-     * @return AgentControl on success
-     * @throws NoSuchElementException when agent not found
+     * @return AgentControl on success and null if agent does not found
      */
     AgentControl getAgent(@NonNull String agentId);
 

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/EngineControl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/EngineControl.java
@@ -48,6 +48,15 @@ public interface EngineControl {
     boolean isEngineRunning();
 
     /**
+     * Gets Agent by agentId.
+     *
+     * @param agentId id of agent
+     * @return AgentControl on success
+     * @throws NoSuchElementException when agent not found
+     */
+    AgentControl getAgent(String agentId);
+
+    /**
      * Waiting until engine will terminated.
      * @throws InterruptedException when thread is interrupted
      */

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/EngineControl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/EngineControl.java
@@ -41,6 +41,13 @@ public interface EngineControl {
     void startEngine(int port, @NonNull EngineEvents engineEvents) throws IOException;
 
     /**
+     * Checks is engine runing.
+     *
+     * @return true if engine is running
+     */
+    boolean isEngineRunning();
+
+    /**
      * Waiting until engine will terminated.
      * @throws InterruptedException when thread is interrupted
      */

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
@@ -23,7 +23,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -61,11 +60,7 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
 
     @Override
     public AgentControl getAgent(@NonNull String agentId) {
-        AgentControlImpl agentControl = agents.get(agentId);
-        if (agentControl == null) {
-            throw new NoSuchElementException("Agent with id " + agentId + " does not found");
-        }
-        return agentControl;
+        return agents.get(agentId);
     }
 
     @Override

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
@@ -60,7 +60,7 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
     }
 
     @Override
-    public AgentControl getAgent(String agentId) {
+    public AgentControl getAgent(@NonNull String agentId) {
         AgentControlImpl agentControl = agents.get(agentId);
         if (agentControl == null) {
             throw new NoSuchElementException("Agent with id " + agentId + " does not found");

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
@@ -30,6 +30,7 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
     private final ConcurrentHashMap<String, AgentControlImpl> agents = new ConcurrentHashMap<>();
     private final AtomicReference<Server> server = new AtomicReference<>();
 
+
     private EngineEvents engineEvents;
 
     @Override
@@ -48,6 +49,11 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
             oldSrv.shutdown();
         }
         logger.atInfo().log("gRPC MQTT client control server started, listening on {}", port);
+    }
+
+    @Override
+    public boolean isEngineRunning() {
+        return server.get() != null;
     }
 
     @Override

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
@@ -5,8 +5,10 @@
 
 package com.aws.greengrass.testing.mqtt.client.control.implementation;
 
+
 import com.aws.greengrass.testing.mqtt.client.Mqtt5Disconnect;
 import com.aws.greengrass.testing.mqtt.client.Mqtt5Message;
+import com.aws.greengrass.testing.mqtt.client.control.api.AgentControl;
 import com.aws.greengrass.testing.mqtt.client.control.api.EngineControl;
 import com.aws.greengrass.testing.mqtt.client.control.implementation.grpc.GRPCDiscoveryServer;
 import com.aws.greengrass.testing.mqtt.client.control.implementation.grpc.GRPCDiscoveryServerInterceptor;
@@ -21,6 +23,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -54,6 +57,15 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
     @Override
     public boolean isEngineRunning() {
         return server.get() != null;
+    }
+
+    @Override
+    public AgentControl getAgent(String agentId) {
+        AgentControlImpl agentControl = agents.get(agentId);
+        if (agentControl == null) {
+            throw new NoSuchElementException("Agent with id " + agentId + " does not found");
+        }
+        return agentControl;
     }
 
     @Override


### PR DESCRIPTION
**Issue #, if available:**
Extend control by adding Engine.isRunning(), Engine.getAgent()

**Description of changes:**
Added EngineControl.isEngineRunning()
Added Engine.getAgent()
Fix mistake in JAVA UAT CI workflow

**Why is this change necessary:**
We update cucumber scenario to add sentences to check is control engine started and is agent registered.
That change add support of these steps from Control.

**How was this change tested:**
At the moment manually, in Phase 2 we going to cover with unit tests.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
