### PR TITLE
chore(uat): reorganize pom relations to parent-child

### DIFF
--- a/uat/custom-components/client-java-sdk/pom.xml
+++ b/uat/custom-components/client-java-sdk/pom.xml
@@ -8,10 +8,15 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.aws.greengrass</groupId>
+
+    <parent>
+        <groupId>com.aws.greengrass</groupId>
+        <artifactId>client-devices-auth-custom-components</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>client-devices-auth-uat-client-java-sdk</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.0-SNAPSHOT</version>
 
     <licenses>
         <license>
@@ -20,19 +25,11 @@
         </license>
     </licenses>
 
-    <repositories>
-        <repository>
-            <id>greengrass-common</id>
-            <name>Greengrass common</name>
-            <url>https://d2jrmugq4soldf.cloudfront.net/snapshots</url>
-        </repository>
-    </repositories>
-
     <dependencies>
         <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
-            <version>${annotation.api.version}</version>
+            <version>${javax.annotation.api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -268,7 +265,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>8.29</version>
+                        <version>${puppycrawl.checkstyle.version}</version>
                     </dependency>
                 </dependencies>
                 <configuration>
@@ -334,24 +331,6 @@
         <groups></groups>
         <jar.name>client-devices-auth-uat-client-java-sdk</jar.name>
         <main.class>com.aws.greengrass.testing.mqtt5.client.Main</main.class>
-        <!-- Dependencies versions -->
-        <log4j.version>2.20.0</log4j.version>
-        <iot.device.sdk.version>1.11.2</iot.device.sdk.version>
-        <protobuf.version>3.21.7</protobuf.version>
-        <protoc.version>3.21.7</protoc.version>
-        <grpc.version>1.53.0</grpc.version>
-        <lombok.version>1.18.22</lombok.version>
-        <annotation.api.version>1.3.2</annotation.api.version>
-        <protobuf.plugin.version>0.6.1</protobuf.plugin.version>
-        <os.plugin.version>1.7.1</os.plugin.version>
-        <exec.plugin.version>3.1.0</exec.plugin.version>
-        <jar.plugin.version>3.3.0</jar.plugin.version>
-        <compiler.plugin.version>3.8.1</compiler.plugin.version>
-        <pmd.plugin.version>3.13.0</pmd.plugin.version>
-        <license.plugin.version>4.0.rc2</license.plugin.version>
-        <spotbugs.plugin.version>4.0.0</spotbugs.plugin.version>
-        <checkstyle.plugin.version>3.1.0</checkstyle.plugin.version>
-        <shade.plugin.version>3.4.1</shade.plugin.version>
     </properties>
     <distributionManagement>
         <snapshotRepository>

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/Main.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/Main.java
@@ -64,7 +64,7 @@ public class Main {
     }
 
 
-    @SuppressWarnings("PMD.MissingBreakInSwitch")
+    @SuppressWarnings({"PMD.MissingBreakInSwitch", "PMD.ImplicitSwitchFallThrough"})
     private static Arguments parseArgs(String... args) {
         String agentId;
         String address = DEFAULT_GRPC_SERVER_IP;

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -157,7 +157,7 @@ public interface MqttConnection {
      * @return useful information from SUBACK packet
      * @throws MqttException on errors
      */
-    SubAckInfo subscribe(long timeout, final Integer subscriptionId, final List<Subscription> subscriptions)
+    SubAckInfo subscribe(long timeout, Integer subscriptionId, List<Subscription> subscriptions)
             throws MqttException;
 
 
@@ -169,7 +169,7 @@ public interface MqttConnection {
      * @return useful information from PUBACK packet or null of no PUBACK has been received (as for QoS 0)
      * @throws MqttException on errors
      */
-    PubAckInfo publish(long timeout, final Message message) throws MqttException;
+    PubAckInfo publish(long timeout, Message message) throws MqttException;
 
     /**
      * Unsubscribes from topics.
@@ -179,7 +179,7 @@ public interface MqttConnection {
      * @return useful information from UNSUBACK packet
      * @throws MqttException on errors
      */
-    UnsubAckInfo unsubscribe(long timeout, final List<String> filters) throws MqttException;
+    UnsubAckInfo unsubscribe(long timeout, List<String> filters) throws MqttException;
 
     /**
      * Closes MQTT connection.

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -111,6 +111,7 @@ class GRPCControlServer {
          * @param request incoming request
          * @param responseObserver response control
          */
+        @SuppressWarnings("PMD.CognitiveComplexity")
         @Override
         public void createMqttConnection(MqttConnectRequest request,
                                             StreamObserver<MqttConnectReply> responseObserver) {
@@ -377,6 +378,7 @@ class GRPCControlServer {
          * @param request incoming request
          * @param responseObserver response control
          */
+        @SuppressWarnings("PMD.CognitiveComplexity")
         @Override
         public void subscribeMqtt(MqttSubscribeRequest request, StreamObserver<MqttSubscribeReply> responseObserver) {
 
@@ -620,6 +622,7 @@ class GRPCControlServer {
         }
     }
 
+    @SuppressWarnings("PMD.CognitiveComplexity")
     private static Mqtt5ConnAck convertConnAckInfo(MqttConnection.ConnAckInfo conAckInfo) {
         final Mqtt5ConnAck.Builder builder = Mqtt5ConnAck.newBuilder();
 

--- a/uat/custom-components/pom.xml
+++ b/uat/custom-components/pom.xml
@@ -9,72 +9,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.aws.greengrass</groupId>
+    <parent>
+        <groupId>com.aws.greengrass</groupId>
+        <artifactId>client-devices-auth-uat</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>client-devices-auth-custom-components</artifactId>
-    <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
+
     <modules>
-        <module>
-            client-java-sdk
-        </module>
+        <module>client-java-sdk</module>
     </modules>
-    <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-    </properties>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.13.0</version>
-                <configuration>
-                    <!-- Current violations should not be exceeded. Try to decrease these over time -->
-                    <maxAllowedViolations>0</maxAllowedViolations>
-                    <printFailingErrors>true</printFailingErrors>
-                    <rulesets>
-                        <ruleset>../../codestyle/pmd-eg-ruleset.xml</ruleset>
-                        <ruleset>../../codestyle/pmd-eg-tests-ruleset.xml</ruleset>
-                    </rulesets>
-                    <includeTests>true</includeTests>
-                    <skip>${skipTests}</skip>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.0</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.puppycrawl.tools</groupId>
-                        <artifactId>checkstyle</artifactId>
-                        <version>8.29</version>
-                    </dependency>
-                </dependencies>
-                <configuration>
-                    <logViolationsToConsole>true</logViolationsToConsole>
-                    <configLocation>../../codestyle/checkstyle.xml</configLocation>
-                    <violationSeverity>warning</violationSeverity>
-                    <maxAllowedViolations>0</maxAllowedViolations>
-                    <skip>${skipTests}</skip>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>validate</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/uat/mqtt-client-control/pom.xml
+++ b/uat/mqtt-client-control/pom.xml
@@ -8,10 +8,15 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.aws.greengrass</groupId>
+
+    <parent>
+        <groupId>com.aws.greengrass</groupId>
+        <artifactId>client-devices-auth-uat</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>aws-greengrass-testing-mqtt-client-control</artifactId>
     <packaging>jar</packaging>
-    <version>${revision}</version>
 
     <licenses>
         <license>
@@ -21,21 +26,11 @@
     </licenses>
     <properties>
         <jar.name>aws-greengrass-testing-mqtt-client-control</jar.name>
-        <revision>1.0.0-SNAPSHOT</revision>
         <main.class>com.aws.greengrass.testing.mqtt.client.control.ExampleControl</main.class>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <skipTests>false</skipTests>
-        <!-- Dependency versions -->
-        <protobuf.version>3.21.7</protobuf.version>
-        <protoc.version>3.21.7</protoc.version>
-        <grpc.version>1.53.0</grpc.version>
-        <protobuf.plugin.version>0.6.1</protobuf.plugin.version>
-        <os.plugin.version>1.7.1</os.plugin.version>
-        <log4j.version>2.20.0</log4j.version>
-        <shade.plugin.version>3.4.1</shade.plugin.version>
-        <lombok.version>1.18.22</lombok.version>
     </properties>
 
     <dependencies>
@@ -65,7 +60,7 @@
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>annotations-api</artifactId>
-            <version>6.0.53</version>
+            <version>${tomcat.annotations.api.version}</version>
             <scope>provided</scope> <!-- not needed at runtime -->
         </dependency>
         <dependency>
@@ -133,7 +128,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>${exec.plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -168,7 +163,7 @@
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <version>4.2.rc3</version>
+                <version>${license.plugin.version}</version>
                 <configuration>
                     <licenseSets>
                         <licenseSet>
@@ -198,12 +193,12 @@
             </plugin>
             <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>${checkstyle.plugin.version}</version>
                 <dependencies>
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>8.29</version>
+                        <version>${puppycrawl.checkstyle.version}</version>
                     </dependency>
                 </dependencies>
                 <configuration>
@@ -227,7 +222,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.20.0</version>
+                <version>${pmd.plugin.version}</version>
                 <configuration>
                     <analysisCache>true</analysisCache>
                     <!-- Current violations should not be exceeded. Try to decrease these over time -->

--- a/uat/pom.xml
+++ b/uat/pom.xml
@@ -9,78 +9,51 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <groupId>com.aws.greengrass</groupId>
     <artifactId>client-devices-auth-uat</artifactId>
-    <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
+    <version>${revision}</version>
+
     <modules>
-        <module>
-            custom-components
-        </module>
-        <module>
-            mqtt-client-control
-        </module>
-        <module>
-            testing-features
-        </module>
+        <module>custom-components</module>
+        <module>mqtt-client-control</module>
+        <module>testing-features</module>
     </modules>
+
+    <repositories>
+        <repository>
+            <id>greengrass-common</id>
+            <name>greengrass common</name>
+            <!-- CloudFront url fronting the aws-greengrass-testing-standalone in S3-->
+            <url>https://d2jrmugq4soldf.cloudfront.net/snapshots</url>
+        </repository>
+    </repositories>
+
     <properties>
+        <revision>1.0-SNAPSHOT</revision>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
+        <!-- Dependency versions -->
+        <protobuf.plugin.version>0.6.1</protobuf.plugin.version>
+        <protobuf.version>3.21.7</protobuf.version>
+        <protoc.version>3.21.7</protoc.version>
+        <grpc.version>1.53.0</grpc.version>
+        <os.plugin.version>1.7.1</os.plugin.version>
+        <lombok.version>1.18.22</lombok.version>
+        <iot.device.sdk.version>1.11.2</iot.device.sdk.version>
+        <tomcat.annotations.api.version>6.0.53</tomcat.annotations.api.version>
+        <javax.annotation.api.version>1.3.2</javax.annotation.api.version>
+        <log4j.version>2.20.0</log4j.version>
+        <jar.plugin.version>3.3.0</jar.plugin.version>
+        <shade.plugin.version>3.4.1</shade.plugin.version>
+        <exec.plugin.version>3.1.0</exec.plugin.version>
+        <license.plugin.version>4.2.rc3</license.plugin.version>
+        <checkstyle.plugin.version>3.1.0</checkstyle.plugin.version>
+        <puppycrawl.checkstyle.version>8.29</puppycrawl.checkstyle.version>
+        <pmd.plugin.version>3.20.0</pmd.plugin.version>
+        <compiler.plugin.version>3.8.1</compiler.plugin.version>
+        <spotbugs.plugin.version>4.0.0</spotbugs.plugin.version>
+        <antrun.plugin.version>3.0.0</antrun.plugin.version>
     </properties>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.13.0</version>
-                <configuration>
-                    <!-- Current violations should not be exceeded. Try to decrease these over time -->
-                    <maxAllowedViolations>0</maxAllowedViolations>
-                    <printFailingErrors>true</printFailingErrors>
-                    <rulesets>
-                        <ruleset>../codestyle/pmd-eg-ruleset.xml</ruleset>
-                        <ruleset>../codestyle/pmd-eg-tests-ruleset.xml</ruleset>
-                    </rulesets>
-                    <includeTests>true</includeTests>
-                    <skip>${skipTests}</skip>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.0</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.puppycrawl.tools</groupId>
-                        <artifactId>checkstyle</artifactId>
-                        <version>8.29</version>
-                    </dependency>
-                </dependencies>
-                <configuration>
-                    <logViolationsToConsole>true</logViolationsToConsole>
-                    <configLocation>../codestyle/checkstyle.xml</configLocation>
-                    <violationSeverity>warning</violationSeverity>
-                    <maxAllowedViolations>0</maxAllowedViolations>
-                    <skip>${skipTests}</skip>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>validate</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/uat/testing-features/pom.xml
+++ b/uat/testing-features/pom.xml
@@ -9,35 +9,134 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.aws.greengrass</groupId>
+
+    <parent>
+        <groupId>com.aws.greengrass</groupId>
+        <artifactId>client-devices-auth-uat</artifactId>
+        <version>${revision}</version>
+    </parent>
+
     <artifactId>client-devices-auth-testing-features</artifactId>
-    <version>1.0-SNAPSHOT</version>
+
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <skipTests>false</skipTests>
-        <lombok.version>1.18.22</lombok.version>
         <greengrass.testing.version>1.1.0-SNAPSHOT</greengrass.testing.version>
         <shade.plugin.version>3.4.1</shade.plugin.version>
     </properties>
-    <repositories>
-        <repository>
-            <id>greengrass-common</id>
-            <name>greengrass common</name>
-            <!-- CloudFront url fronting the aws-greengrass-testing-standalone in S3-->
-            <url>https://d2jrmugq4soldf.cloudfront.net/snapshots</url>
-        </repository>
-    </repositories>
     <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>aws-greengrass-testing-mqtt-client-control</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>aws-greengrass-testing-standalone</artifactId>
             <version>${greengrass.testing.version}</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>${license.plugin.version}</version>
+                <configuration>
+                    <licenseSets>
+                        <licenseSet>
+                            <header>../../.license/header.txt</header>
+                            <headerDefinitions>
+                                <headerDefinition>../../.license/style.xml</headerDefinition>
+                            </headerDefinitions>
+                            <useDefaultExcludes>true</useDefaultExcludes>
+                            <excludes>
+                                <exclude>*</exclude>
+                                <exclude>src/*/resources/**</exclude>
+                            </excludes>
+                        </licenseSet>
+                    </licenseSets>
+                    <mapping>
+                        <java>JAVA_STYLE</java>
+                        <properties>SHELL_STYLE</properties>
+                    </mapping>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${checkstyle.plugin.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>${puppycrawl.checkstyle.version}</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <logViolationsToConsole>true</logViolationsToConsole>
+                    <configLocation>../../codestyle/checkstyle.xml</configLocation>
+                    <violationSeverity>warning</violationSeverity>
+                    <maxAllowedViolations>0</maxAllowedViolations>
+                    <excludes>**/TODO</excludes>
+                    <skip>${skipTests}</skip>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>${pmd.plugin.version}</version>
+                <configuration>
+                    <analysisCache>true</analysisCache>
+                    <!-- Current violations should not be exceeded. Try to decrease these over time -->
+                    <maxAllowedViolations>0</maxAllowedViolations>
+                    <printFailingErrors>true</printFailingErrors>
+                    <rulesets>
+                        <ruleset>../../codestyle/pmd-eg-ruleset.xml</ruleset>
+                        <ruleset>../../codestyle/pmd-eg-tests-ruleset.xml</ruleset>
+                    </rulesets>
+                    <includeTests>true</includeTests>
+                    <skip>${skipTests}</skip>
+                    <excludes>
+                        <exclude>**/generated/*.java</exclude>
+                    </excludes>
+                    <excludeRoots>
+                        <excludeRoot>target/generated-sources/protobuf</excludeRoot>
+                    </excludeRoots>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
@@ -64,7 +163,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>${antrun.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>copy-artifact-to-classpath</id>

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.aws.greengrass.steps;
 
 import io.cucumber.guice.ScenarioScoped;
@@ -48,6 +53,7 @@ public class MqttControlSteps {
         //@TODO Implement method
     }
 
+    @SuppressWarnings("PMD.UseObjectForClearerAPI")
     @And("message {string} received on {string} from {string} topic within {int} {word}")
     public void receive(String message, String clientDeviceId, String topic, int value, String unitOfMeasure) {
         //@TODO Implement method


### PR DESCRIPTION
**Issue #, if available:**
Change pom relations from standalone to parent-children

**Description of changes:**
- pom files are changed to use parent for subprojects
- All plugins/dependecies versions moved to root pom file
- Resolved newly appeared license/checkstype/PMD issues

**Why is this change necessary:**
Subproject testing-features depends on subproject mqtt-client-control and before we have all subprojects as standalone.

**How was this change tested:**
CI build

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
