### PR TITLE
 feat(uat): added autoselect for control port

### DIFF
--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -83,6 +83,7 @@ public class MqttControlSteps {
     private static final Mqtt5RetainHandling SUBSCRIBE_RETAIN_HANDLING
             = Mqtt5RetainHandling.MQTT5_RETAIN_DO_NOT_SEND_AT_SUBSCRIPTION;
 
+    private static final String MQTT_CONTROL_PORT_KEY = "mqttControlPort";
 
     private final TestContext testContext;
 
@@ -97,8 +98,6 @@ public class MqttControlSteps {
 
     private final GreengrassV2Client greengrassClient;
     private int mqttTimeoutSec = DEFAULT_MQTT_TIMEOUT_SEC;
-
-    private final String MQTT_CONTROL_PORT_KEY = "mqttControlPort";
 
     private final EngineControl.EngineEvents engineEvents = new EngineControl.EngineEvents() {
         @Override

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -48,7 +48,6 @@ import software.amazon.awssdk.services.greengrassv2.GreengrassV2Client;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.List;
 import java.util.Optional;

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -66,7 +66,7 @@ public class MqttControlSteps {
 
     private static final int DEFAULT_MQTT_TIMEOUT_SEC = 30;
 
-    private static final int DEFAULT_CONTROL_GRPC_PORT = 47_619;
+    private static final int DEFAULT_CONTROL_GRPC_PORT = 0;
 
     private static final int DEFAULT_MQTT_KEEP_ALIVE = 60;
 
@@ -404,7 +404,7 @@ public class MqttControlSteps {
 
     private void startMqttControl() throws IOException {
         if (!engineControl.isEngineRunning()) {
-            engineControl.startEngine(getFreePort(), engineEvents);
+            engineControl.startEngine(DEFAULT_CONTROL_GRPC_PORT, engineEvents);
             final int boundPort = engineControl.getBoundPort();
             log.info("MQTT clients control started gRPC service on port {}", boundPort);
             scenarioContext.put(MQTT_CONTROL_PORT_KEY, String.valueOf(boundPort));
@@ -579,12 +579,4 @@ public class MqttControlSteps {
                             .build();
     }
 
-    private int getFreePort() {
-        try (ServerSocket socket = new ServerSocket(0)) {
-            socket.setReuseAddress(true);
-            return socket.getLocalPort();
-        } catch (IOException e) {
-            return DEFAULT_CONTROL_GRPC_PORT;
-        }
-    }
 }

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -50,7 +50,7 @@ Feature: GGMQ-1
    "MERGE":{
       "agentId":"aws.greengrass.client.Mqtt5JavaSdkClient",
       "controlAddress":"127.0.0.1",
-      "controlPort":"47619"
+      "controlPort":"${mqttControlPort}"
    }
 }
     """


### PR DESCRIPTION
**Description of changes:**
- added ability to select any free port to start control

**Why is this change necessary:**
- to improve code reliability

**Logs:**
```
[main] GRPCControlServer - GRPCControlServer created and listed on 127.0.0.1:37843.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
