### PR TITLE
feat(uat): create event storage in uat

### DIFF
--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/ConnectionControl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/ConnectionControl.java
@@ -16,6 +16,14 @@ import lombok.NonNull;
  * Control of single MQTT connection.
  */
 public interface ConnectionControl {
+
+    /**
+     * Gets agent control for this connection control.
+     *
+     * @return the agent control
+     */
+    AgentControl getAgentControl();
+
     /**
      * Gets id of the connection.
      *

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImpl.java
@@ -50,6 +50,7 @@ public class AgentControlImpl implements AgentControl {
     // That lock prevent cases when messages are received but connection not yet registered.
     private final Lock connectLock = new ReentrantLock();
 
+    private final EngineControlImpl engineControl;
     private final String agentId;
     private final String address;
     private final int port;
@@ -69,12 +70,15 @@ public class AgentControlImpl implements AgentControl {
     /**
      * Creates instanse of AgentControlImpl.
      *
-     * @param agentId id of agent
-     * @param address address of gRPC server of agent (MQTT client)
-     * @param port port of  gRPC server of agent (MQTT client)
+     * @param engineControl the back reference to whole engineControl
+     * @param agentId the id of agent
+     * @param address the address of gRPC server of agent (MQTT client)
+     * @param port the port of gRPC server of agent (MQTT client)
      */
-    public AgentControlImpl(@NonNull String agentId, @NonNull String address, int port) {
+    public AgentControlImpl(@NonNull EngineControlImpl engineControl, @NonNull String agentId, @NonNull String address,
+                                int port) {
         super();
+        this.engineControl = engineControl;
         this.agentId = agentId;
         this.address = address;
         this.port = port;
@@ -91,16 +95,22 @@ public class AgentControlImpl implements AgentControl {
     /**
      * Creates instanse of AgentControlImpl for testing.
      *
+     * @param engineControl the back reference to whole engineControl
      * @param agentId id of agent
      * @param address address of gRPC server of agent (MQTT client)
      * @param port port of  gRPC server of agent (MQTT client)
      * @param channel the channel
      * @param blockingStub the blockingStub
      */
-    AgentControlImpl(@NonNull String agentId, @NonNull String address, int port,
-                        @NonNull ConnectionControlFactory connectionControlFactory, @NonNull ManagedChannel channel,
+    AgentControlImpl(@NonNull EngineControlImpl engineControl,
+                        @NonNull String agentId,
+                        @NonNull String address,
+                        int port,
+                        @NonNull ConnectionControlFactory connectionControlFactory,
+                        @NonNull ManagedChannel channel,
                         @NonNull MqttClientControlGrpc.MqttClientControlBlockingStub blockingStub) {
         super();
+        this.engineControl = engineControl;
         this.agentId = agentId;
         this.address = address;
         this.port = port;
@@ -108,7 +118,6 @@ public class AgentControlImpl implements AgentControl {
         this.channel = channel;
         this.blockingStub = blockingStub;
     }
-
 
     @Override
     public int getTimeout() {
@@ -180,7 +189,6 @@ public class AgentControlImpl implements AgentControl {
         logger.atInfo().log("createMqttConnection: MQTT connectionId {} created", connectionControl.getConnectionId());
         return connectionControl;
     }
-
 
     /**
      * Do MQTT subscription(s).
@@ -272,6 +280,10 @@ public class AgentControlImpl implements AgentControl {
             // NOTE: connectionControl is not unregistered until closeMqttConnection() explicitly called
             connectionControl.onMqttDisconnect(disconnect, error);
         }
+    }
+
+    EngineControlImpl getEngineControl() {
+        return engineControl;
     }
 
     private void closeAllMqttConnections() {

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
@@ -39,7 +39,8 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
 
 
     interface AgentControlFactory {
-        AgentControlImpl newAgentControl(String agentId, String address, int port);
+        AgentControlImpl newAgentControl(@NonNull EngineControlImpl engineControl, @NonNull String agentId,
+                                            @NonNull String address, int port);
     }
 
     /**
@@ -48,8 +49,9 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
     public EngineControlImpl() {
         this(new AgentControlFactory() {
             @Override
-            public AgentControlImpl newAgentControl(String agentId, String address, int port) {
-                return new AgentControlImpl(agentId, address, port);
+            public AgentControlImpl newAgentControl(@NonNull EngineControlImpl engineControl, @NonNull String agentId, 
+                                                    @NonNull String address, int port) {
+                return new AgentControlImpl(engineControl, agentId, address, port);
             }
         });
     }
@@ -62,6 +64,7 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
         super();
         this.agentControlFactory = agentControlFactory;
     }
+
 
     @Override
     public void startEngine(int port, @NonNull EngineEvents engineEvents) throws IOException {
@@ -134,7 +137,7 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
         isNew[0] = false;
         AgentControlImpl agent = agents.computeIfAbsent(agentId, k -> {
             isNew[0] = true;
-            return agentControlFactory.newAgentControl(agentId, address, port);
+            return agentControlFactory.newAgentControl(this, agentId, address, port);
             });
 
         if (isNew[0]) {
@@ -157,7 +160,6 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
         }
     }
 
-
     @Override
     public void onMessageReceived(@NonNull String agentId, int connectionId, @NonNull Mqtt5Message message) {
         AgentControlImpl agentControl = agents.get(agentId);
@@ -167,7 +169,6 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
             agentControl.onMessageReceived(connectionId, message);
         }
     }
-
 
     @Override
     public void onMqttDisconnect(String agentId, int connectionId, Mqtt5Disconnect disconnect, String error) {

--- a/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImplTest.java
+++ b/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImplTest.java
@@ -44,6 +44,7 @@ class AgentControlImplTest {
     private static final int DEFAULT_PORT = 8474;
     private static final int TEST_TIMEOUT = 44;
 
+    private EngineControlImpl engineControl;
     private ManagedChannel channel;
     private MqttClientControlGrpc.MqttClientControlBlockingStub blockingStub;
     private AgentControlImpl.ConnectionControlFactory connectionControlFactory;
@@ -51,11 +52,12 @@ class AgentControlImplTest {
 
     @BeforeEach
     void setup() {
+        engineControl = mock(EngineControlImpl.class);
         connectionControlFactory = mock(AgentControlImpl.ConnectionControlFactory.class);
         channel = mock(ManagedChannel.class);
         blockingStub = mock(MqttClientControlGrpc.MqttClientControlBlockingStub.class);
-        agentControl = new AgentControlImpl(DEFAULT_AGENT_ID, DEFAULT_ADDRESS, DEFAULT_PORT, connectionControlFactory,
-                                            channel, blockingStub);
+        agentControl = new AgentControlImpl(engineControl, DEFAULT_AGENT_ID, DEFAULT_ADDRESS, DEFAULT_PORT,
+                                            connectionControlFactory, channel, blockingStub);
     }
 
     @AfterEach

--- a/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImplTest.java
+++ b/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImplTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.eq;
@@ -143,7 +144,7 @@ class EngineControlImplTest {
         final String agentAddress = "agent_address";
         final int agentPort = 43000;
         final AgentControlImpl agentControl = mock(AgentControlImpl.class);
-        when(agentControlFactory.newAgentControl(anyString(), anyString(), anyInt())).thenReturn(agentControl);
+        when(agentControlFactory.newAgentControl(any(EngineControlImpl.class), anyString(), anyString(), anyInt())).thenReturn(agentControl);
         engineControl.onDiscoveryAgent(agentId, agentAddress, agentPort);
 
         // WHEN
@@ -176,7 +177,7 @@ class EngineControlImplTest {
 
         final AgentControlImpl agentControl = mock(AgentControlImpl.class);
 
-        when(agentControlFactory.newAgentControl(anyString(), anyString(), anyInt())).thenReturn(agentControl);
+        when(agentControlFactory.newAgentControl(any(EngineControlImpl.class), anyString(), anyString(), anyInt())).thenReturn(agentControl);
         engineControl.onDiscoveryAgent(agentId, agentAddress, agentPort);
 
         // WHEN
@@ -199,7 +200,7 @@ class EngineControlImplTest {
 
         when(agentControl.getConnectionControl(eq(connectionName))).thenReturn(connectionControl);
 
-        when(agentControlFactory.newAgentControl(anyString(), anyString(), anyInt())).thenReturn(agentControl);
+        when(agentControlFactory.newAgentControl(any(EngineControlImpl.class), anyString(), anyString(), anyInt())).thenReturn(agentControl);
         engineControl.onDiscoveryAgent(agentId, agentAddress, agentPort);
 
         // WHEN
@@ -234,14 +235,14 @@ class EngineControlImplTest {
 
         final AgentControlImpl agentControl = mock(AgentControlImpl.class);
 
-        when(agentControlFactory.newAgentControl(anyString(), anyString(), anyInt())).thenReturn(agentControl);
+        when(agentControlFactory.newAgentControl(any(EngineControlImpl.class), anyString(), anyString(), anyInt())).thenReturn(agentControl);
 
         // WHEN
         engineControl.onDiscoveryAgent(agentId, agentAddress, agentPort);
 
         // THEN
         assertSame(agentControl, engineControl.getAgent(agentId));
-        verify(agentControlFactory, times(1)).newAgentControl(eq(agentId), eq(agentAddress), eq(agentPort));
+        verify(agentControlFactory, times(1)).newAgentControl(eq(engineControl), eq(agentId), eq(agentAddress), eq(agentPort));
         verify(agentControl, times(1)).startAgent();
         verify(engineEvents).onAgentAttached(eq(agentControl));
     }
@@ -258,7 +259,7 @@ class EngineControlImplTest {
 
         final AgentControlImpl agentControl = mock(AgentControlImpl.class);
 
-        when(agentControlFactory.newAgentControl(anyString(), anyString(), anyInt())).thenReturn(agentControl);
+        when(agentControlFactory.newAgentControl(any(EngineControlImpl.class), anyString(), anyString(), anyInt())).thenReturn(agentControl);
         engineControl.onDiscoveryAgent(agentId, agentAddress, agentPort);
 
         // WHEN
@@ -282,7 +283,7 @@ class EngineControlImplTest {
 
         final AgentControlImpl agentControl = mock(AgentControlImpl.class);
 
-        when(agentControlFactory.newAgentControl(anyString(), anyString(), anyInt())).thenReturn(agentControl);
+        when(agentControlFactory.newAgentControl(any(EngineControlImpl.class), anyString(), anyString(), anyInt())).thenReturn(agentControl);
         engineControl.onDiscoveryAgent(agentId, agentAddress, agentPort);
 
         final int connectionId = 22;
@@ -307,7 +308,7 @@ class EngineControlImplTest {
 
         final AgentControlImpl agentControl = mock(AgentControlImpl.class);
 
-        when(agentControlFactory.newAgentControl(anyString(), anyString(), anyInt())).thenReturn(agentControl);
+        when(agentControlFactory.newAgentControl(any(EngineControlImpl.class), anyString(), anyString(), anyInt())).thenReturn(agentControl);
         engineControl.onDiscoveryAgent(agentId, agentAddress, agentPort);
 
         final int connectionId = 22;

--- a/uat/testing-features/src/main/java/com/aws/greengrass/testing/mqtt/client/control/addon/api/Event.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/testing/mqtt/client/control/addon/api/Event.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.testing.mqtt.client.control.addon.api;
+
+import lombok.NonNull;
+
+/**
+ * Interface to generic event.
+ */
+public interface Event {
+    /** Type of the event. */
+    enum Type {
+        /** MQTT message is received. */
+        EVENT_TYPE_MQTT_MESSAGE,
+
+        // TODOL implement other events
+        // /** MQTT Connecttion established. */
+        // EVENT_TYPE_MQTT_CONNECTED,
+
+        // /** MQTT connection is disconnected. */
+        // EVENT_TYPE_MQTT_DISCONNECTED,
+
+        // /** Agent is registered and discovered. */
+        // EVENT_TYPE_AGENT_DISCOVERED,
+
+        // /** Agent is unregistered. */
+        // EVENT_TYPE_AGENT_UNREGISTERED,
+    }
+
+    /**
+     * Gets type of event.
+     *
+     * @return type of the event
+     */
+    Type getType();
+
+    /**
+     * Gets name of connection generated the event.
+     *
+     * @return name of the related connection
+     */
+    String getConnectionName();
+
+
+    /**
+     * Gets timestamp of the event.
+     *
+     * @return the value of System.currentTimeMillis() on the moment when event was been created
+     */
+    long getTimestamp();
+
+    /**
+     * Checks is the event matches to filter.
+     *
+     * @param filter the filter to match event
+     * @return true when the event matches to filter
+     */
+    boolean isMatched(@NonNull EventFilter filter);
+}

--- a/uat/testing-features/src/main/java/com/aws/greengrass/testing/mqtt/client/control/addon/api/EventFilter.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/testing/mqtt/client/control/addon/api/EventFilter.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.testing.mqtt.client.control.addon.api;
+
+import com.aws.greengrass.testing.mqtt.client.control.api.ConnectionControl;
+import lombok.Getter;
+import lombok.NonNull;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Filter of events in event storage.
+ */
+@Getter
+public final class EventFilter {
+    private final Event.Type type;
+    private final Long fromTimestamp;           // requires timestamp >= fromTimestamp
+    private final Long toTimestamp;             // means timestamp < toTimestamp
+    private final ConnectionControl connectionControl;
+    private final String agentId;
+    private final Integer connectionId;
+    private final String connectionName;
+    private final String topic;
+    private final String topicFilter;
+    private final byte[] content;
+
+    EventFilter(Builder builder) {
+        super();
+        this.type = builder.type;
+        this.fromTimestamp = builder.fromTimestamp;
+        this.toTimestamp = builder.toTimestamp;
+        this.connectionControl = builder.connectionControl;
+        this.agentId = builder.agentId;
+        this.connectionId = builder.connectionId;
+        this.connectionName = builder.connectionName;
+        this.topic = builder.topic;
+        this.topicFilter = builder.topicFilter;
+        this.content = builder.content;
+    }
+
+    /**
+     * Builder of event filter.
+     */
+    public static class Builder {
+        private Event.Type type;
+        private Long fromTimestamp;
+        private Long toTimestamp;
+        private ConnectionControl connectionControl;
+        private String agentId;
+        private Integer connectionId;
+        private String connectionName;
+        private String topic;
+        private String topicFilter;
+        private byte[] content;
+
+        /**
+         * Sets type of event.
+         * Applicable for any type of event
+         *
+         * @param type the type of events to select by filter
+         */
+        public Builder withType(@NonNull Event.Type type) {
+            this.type = type;
+            return this;
+        }
+
+        /**
+         * Sets `from timestamp` field of filter.
+         * Applicable for any type of event
+         *
+         * @param timestamp the minimal timestamp to select events by filter
+         */
+        public Builder withFromTimestamp(long timestamp) {
+            this.fromTimestamp = timestamp;
+            return this;
+        }
+
+        /**
+         * Sets `to timestamp` field of filter.
+         * Applicable for any type of event
+         *
+         * @param timestamp the maxinal timestamp to select events by filter
+         */
+        public Builder withToTimestamp(long timestamp) {
+            this.toTimestamp = timestamp;
+            return this;
+        }
+
+        /**
+         * Sets connectionControl field of filter.
+         * Applicable for types of event related to connection
+         *
+         * @param connectionControl the exact connectionControl to select events
+         */
+        public Builder withConnectionControl(@NonNull ConnectionControl connectionControl) {
+            this.connectionControl = connectionControl;
+            return this;
+        }
+
+        /**
+         * Sets agentId field of filter.
+         * Applicable for types of event related to agent and/or connection
+         * Does not used if connection is set
+         *
+         * @param agentId the id of agent to select events
+         */
+        public Builder withAgentId(@NonNull String agentId) {
+            this.agentId = agentId;
+            return this;
+        }
+
+        /**
+         * Sets connectionId field of filter.
+         * Applicable for types of event related to connection
+         * Does not used if connection is set
+         * Works only if also agentId is set
+         *
+         * @param connectionId the id of connection to select events
+         */
+        public Builder withConnectionId(int connectionId) {
+            this.connectionId = connectionId;
+            return this;
+        }
+
+        /**
+         * Sets connectionName field of filter.
+         * Applicable for types of event related to connection
+         * Does not used if connection is or agentId/connectionId are set
+         *
+         * @param connectionName the id of connection to select events
+         */
+        public Builder withConnectionName(@NonNull String connectionName) {
+            this.connectionName = connectionName;
+            return this;
+        }
+
+        /**
+         * Sets connectionName field of filter.
+         * Applicable only for MQTT message events
+         *
+         * @param topic the topic of MQTT message
+         */
+        public Builder withTopic(@NonNull String topic) {
+            this.topic = topic;
+            return this;
+        }
+
+        /**
+         * Sets connectionName field of filter.
+         * Applicable only for MQTT message events
+         * Does not used if topic is set
+         *
+         * @param topicFilter the topic filter (as for subscribe) of MQTT message
+         */
+        public Builder withTopicFilter(@NonNull String topicFilter) {
+            this.topicFilter = topicFilter;
+            return this;
+        }
+
+        /**
+         * Sets content field of filter.
+         * Applicable only for MQTT message events
+         * Both withContent() set the same field
+         *
+         * @param content the string content of MQTT message
+         */
+        public Builder withContent(@NonNull String content) {
+            return withContent(content.getBytes(StandardCharsets.UTF_8));
+        }
+
+        /**
+         * Sets content field of filter.
+         * Applicable only for MQTT message events
+         * Both withContent() set the same field
+         *
+         * @param content the byte arrat content of MQTT message
+         */
+        public Builder withContent(@NonNull byte[] content) {
+            this.content = content;
+            return this;
+        }
+
+        public EventFilter build() {
+            return new EventFilter(this);
+        }
+    }
+}

--- a/uat/testing-features/src/main/java/com/aws/greengrass/testing/mqtt/client/control/addon/api/EventStorage.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/testing/mqtt/client/control/addon/api/EventStorage.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.testing.mqtt.client.control.addon.api;
+
+import lombok.NonNull;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Interface to storage of the events.
+ */
+public interface EventStorage {
+
+    /**
+     * Removes all events from storage.
+     */
+    void clear();
+
+    /**
+     * Adds event to storage.
+     *
+     * @param event the event to add
+     */
+    void addEvent(@NonNull Event event);
+
+    /**
+     * Gets matched events from storage immediately.
+     *
+     * @param filter the filter of events
+     * @return the list of matched events
+     */
+    List<Event> getEvents(@NonNull EventFilter filter);
+
+    /**
+     * Waiting for matched events.
+     *
+     * @param filter the filter of events
+     * @param timeout the maximum time to wait
+     * @param unit the time unit of the timeout argument
+     * @return the list of matched events
+     * @throws TimeoutException if the wait timed out
+     * @throws InterruptedException if the current thread was interrupted while waiting
+     */
+    List<Event> awatingEvents(@NonNull EventFilter filter, long timeout, @NonNull TimeUnit unit)
+                throws TimeoutException, InterruptedException;
+}

--- a/uat/testing-features/src/main/java/com/aws/greengrass/testing/mqtt/client/control/addon/implementation/EventStorageImpl.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/testing/mqtt/client/control/addon/implementation/EventStorageImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.testing.mqtt.client.control.addon.implementation;
+
+import com.aws.greengrass.testing.mqtt.client.control.addon.api.Event;
+import com.aws.greengrass.testing.mqtt.client.control.addon.api.EventFilter;
+import com.aws.greengrass.testing.mqtt.client.control.addon.api.EventStorage;
+import lombok.NonNull;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+
+/**
+ * Implementation storage of the events.
+ */
+public class EventStorageImpl implements EventStorage {
+
+    private final List<Event> events = new LinkedList<>();
+
+    @Override
+    public void clear() {
+        synchronized (events) {
+            events.clear();
+        }
+    }
+
+    @Override
+    public void addEvent(@NonNull Event event) {
+         synchronized (events) {
+            events.add(event);
+            events.notifyAll();
+        }
+    }
+
+    @Override
+    public List<Event> getEvents(@NonNull EventFilter filter) {
+        List<Event> result;
+
+        synchronized (events) {
+            result = getEventsAsList(filter);
+        }
+
+        return result;
+    }
+
+    @Override
+    public List<Event> awatingEvents(@NonNull EventFilter filter, long timeout, @NonNull TimeUnit unit)
+                        throws TimeoutException, InterruptedException {
+        List<Event> result;
+        final long deadline = unit.toNanos(timeout) + System.nanoTime();
+
+        synchronized (events) {
+            result = getEventsAsList(filter);
+            while (result.isEmpty()) {
+                final long nanos = deadline - System.nanoTime();
+                if (nanos <= 0) {
+                    throw new TimeoutException("Event doesn't received, timedout");
+                }
+
+                TimeUnit.NANOSECONDS.timedWait(events, nanos);
+                result = getEventsAsList(filter);
+            }
+        }
+        return result;
+    }
+
+
+    private List<Event> getEventsAsList(@NonNull EventFilter filter) {
+        return events.stream().filter(event -> event.isMatched(filter)).collect(Collectors.toList());
+    }
+}

--- a/uat/testing-features/src/main/java/com/aws/greengrass/testing/mqtt/client/control/addon/implementation/MqttMessageEvent.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/testing/mqtt/client/control/addon/implementation/MqttMessageEvent.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.testing.mqtt.client.control.addon.implementation;
+
+import com.aws.greengrass.testing.mqtt.client.Mqtt5Message;
+import com.aws.greengrass.testing.mqtt.client.control.addon.api.Event;
+import com.aws.greengrass.testing.mqtt.client.control.addon.api.EventFilter;
+import com.aws.greengrass.testing.mqtt.client.control.api.ConnectionControl;
+import com.google.protobuf.ByteString;
+import lombok.NonNull;
+
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+/**
+ * Implements received MQTT message event.
+ */
+public class MqttMessageEvent implements Event {
+
+    private final long timestamp;
+    private final ConnectionControl connectionControl;
+    private final Mqtt5Message message;
+
+    /**
+     * Creates instance of MqttMessageEvent.
+     *
+     * @param connectionControl the connection control which receives that message
+     * @param message the gRPC presentation of received MQTT message
+     */
+    public MqttMessageEvent(@NonNull ConnectionControl connectionControl, @NonNull Mqtt5Message message) {
+        super();
+        this.timestamp = System.currentTimeMillis();
+        this.connectionControl = connectionControl;
+        this.message = message;
+    }
+
+    @Override
+    public Type getType() {
+        return Type.EVENT_TYPE_MQTT_MESSAGE;
+    }
+
+    @Override
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public String getConnectionName() {
+        return connectionControl.getConnectionName();
+    }
+
+    @Override
+    public boolean isMatched(@NonNull EventFilter filter) {
+
+        // check event type
+        final Event.Type type = filter.getType();
+        if (type != null && type != getType()) {
+            return false;
+        }
+
+        // check timestamp borders
+        boolean matched = compareTimestamps(filter.getFromTimestamp(), filter.getToTimestamp());
+        if (!matched) {
+            return false;
+        }
+
+        // check connection
+        matched = compareConnection(filter.getConnectionControl(), filter.getAgentId(), filter.getConnectionId(), 
+                                    filter.getConnectionName());
+        if (!matched) {
+            return false;
+        }
+
+        // check topic
+        final String topic = filter.getTopic();
+        if (topic != null) {
+            if (!topic.equals(message.getTopic())) {
+                return false;
+            }
+        } else {
+            // or topic filter
+            final String topicFilter = filter.getTopicFilter();
+            if (topicFilter != null && !isTopicMatched(message.getTopic(), topicFilter)) {
+                return false;
+            }
+        }
+
+        // TODO: check QoS ?
+
+        // check content
+        return comparePayload(filter.getContent());
+    }
+
+    private boolean compareTimestamps(Long from, Long to) {
+        // check from timestamp
+        if (from != null &&  getTimestamp() < from) {
+            return false;
+        }
+
+        return to == null || to > getTimestamp();
+    }
+
+
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    private boolean compareConnection(ConnectionControl expectedConnectionControl, String agentId, Integer connectionId,
+                                        String connectionName) {
+        // 1'st priority
+        if (expectedConnectionControl != null) {
+            // compare references !
+            return expectedConnectionControl == connectionControl;
+        }
+
+        // 2'st priority
+        if (agentId != null && connectionId != null) {
+            return agentId.equals(connectionControl.getAgentControl().getAgentId())
+                        && connectionId == connectionControl.getConnectionId();
+        }
+
+        // 3'th priority
+        // check connection name
+        return connectionName == null || connectionName.equals(getConnectionName());
+    }
+
+    private boolean comparePayload(byte[] expected) {
+        if (expected == null) {
+            return true;
+        }
+
+        ByteString byteStringPayload = message.getPayload();
+        if (byteStringPayload == null) {
+            return false;
+        } else {
+            return Arrays.equals(expected, byteStringPayload.toByteArray());
+        }
+    }
+
+    private static boolean isTopicMatched(@NonNull String topic, @NonNull String topicFilter) {
+        final String regex = topicFilter.replace("+", "[^/]+").replace("#", ".+");
+        return Pattern.matches(regex, topic);
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**
Create event storage

**Description of changes:**
- Added API of EventStorage, Event and EventFilter with builder
- Added implementation of EventStorageImpl and MqttMessageEvent
 
**Why is this change necessary:**
Received events like MQTT messages, disconnect (and partially connect) events can't be handled asynchronously and we need to store it. In addition we need to implement a counter of received messages matched to filter in future. We decided to implement EventStore with the ability to clear, put events, get events by filter and wait for some time for future events if currently missing.

**How was this change tested:**
That code is not yet used, not able to run manual tests. No unit tests has been created.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
