### PR TITLE
test(uat): added unit tests for GRPCLibImpl GRPCLinkImpl

### DIFF
--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCLib.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCLib.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.testing.mqtt5.client;
 
 import com.aws.greengrass.testing.mqtt5.client.exceptions.GRPCException;
+import lombok.NonNull;
 
 /**
  * Interface of gRPC library.
@@ -20,5 +21,5 @@ public interface GRPCLib {
      * @return connection handler
      * @throws GRPCException on errors
      */
-    GRPCLink makeLink(String agentId, String host, int port) throws GRPCException;
+    GRPCLink makeLink(@NonNull String agentId, @NonNull String host, int port) throws GRPCException;
 }

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCLink.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCLink.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.testing.mqtt5.client;
 
 import com.aws.greengrass.testing.mqtt5.client.exceptions.GRPCException;
+import lombok.NonNull;
 
 /**
  * Interface of gRPC bidirectional link.
@@ -19,7 +20,7 @@ public interface GRPCLink {
      * @throws GRPCException on errors
      * @throws InterruptedException when thread has been interrupted
      */
-    String handleRequests(MqttLib mqttLib) throws GRPCException, InterruptedException;
+    String handleRequests(@NonNull MqttLib mqttLib) throws GRPCException, InterruptedException;
 
     /**
      * Unregister agent from control.

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -31,6 +31,7 @@ import io.grpc.InsecureServerCredentials;
 import io.grpc.Server;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import lombok.NonNull;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -555,7 +556,7 @@ class GRPCControlServer {
      * @param port bind port, or 0 to autoselect
      * @throws IOException on errors
      */
