### PR TITLE
test(uat): added ConnectionControlImplTest in uat MQTT client control

### DIFF
--- a/uat/mqtt-client-control/pom.xml
+++ b/uat/mqtt-client-control/pom.xml
@@ -79,6 +79,18 @@
             <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${jupiter.api.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -249,6 +261,11 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/uat/mqtt-client-control/pom.xml
+++ b/uat/mqtt-client-control/pom.xml
@@ -91,6 +91,12 @@
             <version>${mockito.junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito.inline.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/ExampleControl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/ExampleControl.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.testing.mqtt.client.control;
 import com.aws.greengrass.testing.mqtt.client.control.api.AgentControl;
 import com.aws.greengrass.testing.mqtt.client.control.api.EngineControl;
 import com.aws.greengrass.testing.mqtt.client.control.api.EngineControl.EngineEvents;
+import com.aws.greengrass.testing.mqtt.client.control.implementation.AgentControlImpl;
 import com.aws.greengrass.testing.mqtt.client.control.implementation.EngineControlImpl;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -57,7 +58,12 @@ public class ExampleControl {
         super();
         this.useTLS = useTLS;
         this.port = port;
-        this.engine = new EngineControlImpl();
+        this.engine = new EngineControlImpl(new EngineControlImpl.AgentControlFactory() {
+            @Override
+            public AgentControlImpl newAgentControl(String agentId, String address, int port) {
+                return new AgentControlImpl(agentId, address, port);
+            }
+        });
     }
 
     private void testRun() throws IOException, InterruptedException {

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/ExampleControl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/ExampleControl.java
@@ -36,7 +36,7 @@ public class ExampleControl {
         @Override
         public void onAgentAttached(AgentControl agent) {
             logger.atInfo().log("Agent {} is connected", agent.getAgentId());
-            AgentTestScenario scenario = new AgentTestScenario(useTLS, engine, agent);
+            AgentTestScenario scenario = new AgentTestScenario(useTLS, agent);
             executorService.submit(scenario);
         }
 

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/ExampleControl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/ExampleControl.java
@@ -8,7 +8,6 @@ package com.aws.greengrass.testing.mqtt.client.control;
 import com.aws.greengrass.testing.mqtt.client.control.api.AgentControl;
 import com.aws.greengrass.testing.mqtt.client.control.api.EngineControl;
 import com.aws.greengrass.testing.mqtt.client.control.api.EngineControl.EngineEvents;
-import com.aws.greengrass.testing.mqtt.client.control.implementation.AgentControlImpl;
 import com.aws.greengrass.testing.mqtt.client.control.implementation.EngineControlImpl;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -58,12 +57,7 @@ public class ExampleControl {
         super();
         this.useTLS = useTLS;
         this.port = port;
-        this.engine = new EngineControlImpl(new EngineControlImpl.AgentControlFactory() {
-            @Override
-            public AgentControlImpl newAgentControl(String agentId, String address, int port) {
-                return new AgentControlImpl(agentId, address, port);
-            }
-        });
+        this.engine = new EngineControlImpl();
     }
 
     private void testRun() throws IOException, InterruptedException {

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/AgentControl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/AgentControl.java
@@ -79,6 +79,15 @@ public interface AgentControl {
                                             @NonNull ConnectionEvents connectionEvents);
 
     /**
+     * Gets connection control by connection name.
+     * Searching over all controls and find first occurrence of control with such name
+     *
+     * @param connectionName the logical name of a connection
+     * @return connection control or null when does not found
+     */
+    ConnectionControl getConnectionControl(@NonNull String connectionName);
+
+    /**
      * Shutdown whole agent.
      *
      * @param reason shutdown reason

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/EngineControl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/EngineControl.java
@@ -42,9 +42,9 @@ public interface EngineControl {
 
     /**
      * Gets port where gRPC service actually bound to.
-     * @return actual port where gRPC server is listeding
+     * @return actual port where gRPC server is listen or null if not running
      */
-    int getBoundPort();
+    Integer getBoundPort();
 
     /**
      * Checks is engine runing.

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImpl.java
@@ -73,6 +73,25 @@ public class AgentControlImpl implements AgentControl {
         this.port = port;
     }
 
+    /**
+     * Creates instanse of AgentControlImpl for testing.
+     *
+     * @param agentId id of agent
+     * @param address address of gRPC server of agent (MQTT client)
+     * @param port port of  gRPC server of agent (MQTT client)
+     * @param channel the channel
+     * @param blockingStub the blockingStub
+     */
+    AgentControlImpl(String agentId, String address, int port, ManagedChannel channel,
+                        MqttClientControlGrpc.MqttClientControlBlockingStub blockingStub) {
+        super();
+        this.agentId = agentId;
+        this.address = address;
+        this.port = port;
+        this.channel = channel;
+        this.blockingStub = blockingStub;
+    }
+
 
     @Override
     public int getTimeout() {
@@ -90,7 +109,7 @@ public class AgentControlImpl implements AgentControl {
      * @param connectionId id of connected where receives message
      * @param message the received MQTT message
      */
-    public void onMessageReceived(int connectionId, Mqtt5Message message) {
+    void onMessageReceived(int connectionId, Mqtt5Message message) {
         ConnectionControlImpl connectionControl;
         try {
             connectLock.lock();
@@ -113,7 +132,7 @@ public class AgentControlImpl implements AgentControl {
      * @param disconnect optional infomation from DISCONNECT packet
      * @param error optional OS-dependent error string
      */
-    public void onMqttDisconnect(int connectionId, Mqtt5Disconnect disconnect, String error) {
+    void onMqttDisconnect(int connectionId, Mqtt5Disconnect disconnect, String error) {
         ConnectionControlImpl connectionControl = connections.get(connectionId);
         if (connectionControl == null) {
             logger.atWarn().log("MQTT disconnect received but connection with id {} could not found", connectionId);

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImpl.java
@@ -53,11 +53,18 @@ public class AgentControlImpl implements AgentControl {
     private final String agentId;
     private final String address;
     private final int port;
+    private final ConnectionControlFactory connectionControlFactory;
     private int timeout = DEFAULT_TIMEOUT;
 
     private ManagedChannel channel;
     private MqttClientControlGrpc.MqttClientControlBlockingStub blockingStub;
 
+
+    public interface ConnectionControlFactory {
+        ConnectionControlImpl newConnectionControl(MqttConnectReply connectReply,
+                                                    @NonNull ConnectionEvents connectionEvents,
+                                                    @NonNull AgentControlImpl agent);
+    }
 
     /**
      * Creates instanse of AgentControlImpl.
@@ -66,11 +73,19 @@ public class AgentControlImpl implements AgentControl {
      * @param address address of gRPC server of agent (MQTT client)
      * @param port port of  gRPC server of agent (MQTT client)
      */
-    public AgentControlImpl(String agentId, String address, int port) {
+    public AgentControlImpl(@NonNull String agentId, @NonNull String address, int port) {
         super();
         this.agentId = agentId;
         this.address = address;
         this.port = port;
+        this.connectionControlFactory = new ConnectionControlFactory() {
+                @Override
+                public ConnectionControlImpl newConnectionControl(MqttConnectReply connectReply,
+                                                                    @NonNull ConnectionEvents connectionEvents,
+                                                                    @NonNull AgentControlImpl agent) {
+                    return new ConnectionControlImpl(connectReply, connectionEvents, agent);
+                }
+            };
     }
 
     /**
@@ -82,12 +97,14 @@ public class AgentControlImpl implements AgentControl {
      * @param channel the channel
      * @param blockingStub the blockingStub
      */
-    AgentControlImpl(String agentId, String address, int port, ManagedChannel channel,
-                        MqttClientControlGrpc.MqttClientControlBlockingStub blockingStub) {
+    AgentControlImpl(@NonNull String agentId, @NonNull String address, int port,
+                        @NonNull ConnectionControlFactory connectionControlFactory, @NonNull ManagedChannel channel,
+                        @NonNull MqttClientControlGrpc.MqttClientControlBlockingStub blockingStub) {
         super();
         this.agentId = agentId;
         this.address = address;
         this.port = port;
+        this.connectionControlFactory = connectionControlFactory;
         this.channel = channel;
         this.blockingStub = blockingStub;
     }
@@ -103,13 +120,128 @@ public class AgentControlImpl implements AgentControl {
         this.timeout = timeout;
     }
 
+    @Override
+    public void startAgent() {
+        this.channel = Grpc.newChannelBuilderForAddress(address, port, InsecureChannelCredentials.create()).build();
+        this.blockingStub = MqttClientControlGrpc.newBlockingStub(this.channel);
+    }
+
+    @Override
+    public void stopAgent() {
+        closeAllMqttConnections();
+        disconnect();
+    }
+
+    @Override
+    public String getAgentId() {
+        return agentId;
+    }
+
+    @Override
+    public ConnectionControl getConnectionControl(@NonNull String connectionName) {
+        for (ConcurrentHashMap.Entry<Integer, ConnectionControlImpl> entry : connections.entrySet()) {
+            ConnectionControlImpl connectionControl = entry.getValue();
+            if (connectionName.equals(connectionControl.getConnectionName())) {
+                return connectionControl;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void shutdownAgent(@NonNull String reason) {
+        ShutdownRequest request = ShutdownRequest.newBuilder().setReason(reason).build();
+        blockingStub.shutdownAgent(request);
+        isShutdownSent.set(true);
+        logger.atInfo().log("shutdown request sent successfully");
+    }
+
+    @Override
+    public ConnectionControl createMqttConnection(@NonNull MqttConnectRequest connectRequest,
+                                                    @NonNull ConnectionEvents connectionEvents) {
+        ConnectionControlImpl connectionControl;
+        try {
+            connectLock.lock();
+            MqttConnectReply response = blockingStub.createMqttConnection(connectRequest);
+            if (response.getConnected()) {
+                int connectionId = response.getConnectionId().getConnectionId();
+                connectionControl = connectionControlFactory.newConnectionControl(response, connectionEvents, this);
+                connections.put(connectionId, connectionControl);
+                logger.atInfo().log("Created connection with id {} CONNACK '{}'", connectionId, response.getConnAck());
+            } else {
+                String error = response.getError();
+                Mqtt5ConnAck connAck = response.getConnAck();
+                logger.atError().log("Couldn't create MQTT connection error '{}' CONNACK '{}'", error, connAck);
+                throw new RuntimeException("Couldn't create MQTT connection: " + error);
+            }
+        } finally {
+            connectLock.unlock();
+        }
+        logger.atInfo().log("createMqttConnection: MQTT connectionId {} created", connectionControl.getConnectionId());
+        return connectionControl;
+    }
+
+
+    /**
+     * Do MQTT subscription(s).
+     *
+     * @param subscribeRequest subscribe request
+     * @return reply to subscribe
+     * @throws StatusRuntimeException on errors
+     */
+    MqttSubscribeReply subscribeMqtt(@NonNull MqttSubscribeRequest subscribeRequest) {
+        int connectionId = subscribeRequest.getConnectionId().getConnectionId();
+        logger.atInfo().log("SubscribeMqtt: subscribe on connection {}", connectionId);
+        return blockingStub.subscribeMqtt(subscribeRequest);
+    }
+
+    /**
+     * Remove MQTT subscription(s).
+     *
+     * @param unsubscribeRequest unsubscribe request
+     * @return reply to unsubscribe
+     * @throws StatusRuntimeException on errors
+     */
+    MqttSubscribeReply unsubscribeMqtt(@NonNull MqttUnsubscribeRequest unsubscribeRequest) {
+        int connectionId = unsubscribeRequest.getConnectionId().getConnectionId();
+        logger.atInfo().log("UnsubscribeMqtt: unsubscribe on connectionId {}", connectionId);
+        return blockingStub.unsubscribeMqtt(unsubscribeRequest);
+    }
+
+    /**
+     * Publish MQTT message.
+     *
+     * @param publishRequest publish request
+     * @return reply to publish
+     * @throws StatusRuntimeException on errors
+     */
+    MqttPublishReply publishMqtt(@NonNull MqttPublishRequest publishRequest) {
+        int connectionId = publishRequest.getConnectionId().getConnectionId();
+        String topic = publishRequest.getMsg().getTopic();
+        logger.atInfo().log("PublishMqtt: publishing on connectionId {} topic {}", connectionId, topic);
+        return blockingStub.publishMqtt(publishRequest);
+    }
+
+    /**
+     * Close MQTT connection to the broker.
+     *
+     * @param closeRequest parameters of MQTT disconnect
+     * @throws StatusRuntimeException on errors
+     */
+    void closeMqttConnection(@NonNull MqttCloseRequest closeRequest) {
+        blockingStub.closeMqttConnection(closeRequest);
+        int connectionId = closeRequest.getConnectionId().getConnectionId();
+        connections.remove(connectionId);
+        logger.atInfo().log("closeMqttConnection: MQTT connectionId {} closed", connectionId);
+    }
+
     /**
      * Called when MQTT message has been received.
      *
      * @param connectionId id of connected where receives message
      * @param message the received MQTT message
      */
-    void onMessageReceived(int connectionId, Mqtt5Message message) {
+    void onMessageReceived(int connectionId, @NonNull Mqtt5Message message) {
         ConnectionControlImpl connectionControl;
         try {
             connectLock.lock();
@@ -132,7 +264,7 @@ public class AgentControlImpl implements AgentControl {
      * @param disconnect optional infomation from DISCONNECT packet
      * @param error optional OS-dependent error string
      */
-    void onMqttDisconnect(int connectionId, Mqtt5Disconnect disconnect, String error) {
+    void onMqttDisconnect(int connectionId, @NonNull Mqtt5Disconnect disconnect, String error) {
         ConnectionControlImpl connectionControl = connections.get(connectionId);
         if (connectionControl == null) {
             logger.atWarn().log("MQTT disconnect received but connection with id {} could not found", connectionId);
@@ -140,120 +272,6 @@ public class AgentControlImpl implements AgentControl {
             // NOTE: connectionControl is not unregistered until closeMqttConnection() explicitly called
             connectionControl.onMqttDisconnect(disconnect, error);
         }
-    }
-
-    @Override
-    public void startAgent() {
-        this.channel = Grpc.newChannelBuilderForAddress(address, port, InsecureChannelCredentials.create()).build();
-        this.blockingStub = MqttClientControlGrpc.newBlockingStub(this.channel);
-    }
-
-    @Override
-    public void stopAgent() {
-        closeAllMqttConnections();
-        disconnect();
-    }
-
-    @Override
-    public String getAgentId() {
-        return agentId;
-    }
-
-    @Override
-    public void shutdownAgent(String reason) {
-        ShutdownRequest request = ShutdownRequest.newBuilder().setReason(reason).build();
-        blockingStub.shutdownAgent(request);
-        logger.atInfo().log("shutdown request sent successfully");
-        isShutdownSent.set(true);
-    }
-
-    @Override
-    public ConnectionControl createMqttConnection(@NonNull MqttConnectRequest connectRequest,
-                                                    @NonNull ConnectionEvents connectionEvents) {
-        ConnectionControlImpl connectionControl;
-        try {
-            connectLock.lock();
-            MqttConnectReply response = blockingStub.createMqttConnection(connectRequest);
-            if (response.getConnected()) {
-                int connectionId = response.getConnectionId().getConnectionId();
-                connectionControl = new ConnectionControlImpl(response, connectionEvents, this);
-                connections.put(connectionId, connectionControl);
-                logger.atInfo().log("Created connection with id {} CONNACK '{}'", connectionId, response.getConnAck());
-            } else {
-                String error = response.getError();
-                Mqtt5ConnAck connAck = response.getConnAck();
-                logger.atError().log("Couldn't create MQTT connection error '{}' CONNACK '{}'", error, connAck);
-                throw new RuntimeException("Couldn't create MQTT connection: " + error);
-            }
-        } finally {
-            connectLock.unlock();
-        }
-        logger.atInfo().log("createMqttConnection: MQTT connectionId {} created", connectionControl.getConnectionId());
-        return connectionControl;
-    }
-
-    /**
-     * Close MQTT connection to the broker.
-     *
-     * @param closeRequest parameters of MQTT disconnect
-     * @throws StatusRuntimeException on errors
-     */
-    void closeMqttConnection(MqttCloseRequest closeRequest) {
-        blockingStub.closeMqttConnection(closeRequest);
-        int connectionId = closeRequest.getConnectionId().getConnectionId();
-        connections.remove(connectionId);
-        logger.atInfo().log("closeMqttConnection: MQTT connectionId {} closed", connectionId);
-    }
-
-    /**
-     * Do MQTT subscription(s).
-     *
-     * @param subscribeRequest subscribe request
-     * @return reply to subscribe
-     * @throws StatusRuntimeException on errors
-     */
-    MqttSubscribeReply subscribeMqtt(MqttSubscribeRequest subscribeRequest) {
-        int connectionId = subscribeRequest.getConnectionId().getConnectionId();
-        logger.atInfo().log("SubscribeMqtt: subscribe on connection {}", connectionId);
-        return blockingStub.subscribeMqtt(subscribeRequest);
-    }
-
-    /**
-     * Remove MQTT subscription(s).
-     *
-     * @param unsubscribeRequest unsubscribe request
-     * @return reply to unsubscribe
-     * @throws StatusRuntimeException on errors
-     */
-    MqttSubscribeReply unsubscribeMqtt(MqttUnsubscribeRequest unsubscribeRequest) {
-        int connectionId = unsubscribeRequest.getConnectionId().getConnectionId();
-        logger.atInfo().log("UnsubscribeMqtt: unsubscribe on connectionId {}", connectionId);
-        return blockingStub.unsubscribeMqtt(unsubscribeRequest);
-    }
-
-    /**
-     * Publish MQTT message.
-     *
-     * @param publishRequest publish request
-     * @return reply to publish
-     * @throws StatusRuntimeException on errors
-     */
-    MqttPublishReply publishMqtt(MqttPublishRequest publishRequest) {
-        int connectionId = publishRequest.getConnectionId().getConnectionId();
-        String topic = publishRequest.getMsg().getTopic();
-        logger.atInfo().log("PublishMqtt: publishing on connectionId {} topic {}", connectionId, topic);
-        return blockingStub.publishMqtt(publishRequest);
-    }
-
-    @Override
-    public ConnectionControl getConnectionControl(@NonNull String connectionName) {
-        for (ConcurrentHashMap.Entry<Integer, ConnectionControlImpl> entry : connections.entrySet()) {
-            ConnectionControlImpl connectionControl = entry.getValue();
-            if (connectionName.equals(connectionControl.getConnectionName())) {
-                return connectionControl;
-            }
-        }
-        return null;
     }
 
     private void closeAllMqttConnections() {

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImpl.java
@@ -66,7 +66,7 @@ public class AgentControlImpl implements AgentControl {
      * @param address address of gRPC server of agent (MQTT client)
      * @param port port of  gRPC server of agent (MQTT client)
      */
-    AgentControlImpl(String agentId, String address, int port) {
+    public AgentControlImpl(String agentId, String address, int port) {
         super();
         this.agentId = agentId;
         this.address = address;
@@ -245,14 +245,8 @@ public class AgentControlImpl implements AgentControl {
         return blockingStub.publishMqtt(publishRequest);
     }
 
-    /**
-     * Gets connection control by connection name.
-     * Searching over all controls and find first occurrence of control with such name
-     *
-     * @param connectionName the logical name of a connection
-     * @return connection control or null when does not found
-     */
-    ConnectionControlImpl getConnectionControl(@NonNull String connectionName) {
+    @Override
+    public ConnectionControl getConnectionControl(@NonNull String connectionName) {
         for (ConcurrentHashMap.Entry<Integer, ConnectionControlImpl> entry : connections.entrySet()) {
             ConnectionControlImpl connectionControl = entry.getValue();
             if (connectionName.equals(connectionControl.getConnectionName())) {

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/ConnectionControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/ConnectionControlImpl.java
@@ -37,6 +37,7 @@ public class ConnectionControlImpl implements ConnectionControl {
 
     /**
      * Creates instanse of ConnectionControlImpl.
+     *
      * @param connectReply response to connect request from agent
      * @param connectionEvents received of connection events
      * @param agent backreference to agent
@@ -49,7 +50,7 @@ public class ConnectionControlImpl implements ConnectionControl {
         this.connectionEvents = connectionEvents;
         this.agent = agent;
         this.timeout = agent.getTimeout();
-        this.connectionName = "agent:" + agent.getAgentId() + ";connection:" + this.connectionId;
+        this.connectionName = buildConnectionName(agent.getAgentId(), this.connectionId);
     }
 
     @Override
@@ -148,5 +149,9 @@ public class ConnectionControlImpl implements ConnectionControl {
         if (connectionEvents != null) {
             connectionEvents.onMqttDisconnect(this, disconnect, error);
         }
+    }
+
+    static String buildConnectionName(String agentId, int connectionId) {
+        return "agent:" + agentId + ";connection:" + connectionId;
     }
 }

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/DiscoveryEvents.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/DiscoveryEvents.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.testing.mqtt.client.control.implementation;
 
 import com.aws.greengrass.testing.mqtt.client.Mqtt5Disconnect;
 import com.aws.greengrass.testing.mqtt.client.Mqtt5Message;
+import lombok.NonNull;
 
 /**
  * Interface of receiver for events from dicovery service.
@@ -19,14 +20,14 @@ public interface DiscoveryEvents {
      * @param address address of gRPC service of the agent
      * @param port port of of gRPC service of the agent
      */
-    void onDiscoveryAgent(String agentId, String address, int port);
+    void onDiscoveryAgent(@NonNull String agentId, @NonNull String address, int port);
 
     /**
      * Called when agent calls unregister.
      *
      * @param agentId agent identification string
      */
-    void onUnregisterAgent(String agentId);
+    void onUnregisterAgent(@NonNull String agentId);
 
     /**
      * Called when MQTT message has been received.
@@ -35,7 +36,7 @@ public interface DiscoveryEvents {
      * @param connectionId id of connected where receives message
      * @param message the received MQTT message
      */
-    void onMessageReceived(String agentId, int connectionId, Mqtt5Message message);
+    void onMessageReceived(@NonNull String agentId, int connectionId, @NonNull Mqtt5Message message);
 
     /**
      * Called when MQTT connection has been disconnected.
@@ -45,5 +46,5 @@ public interface DiscoveryEvents {
      * @param disconnect optional infomation from DISCONNECT packet
      * @param error optional OS-dependent error string
      */
-    void onMqttDisconnect(String agentId, int connectionId, Mqtt5Disconnect disconnect, String error);
+    void onMqttDisconnect(@NonNull String agentId, int connectionId, @NonNull Mqtt5Disconnect disconnect, String error);
 }

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
@@ -42,7 +42,23 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
         AgentControlImpl newAgentControl(String agentId, String address, int port);
     }
 
-    public EngineControlImpl(@NonNull AgentControlFactory agentControlFactory) {
+    /**
+     * Creates instance of EngineControlImpl.
+     */
+    public EngineControlImpl() {
+        this(new AgentControlFactory() {
+            @Override
+            public AgentControlImpl newAgentControl(String agentId, String address, int port) {
+                return new AgentControlImpl(agentId, address, port);
+            }
+        });
+    }
+
+    /**
+     * Creates instance of EngineControlImpl for tests.
+     * @param agentControlFactory the factory to create agent control
+     */
+    EngineControlImpl(@NonNull AgentControlFactory agentControlFactory) {
         super();
         this.agentControlFactory = agentControlFactory;
     }
@@ -113,7 +129,7 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
 
 
     @Override
-    public void onDiscoveryAgent(String agentId, String address, int port) {
+    public void onDiscoveryAgent(@NonNull String agentId, @NonNull String address, int port) {
         final boolean[] isNew = new boolean[1];
         isNew[0] = false;
         AgentControlImpl agent = agents.computeIfAbsent(agentId, k -> {
@@ -131,7 +147,7 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
     }
 
     @Override
-    public void onUnregisterAgent(String agentId) {
+    public void onUnregisterAgent(@NonNull String agentId) {
         AgentControlImpl agent = agents.remove(agentId);
         if (agent != null) {
             agent.stopAgent();
@@ -143,7 +159,7 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
 
 
     @Override
-    public void onMessageReceived(String agentId, int connectionId, Mqtt5Message message) {
+    public void onMessageReceived(@NonNull String agentId, int connectionId, @NonNull Mqtt5Message message) {
         AgentControlImpl agentControl = agents.get(agentId);
         if (agentControl == null) {
             logger.atWarn().log("Message received but agent {} could not found", agentId);

--- a/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImplTest.java
+++ b/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImplTest.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.testing.mqtt.client.control.implementation;
+
+import com.aws.greengrass.testing.mqtt.client.Mqtt5Disconnect;
+import com.aws.greengrass.testing.mqtt.client.Mqtt5Message;
+import com.aws.greengrass.testing.mqtt.client.MqttCloseRequest;
+import com.aws.greengrass.testing.mqtt.client.MqttConnectReply;
+import com.aws.greengrass.testing.mqtt.client.MqttConnectRequest;
+import com.aws.greengrass.testing.mqtt.client.MqttConnectionId;
+import com.aws.greengrass.testing.mqtt.client.MqttClientControlGrpc;
+import com.aws.greengrass.testing.mqtt.client.MqttPublishRequest;
+import com.aws.greengrass.testing.mqtt.client.MqttUnsubscribeRequest;
+import com.aws.greengrass.testing.mqtt.client.MqttSubscribeRequest;
+import com.aws.greengrass.testing.mqtt.client.ShutdownRequest;
+import com.aws.greengrass.testing.mqtt.client.control.api.AgentControl;
+import com.aws.greengrass.testing.mqtt.client.control.api.ConnectionControl;
+import io.grpc.ManagedChannel;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AgentControlImplTest {
+
+    private static final String DEFAULT_AGENT_ID = "agent1";
+    @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
+    private static final String DEFAULT_ADDRESS = "127.0.0.1";
+    private static final int DEFAULT_PORT = 8474;
+    private static final int TEST_TIMEOUT = 44;
+
+    private ManagedChannel channel;
+    private MqttClientControlGrpc.MqttClientControlBlockingStub blockingStub;
+    private AgentControlImpl.ConnectionControlFactory connectionControlFactory;
+    private AgentControlImpl agentControl;
+
+    @BeforeEach
+    void setup() {
+        connectionControlFactory = mock(AgentControlImpl.ConnectionControlFactory.class);
+        channel = mock(ManagedChannel.class);
+        blockingStub = mock(MqttClientControlGrpc.MqttClientControlBlockingStub.class);
+        agentControl = new AgentControlImpl(DEFAULT_AGENT_ID, DEFAULT_ADDRESS, DEFAULT_PORT, connectionControlFactory,
+                                            channel, blockingStub);
+    }
+
+    @AfterEach
+    void teardown() {
+        agentControl.stopAgent();
+    }
+
+    @Test
+    void GIVEN_agent_control_WHEN_get_timeout_THEN_return_default_timeout() {
+        // GIVEN
+        final int expected = AgentControl.DEFAULT_TIMEOUT;
+
+        // WHEN
+        final int actualTimeout = agentControl.getTimeout();
+
+        // THEN
+        assertEquals(expected, actualTimeout);
+    }
+
+    @Test
+    void GIVEN_agent_control_WHEN_set_and_get_timeout_THEN_get_return_value_was_set() {
+        // GIVEN
+        final int expected = TEST_TIMEOUT;
+
+        // WHEN
+        agentControl.setTimeout(expected);
+        final int actualTimeout = agentControl.getTimeout();
+
+        // THEN
+        assertEquals(expected, actualTimeout);
+    }
+
+    // TODO
+    // startAgent
+    // stopAgent
+
+    @Test
+    void GIVEN_agent_control_WHEN_get_agent_id_THEN_return_valid_value() {
+        // GIVEN
+        final String expected = DEFAULT_AGENT_ID;
+
+        // WHEN
+        final String actual = agentControl.getAgentId();
+
+        // THEN
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void GIVEN_agent_control_without_connections_WHEN_get_connection_control_THEN_return_null() {
+        // GIVEN
+        final String connectionName = "not_exist_connection";
+
+        // WHEN
+        final ConnectionControl actualConnectionControl = agentControl.getConnectionControl(connectionName);
+
+        // THEN
+        assertNull(actualConnectionControl);
+    }
+
+
+    @Test
+    void GIVEN_agent_control_has_connection_WHEN_get_connection_control_THEN_return_connection_control() {
+        // GIVEN
+        final String connectionName = "connection000";
+        final int connectionIdInt = 1974;
+        MqttConnectionId connectionId = MqttConnectionId.newBuilder().setConnectionId(connectionIdInt).build();
+        MqttConnectReply response = MqttConnectReply.newBuilder()
+                                                .setConnected(true)
+                                                .setConnectionId(connectionId)
+                                                .build();
+        when(blockingStub.createMqttConnection(any(MqttConnectRequest.class))).thenReturn(response);
+
+        MqttConnectRequest connectRequest = MqttConnectRequest.newBuilder().build();
+        AgentControl.ConnectionEvents connectionEvents = mock(AgentControl.ConnectionEvents.class);
+
+
+        ConnectionControlImpl connectionControl = mock(ConnectionControlImpl.class);
+        when(connectionControl.getConnectionId()).thenReturn(connectionIdInt);
+        when(connectionControl.getConnectionName()).thenReturn(connectionName);
+
+        when(connectionControlFactory.newConnectionControl(eq(response), eq(connectionEvents), eq(agentControl))).thenReturn(connectionControl);
+        agentControl.createMqttConnection(connectRequest, connectionEvents);
+
+        // WHEN
+        final ConnectionControl actualConnectionControl = agentControl.getConnectionControl(connectionName);
+
+        // THEN
+        assertSame(connectionControl, actualConnectionControl);
+    }
+
+    @Test
+    void GIVEN_agent_control_WHEN_shutdown_agent_THEN_stub_is_called_with_same_reason() {
+        // GIVEN
+        final String reason = "test_reason";
+
+        // WHEN
+        agentControl.shutdownAgent(reason);
+
+        // THEN
+        ArgumentCaptor<ShutdownRequest> argument = ArgumentCaptor.forClass(ShutdownRequest.class);
+        verify(blockingStub).shutdownAgent(argument.capture());
+        assertEquals(reason, argument.getValue().getReason());
+    }
+
+    @Test
+    void GIVEN_agent_control_WHEN_create_mqtt_connection_THEN_connection_control_created() {
+        // GIVEN
+        final int connectionIdInt = 1975;
+        MqttConnectionId connectionId = MqttConnectionId.newBuilder().setConnectionId(connectionIdInt).build();
+        MqttConnectReply response = MqttConnectReply.newBuilder()
+                                                .setConnected(true)
+                                                .setConnectionId(connectionId)
+                                                .build();
+        MqttConnectRequest connectRequest = MqttConnectRequest.newBuilder().build();
+        when(blockingStub.createMqttConnection(eq(connectRequest))).thenReturn(response);
+        AgentControl.ConnectionEvents connectionEvents = mock(AgentControl.ConnectionEvents.class);
+
+        ConnectionControlImpl connectionControl = mock(ConnectionControlImpl.class);
+        when(connectionControl.getConnectionId()).thenReturn(connectionIdInt);
+        when(connectionControlFactory.newConnectionControl(eq(response), eq(connectionEvents), eq(agentControl))).thenReturn(connectionControl);
+
+        // WHEN
+        ConnectionControl actualConnectionControl = agentControl.createMqttConnection(connectRequest, connectionEvents);
+
+        // THEN
+        assertSame(connectionControl, actualConnectionControl);
+        verify(blockingStub).createMqttConnection(eq(connectRequest));
+    }
+
+    @Test
+    void GIVEN_agent_control_WHEN_subscribe_mqtt_THEN_stub_is_called() {
+        // GIVEN
+        final int connectionIdInt = 1976;
+        MqttConnectionId connectionId = MqttConnectionId.newBuilder().setConnectionId(connectionIdInt).build();
+        MqttSubscribeRequest subscribeRequest = MqttSubscribeRequest.newBuilder().setConnectionId(connectionId).build();
+
+        // WHEN
+        agentControl.subscribeMqtt(subscribeRequest);
+
+        // THEN
+        verify(blockingStub).subscribeMqtt(eq(subscribeRequest));
+    }
+
+    @Test
+    void GIVEN_agent_control_WHEN_unsubscribe_mqtt_THEN_stub_is_called() {
+        // GIVEN
+        final int connectionIdInt = 1977;
+        MqttConnectionId connectionId = MqttConnectionId.newBuilder().setConnectionId(connectionIdInt).build();
+        MqttUnsubscribeRequest unsubscribeRequest = MqttUnsubscribeRequest.newBuilder().setConnectionId(connectionId).build();
+
+        // WHEN
+        agentControl.unsubscribeMqtt(unsubscribeRequest);
+
+        // THEN
+        verify(blockingStub).unsubscribeMqtt(eq(unsubscribeRequest));
+    }
+
+    @Test
+    void GIVEN_agent_control_WHEN_publish_mqtt_THEN_stub_is_called() {
+        // GIVEN
+        final int connectionIdInt = 1978;
+        MqttConnectionId connectionId = MqttConnectionId.newBuilder().setConnectionId(connectionIdInt).build();
+        Mqtt5Message message = Mqtt5Message.newBuilder().setTopic("/topic").build();
+        MqttPublishRequest publishRequest = MqttPublishRequest.newBuilder().setConnectionId(connectionId).setMsg(message).build();
+
+        // WHEN
+        agentControl.publishMqtt(publishRequest);
+
+        // THEN
+        verify(blockingStub).publishMqtt(eq(publishRequest));
+    }
+
+    @Test
+    void GIVEN_agent_control_WHEN_close_mqtt_connection_THEN_stub_is_called() {
+        // GIVEN
+        final int connectionIdInt = 1979;
+        MqttConnectionId connectionId = MqttConnectionId.newBuilder().setConnectionId(connectionIdInt).build();
+        MqttCloseRequest closeRequest = MqttCloseRequest.newBuilder().setConnectionId(connectionId).build();
+
+        // WHEN
+        agentControl.closeMqttConnection(closeRequest);
+
+        // THEN
+        verify(blockingStub).closeMqttConnection(eq(closeRequest));
+    }
+
+    @Test
+    void GIVEN_agent_control_has_connection_WHEN_on_message_received_THEN_stub_is_called() {
+        // GIVEN
+        final int connectionIdInt = 1980;
+        MqttConnectionId connectionId = MqttConnectionId.newBuilder().setConnectionId(connectionIdInt).build();
+        MqttConnectReply response = MqttConnectReply.newBuilder()
+                                                .setConnected(true)
+                                                .setConnectionId(connectionId)
+                                                .build();
+        when(blockingStub.createMqttConnection(any(MqttConnectRequest.class))).thenReturn(response);
+
+        MqttConnectRequest connectRequest = MqttConnectRequest.newBuilder().build();
+        AgentControl.ConnectionEvents connectionEvents = mock(AgentControl.ConnectionEvents.class);
+
+        ConnectionControlImpl connectionControl = mock(ConnectionControlImpl.class);
+        when(connectionControl.getConnectionId()).thenReturn(connectionIdInt);
+        when(connectionControlFactory.newConnectionControl(any(MqttConnectReply.class), any(AgentControl.ConnectionEvents.class), any(AgentControlImpl.class))).thenReturn(connectionControl);
+
+        agentControl.createMqttConnection(connectRequest, connectionEvents);
+
+        Mqtt5Message message = Mqtt5Message.newBuilder().setTopic("/topic").build();
+
+        // WHEN
+        agentControl.onMessageReceived(connectionIdInt, message);
+
+        // THEN
+        verify(connectionControl).onMessageReceived(eq(message));
+    }
+
+    @Test
+    void GIVEN_agent_control_has_connection_WHEN_on_mqtt_disconnect_THEN_stub_is_called() {
+        // GIVEN
+        final String error = "error_string";
+        final int connectionIdInt = 1981;
+        MqttConnectionId connectionId = MqttConnectionId.newBuilder().setConnectionId(connectionIdInt).build();
+        MqttConnectReply response = MqttConnectReply.newBuilder()
+                                                .setConnected(true)
+                                                .setConnectionId(connectionId)
+                                                .build();
+        when(blockingStub.createMqttConnection(any(MqttConnectRequest.class))).thenReturn(response);
+
+        MqttConnectRequest connectRequest = MqttConnectRequest.newBuilder().build();
+        AgentControl.ConnectionEvents connectionEvents = mock(AgentControl.ConnectionEvents.class);
+
+        ConnectionControlImpl connectionControl = mock(ConnectionControlImpl.class);
+        when(connectionControl.getConnectionId()).thenReturn(connectionIdInt);
+        when(connectionControlFactory.newConnectionControl(any(MqttConnectReply.class), any(AgentControl.ConnectionEvents.class), any(AgentControlImpl.class))).thenReturn(connectionControl);
+
+        agentControl.createMqttConnection(connectRequest, connectionEvents);
+
+        Mqtt5Disconnect disconnect = Mqtt5Disconnect.newBuilder().build();
+
+        // WHEN
+        agentControl.onMqttDisconnect(connectionIdInt, disconnect, error);
+
+        // THEN
+        verify(connectionControl).onMqttDisconnect(eq(disconnect), eq(error));
+    }
+
+    // onMqttDisconnect
+}

--- a/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/ConnectionControlImplTest.java
+++ b/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/ConnectionControlImplTest.java
@@ -20,8 +20,8 @@ import com.aws.greengrass.testing.mqtt.client.MqttUnsubscribeRequest;
 import com.aws.greengrass.testing.mqtt.client.control.api.AgentControl.ConnectionEvents;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;

--- a/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/ConnectionControlImplTest.java
+++ b/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/ConnectionControlImplTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.testing.mqtt.client.control.implementation;
+
+import com.aws.greengrass.testing.mqtt.client.Mqtt5ConnAck;
+import com.aws.greengrass.testing.mqtt.client.Mqtt5Disconnect;
+import com.aws.greengrass.testing.mqtt.client.Mqtt5Message;
+import com.aws.greengrass.testing.mqtt.client.Mqtt5Subscription;
+import com.aws.greengrass.testing.mqtt.client.MqttCloseRequest;
+import com.aws.greengrass.testing.mqtt.client.MqttConnectReply;
+import com.aws.greengrass.testing.mqtt.client.MqttConnectionId;
+import com.aws.greengrass.testing.mqtt.client.MqttPublishReply;
+import com.aws.greengrass.testing.mqtt.client.MqttPublishRequest;
+import com.aws.greengrass.testing.mqtt.client.MqttSubscribeReply;
+import com.aws.greengrass.testing.mqtt.client.MqttSubscribeRequest;
+import com.aws.greengrass.testing.mqtt.client.MqttUnsubscribeRequest;
+import com.aws.greengrass.testing.mqtt.client.control.api.AgentControl.ConnectionEvents;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ConnectionControlImplTest {
+    private static final int CONNECTION_ID = 1974;
+    private static final int DEFAULT_TIMEOUT = 1970;
+    private static final int TIMEOUT = 2023;
+    private static final String CONNECTION_NANE = "testConnection";
+    private static final String AGENT_ID = "agent1";
+
+    private ConnectionControlImpl connectionControl;
+
+    private MqttConnectReply connectReply;
+    private ConnectionEvents connectionEvents;
+    private Mqtt5ConnAck connAck;
+    private AgentControlImpl agent;
+
+    @BeforeEach
+    void setup() {
+        MqttConnectionId connectionId = MqttConnectionId.newBuilder().setConnectionId(CONNECTION_ID).build();
+        connAck = Mqtt5ConnAck.newBuilder().build();
+        connectReply = MqttConnectReply.newBuilder()
+                                        .setConnectionId(connectionId)
+                                        .setConnAck(connAck)
+                                        .build();
+
+        connectionEvents = mock(ConnectionEvents.class);
+
+        agent = mock(AgentControlImpl.class);
+        when(agent.getAgentId()).thenReturn(AGENT_ID);
+        when(agent.getTimeout()).thenReturn(DEFAULT_TIMEOUT);
+
+        connectionControl = new ConnectionControlImpl(connectReply, connectionEvents, agent);
+    }
+
+    @Test
+    void GIVEN_default_connection_control_WHEN_get_connection_id_THEN_expected() {
+        assertEquals(CONNECTION_ID, connectionControl.getConnectionId());
+    }
+
+    @Test
+    void GIVEN_default_connection_control_WHEN_get_connection_name_THEN_same_as_from_build_connection_name() {
+        final String expected = ConnectionControlImpl.buildConnectionName(AGENT_ID, CONNECTION_ID);
+        assertEquals(expected, connectionControl.getConnectionName());
+    }
+
+    @Test
+    void GIVEN_connection_name_WHEN_set_and_get_connection_name_THEN_as_was_set() {
+        connectionControl.setConnectionName(CONNECTION_NANE);
+        assertEquals(CONNECTION_NANE, connectionControl.getConnectionName());
+    }
+
+    @Test
+    void GIVEN_default_connection_control_WHEN_get_conn_ack_THEN_same_as_passed_to_contructor() {
+        assertSame(connAck, connectionControl.getConnAck());
+    }
+
+    @Test
+    void GIVEN_default_connection_control_WHEN_get_timeout_THEN_timeout_from_agent() {
+        assertEquals(DEFAULT_TIMEOUT, connectionControl.getTimeout());
+    }
+
+    @Test
+    void GIVEN_timeout_WHEN_set_and_get_timeout_THEN_as_was_set() {
+        // WHEN
+        connectionControl.setTimeout(TIMEOUT);
+
+        // THEN
+        assertEquals(TIMEOUT, connectionControl.getTimeout());
+    }
+
+    @Test
+    void GIVEN_reason_WHEN_close_mqtt_connection_THEN_agents_method_is_called() {
+        // GIVEN
+        final int reason = 123;
+
+        // WHEN
+        connectionControl.closeMqttConnection(reason);
+
+        // THEN
+        verify(agent, times(1)).closeMqttConnection(any(MqttCloseRequest.class));
+    }
+
+    @Test
+    void GIVEN_subscriptions_WHEN_subscribe_mqtt_THEN_agents_method_is_called() {
+        // GIVEN
+        final int subscriptionId = 344;
+        Mqtt5Subscription subscription = Mqtt5Subscription.newBuilder().build();
+        MqttSubscribeReply reply = MqttSubscribeReply.newBuilder().build();
+
+        when(agent.subscribeMqtt(any(MqttSubscribeRequest.class))).thenReturn(reply);
+
+        // WHEN
+        final MqttSubscribeReply actual = connectionControl.subscribeMqtt(subscriptionId, subscription);
+
+        // THEN
+        assertSame(reply, actual);
+        verify(agent, times(1)).subscribeMqtt(any(MqttSubscribeRequest.class));
+    }
+
+    @Test
+    void GIVEN_filter_WHEN_unsubscribe_mqtt_THEN_agents_method_is_called() {
+        // GIVEN
+        String filter = "testFilter";
+        MqttSubscribeReply reply = MqttSubscribeReply.newBuilder().build();
+
+        when(agent.unsubscribeMqtt(any(MqttUnsubscribeRequest.class))).thenReturn(reply);
+
+        // WHEN
+        MqttSubscribeReply actual = connectionControl.unsubscribeMqtt(filter);
+
+        // THEN
+        assertSame(reply, actual);
+        verify(agent, times(1)).unsubscribeMqtt(any(MqttUnsubscribeRequest.class));
+    }
+
+    @Test
+    void GIVEN_message_WHEN_publish_mqtt_THEN_agents_method_is_called() {
+        // GIVEN
+        Mqtt5Message message = Mqtt5Message.newBuilder().build();
+        MqttPublishReply reply = MqttPublishReply.newBuilder().build();
+
+        when(agent.publishMqtt(any(MqttPublishRequest.class))).thenReturn(reply);
+
+        // WHEN
+        MqttPublishReply actual = connectionControl.publishMqtt(message);
+
+        // THEN
+        assertSame(reply, actual);
+        verify(agent, times(1)).publishMqtt(any(MqttPublishRequest.class));
+    }
+
+    @Test
+    void GIVEN_received_message_WHEN_on_message_received_THEN_callback_is_called() {
+        // GIVEN
+        Mqtt5Message message = Mqtt5Message.newBuilder().build();
+
+        // WHEN
+        connectionControl.onMessageReceived(message);
+
+        // THEN
+        verify(connectionEvents, times(1)).onMessageReceived(connectionControl, message);
+    }
+
+    @Test
+    void GIVEN_disconnect_message_WHEN_on_mqtt_disconnect_THEN_callback_is_called() {
+        // GIVEN
+        final String error = "test_error_string";
+        Mqtt5Disconnect mqttDisconnect = Mqtt5Disconnect.newBuilder().build();
+
+        // WHEN
+        connectionControl.onMqttDisconnect(mqttDisconnect, error);
+
+        // THEN
+        verify(connectionEvents, times(1)).onMqttDisconnect(eq(connectionControl), eq(mqttDisconnect), eq(error));
+    }
+}
+

--- a/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImplTest.java
+++ b/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImplTest.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.testing.mqtt.client.control.implementation;
+
+import com.aws.greengrass.testing.mqtt.client.Mqtt5Disconnect;
+import com.aws.greengrass.testing.mqtt.client.Mqtt5Message;
+import com.aws.greengrass.testing.mqtt.client.control.api.AgentControl;
+import com.aws.greengrass.testing.mqtt.client.control.api.EngineControl;
+import com.aws.greengrass.testing.mqtt.client.control.api.ConnectionControl;
+import java.io.IOException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EngineControlImplTest {
+
+    private EngineControlImpl engineControl;
+
+    @Mock
+    private EngineControl.EngineEvents engineEvents;
+
+    @Mock
+    EngineControlImpl.AgentControlFactory agentControlFactory;
+
+
+    @BeforeEach
+    void setup() {
+        engineControl = new EngineControlImpl(agentControlFactory);
+    }
+
+    @AfterEach
+    void teardown() throws InterruptedException {
+        engineControl.stopEngine();
+        engineControl.awaitTermination();
+    }
+
+
+    @Test
+    void GIVEN_engine_not_started_WHEN_start_engine_THEN_no_exceptions() throws IOException {
+        // GIVEN
+        final int port = 9131;
+
+        // WHEN
+        engineControl.startEngine(port, engineEvents);
+    }
+
+    @Test
+    void GIVEN_engine_not_started_WHEN_get_bound_port_THEN_return_null() {
+        // WHEN
+        final Integer boundPort = engineControl.getBoundPort();
+
+        // THEN
+        assertNull(boundPort);
+    }
+
+    @Test
+    void GIVEN_engine_started_on_fixed_port_WHEN_get_bound_port_THEN_return_same_value() throws IOException {
+        // GIVEN
+        final int port = 9132;
+        engineControl.startEngine(port, engineEvents);
+
+        // WHEN
+        final Integer boundPort = engineControl.getBoundPort();
+
+        // THEN
+        assertNotNull(boundPort);
+        assertEquals(port, boundPort);
+    }
+
+    @Test
+    void GIVEN_engine_started_on_autoselected_port_WHEN_get_bound_port_THEN_get_some_value() throws IOException {
+        // GIVEN
+        final int port = 0;
+        engineControl.startEngine(port, engineEvents);
+
+        // WHEN
+        final Integer boundPort = engineControl.getBoundPort();
+
+        // THEN
+        assertNotNull(boundPort);
+        assertTrue(boundPort >= 1024);
+    }
+
+    @Test
+    void GIVEN_engine_not_started_WHEN_is_engine_running_THEN_return_false() {
+        // WHEN
+        final boolean isRunning = engineControl.isEngineRunning();
+
+        // THEN
+        assertFalse(isRunning);
+    }
+
+    @Test
+    void GIVEN_engine_started_WHEN_is_engine_running_THEN_return_true() throws IOException {
+        // GIVEN
+        final int port = 0;
+        engineControl.startEngine(port, engineEvents);
+
+        // WHEN
+        final boolean isRunning = engineControl.isEngineRunning();
+
+        // THEN
+        assertTrue(isRunning);
+    }
+
+    @Test
+    void GIVEN_no_agents_WHEN_get_agent_THEN_return_null() {
+        // GIVEN
+        final String agentId = "not_exist_agent";
+
+        // WHEN
+        final AgentControl agentControl = engineControl.getAgent(agentId);
+
+        // THEN
+        assertNull(agentControl);
+    }
+
+    @Test
+    void GIVEN_registered_agent_WHEN_get_agent_THEN_return_valid_agent() {
+        // GIVEN
+        final String agentId = "agent000";
+        final String agentAddress = "agent_address";
+        final int agentPort = 43000;
+        final AgentControlImpl agentControl = mock(AgentControlImpl.class);
+        when(agentControlFactory.newAgentControl(anyString(), anyString(), anyInt())).thenReturn(agentControl);
+        engineControl.onDiscoveryAgent(agentId, agentAddress, agentPort);
+
+        // WHEN
+        final AgentControl actualAgentControl = engineControl.getAgent(agentId);
+
+        // THEN
+        assertSame(agentControl, actualAgentControl);
+    }
+
+
+    @Test
+    void GIVEN_no_agents_WHEN_get_connection_control_THEN_return_null() {
+        // GIVEN
+        final String connectionName = "not_exist_connection";
+
+        // WHEN
+        final ConnectionControl connectionControl = engineControl.getConnectionControl(connectionName);
+
+        // THEN
+        assertNull(connectionControl);
+    }
+
+    @Test
+    void GIVEN_registered_agent_without_connection_WHEN_get_connection_control_THEN_return_null() {
+        // GIVEN
+        final String connectionName = "connection_name";
+        final String agentId = "agent001";
+        final String agentAddress = "agent_address";
+        final int agentPort = 43001;
+
+        final AgentControlImpl agentControl = mock(AgentControlImpl.class);
+
+        when(agentControlFactory.newAgentControl(anyString(), anyString(), anyInt())).thenReturn(agentControl);
+        engineControl.onDiscoveryAgent(agentId, agentAddress, agentPort);
+
+        // WHEN
+        final ConnectionControl actualConnectionControl = engineControl.getConnectionControl(connectionName);
+
+        // THEN
+        assertNull(actualConnectionControl);
+    }
+
+    @Test
+    void GIVEN_registered_agent_with_connection_WHEN_get_connection_control_THEN_valid_connection_control() throws IOException {
+        // GIVEN
+        final String connectionName = "connection_name";
+        final String agentId = "agent002";
+        final String agentAddress = "agent_address";
+        final int agentPort = 43002;
+
+        final ConnectionControl connectionControl = mock(ConnectionControl.class);
+        final AgentControlImpl agentControl = mock(AgentControlImpl.class);
+
+        when(agentControl.getConnectionControl(eq(connectionName))).thenReturn(connectionControl);
+
+        when(agentControlFactory.newAgentControl(anyString(), anyString(), anyInt())).thenReturn(agentControl);
+        engineControl.onDiscoveryAgent(agentId, agentAddress, agentPort);
+
+        // WHEN
+        final ConnectionControl actualConnectionControl = engineControl.getConnectionControl(connectionName);
+
+        // THEN
+        assertSame(connectionControl, actualConnectionControl);
+    }
+
+
+    @Test
+    void GIVEN_engine_started_WHEN_stop_engine_THEN_engine_is_stopped() throws IOException, InterruptedException {
+        // GIVEN
+        final int port = 0;
+        engineControl.startEngine(port, engineEvents);
+
+        // WHEN
+        engineControl.stopEngine();
+
+        // THEN
+        assertFalse(engineControl.isEngineRunning());
+    }
+
+    @Test
+    void GIVEN_engine_started_WHEN_on_discovery_agent_THEN_agent_created_and_started_and_attached() throws IOException {
+        // GIVEN
+        engineControl.startEngine(0, engineEvents);
+
+        final String agentId = "agent003";
+        final String agentAddress = "agent_address";
+        final int agentPort = 43003;
+
+        final AgentControlImpl agentControl = mock(AgentControlImpl.class);
+
+        when(agentControlFactory.newAgentControl(anyString(), anyString(), anyInt())).thenReturn(agentControl);
+
+        // WHEN
+        engineControl.onDiscoveryAgent(agentId, agentAddress, agentPort);
+
+        // THEN
+        assertSame(agentControl, engineControl.getAgent(agentId));
+        verify(agentControlFactory, times(1)).newAgentControl(eq(agentId), eq(agentAddress), eq(agentPort));
+        verify(agentControl, times(1)).startAgent();
+        verify(engineEvents).onAgentAttached(eq(agentControl));
+    }
+
+
+    @Test
+    void GIVEN_engine_started_and_has_agent_WHEN_on_unregister_agent_THEN_agent_stopped_and_detached() throws IOException {
+        // GIVEN
+        engineControl.startEngine(0, engineEvents);
+
+        final String agentId = "agent004";
+        final String agentAddress = "agent_address";
+        final int agentPort = 43004;
+
+        final AgentControlImpl agentControl = mock(AgentControlImpl.class);
+
+        when(agentControlFactory.newAgentControl(anyString(), anyString(), anyInt())).thenReturn(agentControl);
+        engineControl.onDiscoveryAgent(agentId, agentAddress, agentPort);
+
+        // WHEN
+        engineControl.onUnregisterAgent(agentId);
+
+        // THEN
+        assertNull(engineControl.getAgent(agentId));
+        verify(agentControl, times(1)).stopAgent();
+        verify(engineEvents).onAgentDeattached(eq(agentControl));
+    }
+
+    @Test
+    void GIVEN_engine_started_and_has_agent_WHEN_on_message_recevied_THEN_callback_is_called() throws IOException {
+        // GIVEN
+        engineControl.startEngine(0, engineEvents);
+
+
+        final String agentId = "agent005";
+        final String agentAddress = "agent_address";
+        final int agentPort = 43005;
+
+        final AgentControlImpl agentControl = mock(AgentControlImpl.class);
+
+        when(agentControlFactory.newAgentControl(anyString(), anyString(), anyInt())).thenReturn(agentControl);
+        engineControl.onDiscoveryAgent(agentId, agentAddress, agentPort);
+
+        final int connectionId = 22;
+        Mqtt5Message message = Mqtt5Message.newBuilder().build();
+
+        // WHEN
+        engineControl.onMessageReceived(agentId, connectionId, message);
+
+        // THEN
+        verify(agentControl).onMessageReceived(eq(connectionId), eq(message));
+    }
+
+    @Test
+    void GIVEN_engine_started_and_has_agent_WHEN_on_mqtt_disconnect_THEN_callback_is_called() throws IOException {
+        // GIVEN
+        engineControl.startEngine(0, engineEvents);
+
+
+        final String agentId = "agent006";
+        final String agentAddress = "agent_address";
+        final int agentPort = 43006;
+
+        final AgentControlImpl agentControl = mock(AgentControlImpl.class);
+
+        when(agentControlFactory.newAgentControl(anyString(), anyString(), anyInt())).thenReturn(agentControl);
+        engineControl.onDiscoveryAgent(agentId, agentAddress, agentPort);
+
+        final int connectionId = 22;
+        Mqtt5Disconnect disconnect = Mqtt5Disconnect.newBuilder().build();
+        final String error = "test_error";
+
+        // WHEN
+        engineControl.onMqttDisconnect(agentId, connectionId, disconnect, error);
+
+        // THEN
+        verify(agentControl).onMqttDisconnect(eq(connectionId), eq(disconnect), eq(error));
+    }
+}

--- a/uat/pom.xml
+++ b/uat/pom.xml
@@ -49,6 +49,7 @@
         <mockito.version>3.2.0</mockito.version>
         <jupiter.api.version>5.6.2</jupiter.api.version>
         <mockito.junit.jupiter.version>3.5.13</mockito.junit.jupiter.version>
+        <mockito.inline.version>5.2.0</mockito.inline.version>
         <!-- Plugin versions -->
         <jar.plugin.version>3.3.0</jar.plugin.version>
         <shade.plugin.version>3.4.1</shade.plugin.version>

--- a/uat/pom.xml
+++ b/uat/pom.xml
@@ -45,6 +45,11 @@
         <tomcat.annotations.api.version>6.0.53</tomcat.annotations.api.version>
         <javax.annotation.api.version>1.3.2</javax.annotation.api.version>
         <log4j.version>2.20.0</log4j.version>
+        <junit.version>5.9.2</junit.version>
+        <mockito.version>3.2.0</mockito.version>
+        <jupiter.api.version>5.6.2</jupiter.api.version>
+        <mockito.junit.jupiter.version>3.5.13</mockito.junit.jupiter.version>
+        <!-- Plugin versions -->
         <jar.plugin.version>3.3.0</jar.plugin.version>
         <shade.plugin.version>3.4.1</shade.plugin.version>
         <exec.plugin.version>3.1.0</exec.plugin.version>
@@ -55,7 +60,6 @@
         <compiler.plugin.version>3.8.1</compiler.plugin.version>
         <spotbugs.plugin.version>4.0.0</spotbugs.plugin.version>
         <antrun.plugin.version>3.0.0</antrun.plugin.version>
-        <junit.version>5.9.2</junit.version>
-        <mockito.version>3.2.0</mockito.version>
+        <surefire.plugin.version>3.0.0</surefire.plugin.version>
     </properties>
 </project>


### PR DESCRIPTION
**Issue #, if available:**
Create unit tests in control

**Description of changes:**
- Added junit-jupiter-api and mockito-junit-jupiter dependencies.
- Added maven-surefire-plugin
- Added unit tests for ConnectionControlImpl in ConnectionControlImplTest
- Added unit tests for EngineControlImpl in EngineControlImplTest
- Added unit tests for AgentControlImpl in AgentControlImplTest

**Why is this change necessary:**
We should test MQTT client control automatically

**How was this change tested:**
On CI

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
