### PR TITLE
feat(uat): add support of multi-homed broker

### DIFF
--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -184,12 +184,12 @@ class GRPCControlServer {
             // check TLS optional settings
             if (request.hasTls()) {
                 TLSSettings tls = request.getTls();
-                String ca = tls.getCa();
+                List<String> caList = tls.getCaListList();
 
-                if (ca == null || ca.isEmpty()) {
-                    logger.atWarn().log("empty CA");
+                if (caList == null || caList.isEmpty()) {
+                    logger.atWarn().log("empty CA list");
                     responseObserver.onError(Status.INVALID_ARGUMENT
-                                                .withDescription("empty CA")
+                                                .withDescription("empty CA list")
                                                 .asRuntimeException());
                     return;
                 }
@@ -212,9 +212,9 @@ class GRPCControlServer {
                     return;
                 }
 
+                final String ca = String.join("\n", caList);
                 connectionParamsBuilder.ca(ca).cert(cert).key(key);
             }
-
 
             logger.atInfo().log("createMqttConnection: clientId {} broker {}:{}", clientId, host, port);
             MqttConnectReply.Builder builder = MqttConnectReply.newBuilder();

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
@@ -179,7 +179,7 @@ class AgentTestScenario implements Runnable {
                     .setProtocolVersion(MqttProtoVersion.MQTT_PROTOCOL_V50);
 
         if (useTLS) {
-            TLSSettings tlsSettings = TLSSettings.newBuilder().setCa(ca).setCert(cert).setKey(key).build();
+            TLSSettings tlsSettings = TLSSettings.newBuilder().addCaList(ca).setCert(cert).setKey(key).build();
             builder.setTls(tlsSettings);
         }
 

--- a/uat/proto/mqtt_client_control.proto
+++ b/uat/proto/mqtt_client_control.proto
@@ -192,7 +192,7 @@ message Mqtt5Subscription {
 
 // Optional TLS settings for MQTT connection
 message TLSSettings {
-    string ca = 1;                                      // list of PEM formatted CA, separated by "\n\n\n"
+    repeated string caList = 1;                         // list of PEM formatted CA
     string cert = 2;                                    // MQTT client's certificate, PEM formatted
     string key = 3;                                     // MQTT client's private key
 };

--- a/uat/proto/mqtt_client_control.proto
+++ b/uat/proto/mqtt_client_control.proto
@@ -192,9 +192,9 @@ message Mqtt5Subscription {
 
 // Optional TLS settings for MQTT connection
 message TLSSettings {
-    string ca = 1;
-    string cert = 2;
-    string key = 3;
+    string ca = 1;                                      // list of PEM formatted CA, separated by "\n\n\n"
+    string cert = 2;                                    // MQTT client's certificate, PEM formatted
+    string key = 3;                                     // MQTT client's private key
 };
 
 // Request to shutdown client has a reason field


### PR DESCRIPTION
**Issue #, if available:**
Multi-homed broker is not supported

**Description of changes:**
- Add support of multi-homed broker but implement iteration over addresses in building block of connect
- Add comments in gRPC protocol about semantic and format of TLS message
- Remove local check of broker address connectivity

**Why is this change necessary:**
Currently implementation is use just first address of broker which available locally. 
It will not works for remote clients.
That cons should be fixed.

**How was this change tested:**
No specific tests for that code due to it is building blocks

**Scenario results:**
```
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
[INFO ] 2023-04-19 18:02:07.964 [main] GreengrassContextModule - Extracting greengrass-nucleus-latest.zip into /tmp/gg-testing-6195196938472998242/greengrass
[INFO ] 2023-04-19 18:02:08.667 [main] LoggerSteps - OTF Version is otf-1.1.0-SNAPSHOT
[INFO ] 2023-04-19 18:02:08.667 [main] LoggerSteps - Attaching thread context to scenario: 'GGMQ-1-T1: As a customer, I can connect, subscribe, publish and receive using client application to MQTT topic'
[WARN ] 2023-04-19 18:02:08.789 [main] ProfileFileReader - Ignoring profile 'sso-session default' on line 6 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-04-19 18:02:09.303 [main] ProfileFileReader - Ignoring profile 'sso-session default' on line 6 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-04-19 18:02:09.351 [main] ProfileFileReader - Ignoring profile 'sso-session default' on line 6 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-04-19 18:02:09.412 [main] ProfileFileReader - Ignoring profile 'sso-session default' on line 6 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-04-19 18:02:10.243 [main] ProfileFileReader - Ignoring profile 'sso-session default' on line 6 because it did not start with 'profile ' and it was not 'default'.
[INFO ] 2023-04-19 18:02:11.110 [main] AbstractAWSResourceLifecycle - Created IotPolicy in IotLifecycle
[INFO ] 2023-04-19 18:02:12.489 [main] AbstractAWSResourceLifecycle - Created IamPolicy in IamLifecycle
[INFO ] 2023-04-19 18:02:12.932 [main] AbstractAWSResourceLifecycle - Created IamRole in IamLifecycle
[INFO ] 2023-04-19 18:02:13.147 [main] AbstractAWSResourceLifecycle - Created IotRoleAlias in IotLifecycle
[INFO ] 2023-04-19 18:02:13.240 [main] AbstractAWSResourceLifecycle - Created IotPolicy in IotLifecycle
[INFO ] 2023-04-19 18:02:13.352 [main] AbstractAWSResourceLifecycle - Created IotThingGroup in IotLifecycle
[INFO ] 2023-04-19 18:02:14.111 [main] AbstractAWSResourceLifecycle - Created IotCertificate in IotLifecycle
[INFO ] 2023-04-19 18:02:14.208 [main] AbstractAWSResourceLifecycle - Created IotThing in IotLifecycle
[INFO ] 2023-04-19 18:02:14.366 [main] feature - Finished step: 'my device is registered as a Thing' with status PASSED
[INFO ] 2023-04-19 18:02:15.261 [main] DefaultGreengrass - Starting Greengrass on pid 226452
[INFO ] 2023-04-19 18:02:15.261 [main] feature - Finished step: 'my device is running Greengrass' with status PASSED
[INFO ] 2023-04-19 18:02:18.528 [main] AbstractAWSResourceLifecycle - Created S3Bucket in S3Lifecycle
[INFO ] 2023-04-19 18:02:23.678 [main] AbstractAWSResourceLifecycle - Created S3Object in S3Lifecycle
[INFO ] 2023-04-19 18:02:23.679 [main] RecipeComponentPreparationService - Uploaded /tmp/gg-testing-6195196938472998242/65040f17d5ef20ef812c/components/aws.greengrass.client.Mqtt5JavaSdkClient/aws.greengrass.client.Mqtt5JavaSdkClient.jar to s3://gg-65040f17d5ef20ef812c-gg-component-store/greengrass/artifacts/aws.greengrass.client.Mqtt5JavaSdkClient.jar
[INFO ] 2023-04-19 18:02:24.530 [main] AbstractAWSResourceLifecycle - Created GreengrassComponent in GreengrassV2Lifecycle
[INFO ] 2023-04-19 18:02:24.531 [main] RecipeComponentPreparationService - Created component aws.greengrass.client.Mqtt5JavaSdkClient:1.0.0-65040f17d5ef20ef812c from /greengrass/components/recipes/client_java_sdk.yaml
[INFO ] 2023-04-19 18:02:24.532 [main] feature - Finished step: 'I create a Greengrass deployment with components' with status PASSED
[INFO ] 2023-04-19 18:02:24.746 [main] EngineControlImpl - MQTT client control gRPC server started, listening on 42891
[INFO ] 2023-04-19 18:02:24.747 [main] MqttControlSteps - MQTT clients control started gRPC service on port 42891
[INFO ] 2023-04-19 18:02:24.836 [main] AbstractAWSResourceLifecycle - Created IotPolicy in IotLifecycle
[INFO ] 2023-04-19 18:02:25.401 [main] AbstractAWSResourceLifecycle - Created IotCertificate in IotLifecycle
[INFO ] 2023-04-19 18:02:25.402 [main] AbstractAWSResourceLifecycle - Created IotThing in IotLifecycle
[INFO ] 2023-04-19 18:02:25.403 [main] feature - Finished step: 'I create client device "clientDeviceTest"' with status PASSED
[INFO ] 2023-04-19 18:02:26.711 [main] feature - Finished step: 'I associate "clientDeviceTest" with ggc' with status PASSED
[INFO ] 2023-04-19 18:02:26.727 [main] feature - Finished step: 'I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:' with status PASSED
[INFO ] 2023-04-19 18:02:26.728 [main] feature - Finished step: 'I update my Greengrass deployment configuration, setting the component aws.greengrass.client.Mqtt5JavaSdkClient configuration to:' with status PASSED
[INFO ] 2023-04-19 18:02:27.139 [main] AbstractAWSResourceLifecycle - Created GreengrassDeployment in GreengrassV2Lifecycle
[INFO ] 2023-04-19 18:02:27.140 [main] DeploymentSteps - Created Greengrass deployment: ef2377e8-3a16-4de7-afe6-735b6645314c
[INFO ] 2023-04-19 18:02:27.140 [main] feature - Finished step: 'I deploy the Greengrass deployment configuration' with status PASSED
[INFO ] 2023-04-19 18:03:00.461 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId aws.greengrass.client.Mqtt5JavaSdkClient
[INFO ] 2023-04-19 18:03:00.554 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId aws.greengrass.client.Mqtt5JavaSdkClient address 127.0.0.1 port 33501
[INFO ] 2023-04-19 18:03:00.556 [grpc-default-executor-0] EngineControlImpl - Created new agent control for aws.greengrass.client.Mqtt5JavaSdkClient on 127.0.0.1:33501
[INFO ] 2023-04-19 18:03:00.601 [grpc-default-executor-0] MqttControlSteps - Agent aws.greengrass.client.Mqtt5JavaSdkClient is connected
[INFO ] 2023-04-19 18:03:09.929 [main] feature - Finished step: 'the Greengrass deployment is COMPLETED on the device after 300 seconds' with status PASSED
[INFO ] 2023-04-19 18:03:10.566 [main] feature - Finished step: 'I discover core device broker as "default_broker" from "clientDeviceTest"' with status PASSED
[INFO ] 2023-04-19 18:03:10.567 [main] MqttControlSteps - Creating MQTT connection with broker default_broker to address 172.17.0.1:8883 as Thing gg-65040f17d5ef20ef812c-clientDeviceTest on aws.greengrass.client.Mqtt5JavaSdkClient
[INFO ] 2023-04-19 18:03:11.717 [main] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
reasonCode: 0
retainAvailable: true
maximumPacketSize: 268435455
wildcardSubscriptionsAvailable: true
subscriptionIdentifiersAvailable: true
sharedSubscriptionsAvailable: true
'
[INFO ] 2023-04-19 18:03:11.717 [main] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-04-19 18:03:11.717 [main] MqttControlSteps - Connection with broker default_broker established to address 172.17.0.1:8883 as Thing gg-65040f17d5ef20ef812c-clientDeviceTest on aws.greengrass.client.Mqtt5JavaSdkClient
[INFO ] 2023-04-19 18:03:11.718 [main] feature - Finished step: 'I connect device "clientDeviceTest" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker"' with status PASSED
[INFO ] 2023-04-19 18:03:11.718 [main] MqttControlSteps - Create MQTT subscription for Thing gg-65040f17d5ef20ef812c-clientDeviceTest to topics filter iot_data_0 with QoS 0
[INFO ] 2023-04-19 18:03:11.718 [main] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-04-19 18:03:11.732 [main] MqttControlSteps - MQTT subscription has on topics filter iot_data_0 been created
[INFO ] 2023-04-19 18:03:11.732 [main] feature - Finished step: 'I subscribe "clientDeviceTest" to "iot_data_0" with qos 0' with status PASSED
[INFO ] 2023-04-19 18:03:11.733 [main] MqttControlSteps - Publishing MQTT message Test message as Thing gg-65040f17d5ef20ef812c-clientDeviceTest to topics filter iot_data_0 with QoS 0
[INFO ] 2023-04-19 18:03:11.733 [main] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic iot_data_0
[INFO ] 2023-04-19 18:03:11.744 [main] MqttControlSteps - MQTT message Test message has been succesfully published
[INFO ] 2023-04-19 18:03:11.744 [main] feature - Finished step: 'I publish from "clientDeviceTest" to "iot_data_0" with qos 0 and message "Test message"' with status PASSED
[INFO ] 2023-04-19 18:03:11.745 [main] MqttControlSteps - Awaiting for MQTT message Test message on topic iot_data_0 on Thing gg-65040f17d5ef20ef812c-clientDeviceTest for 5 seconds
[INFO ] 2023-04-19 18:03:11.751 [grpc-default-executor-0] GRPCDiscoveryServer - OnReceiveMessage: agentId aws.greengrass.client.Mqtt5JavaSdkClient connectionId 1 topic iot_data_0 QoS 0
[INFO ] 2023-04-19 18:03:11.752 [main] feature - Finished step: 'message "Test message" received on "clientDeviceTest" from "iot_data_0" topic within 5 seconds' with status PASSED
[INFO ] 2023-04-19 18:03:11.754 [grpc-default-executor-0] MqttControlSteps - Message received on connection with name gg-65040f17d5ef20ef812c-clientDeviceTest: topic: "iot_data_0"
payload: "Test message"
[INFO ] 2023-04-19 18:03:17.259 [main] AWSResourcesSteps - Successfully removed externally created resources
[INFO ] 2023-04-19 18:03:17.264 [main] LoggerSteps - Clearing thread context on scenario: 'GGMQ-1-T1: As a customer, I can connect, subscribe, publish and receive using client application to MQTT topic'
[INFO ] 2023-04-19 18:03:17.274 [main] StepTrackingReporting - Passed: 'GGMQ-1-T1: As a customer, I can connect, subscribe, publish and receive using client application to MQTT topic'
[INFO ] 2023-04-19 18:03:17.372 [Thread-1] AWSResourcesCleanupModule - Cleaned up com.aws.greengrass.testing.resources.AWSResources@6fa8e499

```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