-    public GRPCControlServer(GRPCClient client, String host, int port) throws IOException {
+    public GRPCControlServer(@NonNull GRPCClient client, @NonNull String host, int port) throws IOException {
         super();
         this.client = client;
 

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
@@ -24,6 +24,7 @@ import io.grpc.Grpc;
 import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannel;
 import io.grpc.StatusRuntimeException;
+import lombok.NonNull;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -46,7 +47,7 @@ class GRPCDiscoveryClient implements GRPCClient {
      * @param address address of gRPC service
      * @throws GRPCException on errors
      */
-    GRPCDiscoveryClient(String agentId, String address) throws GRPCException {
+    GRPCDiscoveryClient(@NonNull String agentId, @NonNull String address) throws GRPCException {
         super();
         this.agentId = agentId;
         this.channel = Grpc.newChannelBuilder(address, InsecureChannelCredentials.create()).build();

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCLibImpl.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCLibImpl.java
@@ -8,13 +8,42 @@ package com.aws.greengrass.testing.mqtt5.client.grpc;
 import com.aws.greengrass.testing.mqtt5.client.GRPCLib;
 import com.aws.greengrass.testing.mqtt5.client.GRPCLink;
 import com.aws.greengrass.testing.mqtt5.client.exceptions.GRPCException;
+import lombok.NonNull;
 
 /**
  * Implementation of gRPC library.
  */
 public class GRPCLibImpl implements GRPCLib {
+    private final LinkFactory linkFactory;
+
+    interface LinkFactory {
+        GRPCLink newLink(@NonNull String agentId, @NonNull String host, int port) throws GRPCException;
+    }
+
+    /**
+     * Creates instance of GRPCLibImpl.
+     */
+    public GRPCLibImpl() {
+        this(new LinkFactory() {
+            @Override
+            public GRPCLink newLink(@NonNull String agentId, @NonNull String host, int port) throws GRPCException {
+                return new GRPCLinkImpl(agentId, host, port);
+            }
+        });
+    }
+
+    /**
+     * Creates instance of GRPCLibImpl for tests.
+     *
+     * @param linkFactory the factory for gRPC links
+     */
+    GRPCLibImpl(@NonNull LinkFactory linkFactory) {
+        super();
+        this.linkFactory = linkFactory;
+    }
+
     @Override
-    public GRPCLink makeLink(String agentId, String host, int port) throws GRPCException {
-        return new GRPCLinkImpl(agentId, host, port);
+    public GRPCLink makeLink(@NonNull String agentId, @NonNull String host, int port) throws GRPCException {
+        return linkFactory.newLink(agentId, host, port);
     }
 }

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCLinkImpl.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCLinkImpl.java
@@ -25,7 +25,7 @@ public class GRPCLinkImpl implements GRPCLink {
     private final GRPCDiscoveryClient client;
     private final GRPCControlServer server;
 
-    interface HalfsFactory {
+    interface HalvesFactory {
         GRPCDiscoveryClient newClient(@NonNull String agentId, @NonNull String address) throws GRPCException;
 
         GRPCControlServer newServer(@NonNull GRPCDiscoveryClient client, @NonNull String host, int port)
@@ -41,7 +41,7 @@ public class GRPCLinkImpl implements GRPCLink {
      * @throws GRPCException on errors
      */
     public GRPCLinkImpl(@NonNull String agentId, @NonNull String host, int port) throws GRPCException {
-        this(agentId, host, port, new HalfsFactory() {
+        this(agentId, host, port, new HalvesFactory() {
             @Override
             public GRPCDiscoveryClient newClient(@NonNull String agentId, @NonNull String address)
                         throws GRPCException {
@@ -62,21 +62,21 @@ public class GRPCLinkImpl implements GRPCLink {
      * @param agentId the id of agent to identify control channel by gRPC server
      * @param host the host name of gRPC server to connect to
      * @param port the TCP port to connect to
-     * @param halfsFactory the factory for client and server
+     * @param halvesFactory the factory for client and server
      * @throws GRPCException on errors
      */
-    GRPCLinkImpl(@NonNull String agentId, @NonNull String host, int port, @NonNull HalfsFactory halfsFactory)
+    GRPCLinkImpl(@NonNull String agentId, @NonNull String host, int port, @NonNull HalvesFactory halvesFactory)
                     throws GRPCException {
         super();
         logger.atInfo().log("Making gPRC link with {}:{} as {}", host, port, agentId);
 
         String otfAddress = buildAddress(host, port);
-        GRPCDiscoveryClient client = halfsFactory.newClient(agentId, otfAddress);
+        GRPCDiscoveryClient client = halvesFactory.newClient(agentId, otfAddress);
         String localIP = client.registerAgent();
         logger.atInfo().log("Local address is {}", localIP);
 
         try {
-            GRPCControlServer server = halfsFactory.newServer(client, localIP, AUTOSELECT_PORT);
+            GRPCControlServer server = halvesFactory.newServer(client, localIP, AUTOSELECT_PORT);
             int servicePort = server.getPort();
             client.discoveryAgent(localIP, servicePort);
             this.client = client;

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttLibImpl.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttLibImpl.java
@@ -55,7 +55,7 @@ public class MqttLibImpl implements MqttLib {
      *
      * @param connectionFactory the factory of connections
      */
-    MqttLibImpl(ConnectionFactory connectionFactory) {
+    MqttLibImpl(@NonNull ConnectionFactory connectionFactory) {
         super();
         this.connectionFactory = connectionFactory;
     }

--- a/uat/custom-components/client-java-sdk/src/test/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCLibImplTest.java
+++ b/uat/custom-components/client-java-sdk/src/test/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCLibImplTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.testing.mqtt5.client.grpc;
+
+import com.aws.greengrass.testing.mqtt5.client.GRPCLink;
+import com.aws.greengrass.testing.mqtt5.client.exceptions.GRPCException;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+class GRPCLibImplTest {
+
+    private GRPCLibImpl.LinkFactory linkFactory;
+    private GRPCLibImpl gRPCLibImpl;
+
+    @BeforeEach
+    void setup() {
+        linkFactory = mock(GRPCLibImpl.LinkFactory.class);
+        gRPCLibImpl = new GRPCLibImpl(linkFactory);
+    }
+
+    @Test
+    void GIVEN_link_WHEN_makeLink_THEN_that_link_returned() throws GRPCException {
+        // GIVEN
+        final String agentId = "agentId";
+        final String host = "hostname";
+        final int port = 9999;
+
+        GRPCLink gRPCLink = mock(GRPCLink.class);
+        when(linkFactory.newLink(eq(agentId), eq(host), eq(port))).thenReturn(gRPCLink);
+
+        // WHEN
+        GRPCLink actualGRPCLink = gRPCLibImpl.makeLink(agentId, host, port);
+
+        // THEN
+        assertSame(gRPCLink, actualGRPCLink);
+    }
+}

--- a/uat/custom-components/client-java-sdk/src/test/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCLinkImplTest.java
+++ b/uat/custom-components/client-java-sdk/src/test/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCLinkImplTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.testing.mqtt5.client.grpc;
+
+import com.aws.greengrass.testing.mqtt5.client.MqttLib;
+import com.aws.greengrass.testing.mqtt5.client.exceptions.GRPCException;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GRPCLinkImplTest {
+    private static final String AGENT_ID = "agent000";
+    private static final String HOST = "test_host";
+    private static final int PORT = 1974;
+    private static final String LOCAL_IP = "local_ip";
+
+    private static final int SERVICE_PORT = 11_393;
+
+    private GRPCDiscoveryClient client;
+    private GRPCControlServer server;
+
+    private GRPCLinkImpl gRPCLinkImpl;
+
+    @BeforeEach
+    void setup() throws GRPCException, IOException {
+        client = mock(GRPCDiscoveryClient.class);
+        when(client.registerAgent()).thenReturn(LOCAL_IP);
+
+        server = mock(GRPCControlServer.class);
+        when(server.getPort()).thenReturn(SERVICE_PORT);
+
+        GRPCLinkImpl.HalfsFactory halfsFactory = mock(GRPCLinkImpl.HalfsFactory.class);
+        final String buildAddress = GRPCLinkImpl.buildAddress(HOST, PORT);
+        when(halfsFactory.newClient(eq(AGENT_ID), eq(buildAddress))).thenReturn(client);
+        when(halfsFactory.newServer(eq(client), eq(LOCAL_IP), eq(0))).thenReturn(server);
+
+        gRPCLinkImpl = new GRPCLinkImpl(AGENT_ID, HOST, PORT, halfsFactory);
+
+        verify(halfsFactory).newClient(eq(AGENT_ID), eq(buildAddress));
+        verify(client).registerAgent();
+        verify(halfsFactory).newServer(eq(client), eq(LOCAL_IP), eq(0));
+        verify(server).getPort();
+        verify(client).discoveryAgent(eq(LOCAL_IP), eq(SERVICE_PORT));
+    }
+
+    @SuppressWarnings("PMD.CloseResource")
+    @Test
+    void GIVEN_link_WHEN_handle_requests_THEN_server_is_called_correct_reason_returned() throws GRPCException, InterruptedException {
+        // GIVEN
+        final String reason = "test_reason";
+        final String expectedShutdownReason = "Agent shutdown by OTF request '" + reason + "'";
+
+        when(server.getShutdownReason()).thenReturn(reason);
+
+        final MqttLib mqttLib = mock(MqttLib.class);
+
+        // WHEN
+        String shutdownReason = gRPCLinkImpl.handleRequests(mqttLib);
+
+        // THEN
+        assertEquals(expectedShutdownReason, shutdownReason);
+        verify(server).waiting(eq(mqttLib));
+    }
+
+    @Test
+    void GIVEN_link_WHEN_shutdown_THEN_client_and_server_were_closed() throws GRPCException {
+        // GIVEN
+        final String reason = "test_clients_reason";
+
+        // WHEN
+        gRPCLinkImpl.shutdown(reason);
+
+        // THEN
+        verify(client).unregisterAgent(eq(reason));
+        verify(client).close();
+        verify(server).close();
+    }
+}

--- a/uat/custom-components/client-java-sdk/src/test/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCLinkImplTest.java
+++ b/uat/custom-components/client-java-sdk/src/test/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCLinkImplTest.java
@@ -42,16 +42,16 @@ class GRPCLinkImplTest {
         server = mock(GRPCControlServer.class);
         when(server.getPort()).thenReturn(SERVICE_PORT);
 
-        GRPCLinkImpl.HalfsFactory halfsFactory = mock(GRPCLinkImpl.HalfsFactory.class);
+        GRPCLinkImpl.HalvesFactory halvesFactory = mock(GRPCLinkImpl.HalvesFactory.class);
         final String buildAddress = GRPCLinkImpl.buildAddress(HOST, PORT);
-        when(halfsFactory.newClient(eq(AGENT_ID), eq(buildAddress))).thenReturn(client);
-        when(halfsFactory.newServer(eq(client), eq(LOCAL_IP), eq(0))).thenReturn(server);
+        when(halvesFactory.newClient(eq(AGENT_ID), eq(buildAddress))).thenReturn(client);
+        when(halvesFactory.newServer(eq(client), eq(LOCAL_IP), eq(0))).thenReturn(server);
 
-        gRPCLinkImpl = new GRPCLinkImpl(AGENT_ID, HOST, PORT, halfsFactory);
+        gRPCLinkImpl = new GRPCLinkImpl(AGENT_ID, HOST, PORT, halvesFactory);
 
-        verify(halfsFactory).newClient(eq(AGENT_ID), eq(buildAddress));
+        verify(halvesFactory).newClient(eq(AGENT_ID), eq(buildAddress));
         verify(client).registerAgent();
-        verify(halfsFactory).newServer(eq(client), eq(LOCAL_IP), eq(0));
+        verify(halvesFactory).newServer(eq(client), eq(LOCAL_IP), eq(0));
         verify(server).getPort();
         verify(client).discoveryAgent(eq(LOCAL_IP), eq(SERVICE_PORT));
     }

--- a/uat/custom-components/client-java-sdk/src/test/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttConnectionImplTest.java
+++ b/uat/custom-components/client-java-sdk/src/test/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttConnectionImplTest.java
@@ -54,7 +54,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-
 @ExtendWith(MockitoExtension.class)
 class MqttConnectionImplTest {
     private static final int DEFAULT_TIMEOUT_SEC = 10;

--- a/uat/custom-components/client-java-sdk/src/test/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttConnectionImplTest.java
+++ b/uat/custom-components/client-java-sdk/src/test/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttConnectionImplTest.java
@@ -49,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.Mockito.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/uat/custom-components/client-java-sdk/src/test/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttLibImplTest.java
+++ b/uat/custom-components/client-java-sdk/src/test/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttLibImplTest.java
@@ -18,7 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.Mockito.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImpl.java
@@ -60,7 +60,7 @@ public class AgentControlImpl implements AgentControl {
     private MqttClientControlGrpc.MqttClientControlBlockingStub blockingStub;
 
 
-    public interface ConnectionControlFactory {
+    interface ConnectionControlFactory {
         ConnectionControlImpl newConnectionControl(MqttConnectReply connectReply,
                                                     @NonNull ConnectionEvents connectionEvents,
                                                     @NonNull AgentControlImpl agent);

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
@@ -38,7 +38,7 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
     private Integer boundPort = null;
 
 
-    public interface AgentControlFactory {
+    interface AgentControlFactory {
         AgentControlImpl newAgentControl(String agentId, String address, int port);
     }
 
@@ -79,7 +79,7 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
         if (oldSrv != null) {
             oldSrv.shutdown();
         }
-        logger.atInfo().log("gRPC MQTT client control server started, listening on {}", boundPort);
+        logger.atInfo().log("MQTT client control gRPC server started, listening on {}", boundPort);
     }
 
     @Override

--- a/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImplTest.java
+++ b/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImplTest.java
@@ -29,7 +29,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.Mockito.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/ConnectionControlImplTest.java
+++ b/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/ConnectionControlImplTest.java
@@ -25,7 +25,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.mockito.Mockito.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;


### PR DESCRIPTION
**Issue #, if available:**
Create unit tests of AWS IoT device SDK client

**Description of changes:**
- Added unit tests for GRPCLibImpl
- Added unit tests for GRPCLinkImpl
- Tune interfaces using NonNull
- Decouple implementations by using factory to allow unit testing
- Added constructors for test
- Change to correct ArgumentMatchers.any()

**Why is this change necessary:**
Code of MQTT client based on AWS IoT device SDK should be covered by unit tests.

**How was this change tested:**
These unit tests will be running during project build on CI.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
