### PR TITLE
feat(uat): add support of remote clients and multi-homed control

### DIFF
--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCLib.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCLib.java
@@ -15,11 +15,11 @@ public interface GRPCLib {
     /**
      * Creates and establishes bidirectional link with the client control.
      *
-     * @param agentId id of agent to identify control channel by control
-     * @param host host name of gRPC server to connect to
-     * @param port TCP port to connect to
+     * @param agentId the id of agent to identify control channel by control
+     * @param hosts the array of host name or IP address of gRPC server to connect to
+     * @param port the TCP port to connect to
      * @return connection handler
      * @throws GRPCException on errors
      */
-    GRPCLink makeLink(@NonNull String agentId, @NonNull String host, int port) throws GRPCException;
+    GRPCLink makeLink(@NonNull String agentId, @NonNull String[] hosts, int port) throws GRPCException;
 }

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCLibImpl.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCLibImpl.java
@@ -17,7 +17,7 @@ public class GRPCLibImpl implements GRPCLib {
     private final LinkFactory linkFactory;
 
     interface LinkFactory {
-        GRPCLink newLink(@NonNull String agentId, @NonNull String host, int port) throws GRPCException;
+        GRPCLink newLink(@NonNull String agentId, @NonNull String[] hosts, int port) throws GRPCException;
     }
 
     /**
@@ -26,8 +26,8 @@ public class GRPCLibImpl implements GRPCLib {
     public GRPCLibImpl() {
         this(new LinkFactory() {
             @Override
-            public GRPCLink newLink(@NonNull String agentId, @NonNull String host, int port) throws GRPCException {
-                return new GRPCLinkImpl(agentId, host, port);
+            public GRPCLink newLink(@NonNull String agentId, @NonNull String[] hosts, int port) throws GRPCException {
+                return new GRPCLinkImpl(agentId, hosts, port);
             }
         });
     }
@@ -43,7 +43,7 @@ public class GRPCLibImpl implements GRPCLib {
     }
 
     @Override
-    public GRPCLink makeLink(@NonNull String agentId, @NonNull String host, int port) throws GRPCException {
-        return linkFactory.newLink(agentId, host, port);
+    public GRPCLink makeLink(@NonNull String agentId, @NonNull String[] hosts, int port) throws GRPCException {
+        return linkFactory.newLink(agentId, hosts, port);
     }
 }

--- a/uat/custom-components/client-java-sdk/src/test/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCLibImplTest.java
+++ b/uat/custom-components/client-java-sdk/src/test/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCLibImplTest.java
@@ -34,14 +34,14 @@ class GRPCLibImplTest {
     void GIVEN_link_WHEN_makeLink_THEN_that_link_returned() throws GRPCException {
         // GIVEN
         final String agentId = "agentId";
-        final String host = "hostname";
+        final String[] hosts = {"hostname"};
         final int port = 9999;
 
         GRPCLink gRPCLink = mock(GRPCLink.class);
-        when(linkFactory.newLink(eq(agentId), eq(host), eq(port))).thenReturn(gRPCLink);
+        when(linkFactory.newLink(eq(agentId), eq(hosts), eq(port))).thenReturn(gRPCLink);
 
         // WHEN
-        GRPCLink actualGRPCLink = gRPCLibImpl.makeLink(agentId, host, port);
+        GRPCLink actualGRPCLink = gRPCLibImpl.makeLink(agentId, hosts, port);
 
         // THEN
         assertSame(gRPCLink, actualGRPCLink);

--- a/uat/custom-components/client-java-sdk/src/test/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCLinkImplTest.java
+++ b/uat/custom-components/client-java-sdk/src/test/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCLinkImplTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class GRPCLinkImplTest {
     private static final String AGENT_ID = "agent000";
-    private static final String HOST = "test_host";
+    private static final String[] HOSTS = { "test_host" };
     private static final int PORT = 1974;
     private static final String LOCAL_IP = "local_ip";
 
@@ -43,11 +43,11 @@ class GRPCLinkImplTest {
         when(server.getPort()).thenReturn(SERVICE_PORT);
 
         GRPCLinkImpl.HalvesFactory halvesFactory = mock(GRPCLinkImpl.HalvesFactory.class);
-        final String buildAddress = GRPCLinkImpl.buildAddress(HOST, PORT);
+        final String buildAddress = GRPCLinkImpl.buildAddress(HOSTS[0], PORT);
         when(halvesFactory.newClient(eq(AGENT_ID), eq(buildAddress))).thenReturn(client);
         when(halvesFactory.newServer(eq(client), eq(LOCAL_IP), eq(0))).thenReturn(server);
 
-        gRPCLinkImpl = new GRPCLinkImpl(AGENT_ID, HOST, PORT, halvesFactory);
+        gRPCLinkImpl = new GRPCLinkImpl(AGENT_ID, HOSTS, PORT, halvesFactory);
 
         verify(halvesFactory).newClient(eq(AGENT_ID), eq(buildAddress));
         verify(client).registerAgent();

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/EngineControl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/EngineControl.java
@@ -61,6 +61,13 @@ public interface EngineControl {
     Integer getBoundPort();
 
     /**
+     * Get array of local IP addresses.
+     *
+     * @return the array of IP addresses where control can be reached
+     */
+    String[] getIPs();
+
+    /**
      * Checks is engine runing.
      *
      * @return true if engine is running

--- a/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImplTest.java
+++ b/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImplTest.java
@@ -321,4 +321,16 @@ class EngineControlImplTest {
         // THEN
         verify(agentControl).onMqttDisconnect(eq(connectionId), eq(disconnect), eq(error));
     }
+
+    @Test
+    void GIVEN_control_WHEN_get_ips_THEN_XXX() throws IOException {
+        // GIVEN
+
+        // WHEN
+        String[] ips = engineControl.getIPs();
+
+        // THEN
+        assertNotNull(ips);
+        assertTrue(ips.length > 0);
+    }
 }

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -64,7 +64,12 @@ public class MqttControlSteps {
 
     private static final int DEFAULT_MQTT_TIMEOUT_SEC = 30;
 
+    @SuppressWarnings("PMD.AvoidUsingHardCodedIP")
+    private static final String DEFAULT_CONTROL_GRPC_IP = "127.0.0.1";
+    private static final String MQTT_CONTROL_ADDRESSES_KEY = "mqttControlAddresses";
+
     private static final int DEFAULT_CONTROL_GRPC_PORT = 0;
+    private static final String MQTT_CONTROL_PORT_KEY = "mqttControlPort";
 
     private static final int MQTT5_REASON_SUCCESS = 0;
     private static final int MQTT5_GRANTED_QOS_2 = 2;
@@ -81,7 +86,6 @@ public class MqttControlSteps {
     private static final Mqtt5RetainHandling SUBSCRIBE_RETAIN_HANDLING
             = Mqtt5RetainHandling.MQTT5_RETAIN_DO_NOT_SEND_AT_SUBSCRIPTION;
 
-    private static final String MQTT_CONTROL_PORT_KEY = "mqttControlPort";
 
     private final TestContext testContext;
 
@@ -439,8 +443,15 @@ public class MqttControlSteps {
     private void startMqttControl() throws IOException {
         if (!engineControl.isEngineRunning()) {
             engineControl.startEngine(DEFAULT_CONTROL_GRPC_PORT, engineEvents);
+
             final int boundPort = engineControl.getBoundPort();
-            log.info("MQTT clients control started gRPC service on port {}", boundPort);
+            String[] addresses = engineControl.getIPs();
+            log.info("MQTT clients control started gRPC service on port {} adrresses {}", boundPort, addresses);
+
+            if (addresses == null || addresses.length == 0) {
+                addresses = new String[] { DEFAULT_CONTROL_GRPC_IP };
+            }
+            scenarioContext.put(MQTT_CONTROL_ADDRESSES_KEY, String.join(" ", addresses));
             scenarioContext.put(MQTT_CONTROL_PORT_KEY, String.valueOf(boundPort));
         }
     }

--- a/uat/testing-features/src/main/resources/greengrass/components/recipes/client_java_sdk.yaml
+++ b/uat/testing-features/src/main/resources/greengrass/components/recipes/client_java_sdk.yaml
@@ -13,7 +13,7 @@ ComponentConfiguration:
   DefaultConfiguration:
     # agentId should be the same as ComponentName
     agentId: aws.greengrass.client.Mqtt5JavaSdkClient
-    controlAddress: 127.0.0.1
+    controlAddresses: 127.0.0.1
     controlPort: 47619
 Manifests:
   - Artifacts:
@@ -23,4 +23,4 @@ Manifests:
           Execute: ALL
     Lifecycle:
       Run: |
-        java -jar {artifacts:path}/aws.greengrass.client.Mqtt5JavaSdkClient.jar "{configuration:/agentId}" "{configuration:/controlPort}" "{configuration:/controlAddress}"
+        java -jar {artifacts:path}/aws.greengrass.client.Mqtt5JavaSdkClient.jar "{configuration:/agentId}" "{configuration:/controlPort}" {configuration:/controlAddresses}

--- a/uat/testing-features/src/main/resources/greengrass/components/recipes/client_java_sdk.yaml
+++ b/uat/testing-features/src/main/resources/greengrass/components/recipes/client_java_sdk.yaml
@@ -23,4 +23,4 @@ Manifests:
           Execute: ALL
     Lifecycle:
       Run: |
-        java -jar {artifacts:path}/aws.greengrass.client.Mqtt5JavaSdkClient.jar {configuration:/agentId} {configuration:/controlAddress} "{configuration:/controlPort}"
+        java -jar {artifacts:path}/aws.greengrass.client.Mqtt5JavaSdkClient.jar "{configuration:/agentId}" "{configuration:/controlPort}" "{configuration:/controlAddress}"

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -49,7 +49,7 @@ Feature: GGMQ-1
 {
    "MERGE":{
       "agentId":"aws.greengrass.client.Mqtt5JavaSdkClient",
-      "controlAddress":"127.0.0.1",
+      "controlAddresses":"${mqttControlAddresses}",
       "controlPort":"${mqttControlPort}"
    }
 }


### PR DESCRIPTION
**Issue #, if available:**
Multi-homed control is not supported

**Description of changes:**
- Add detection of control addresses and pass to client
- Allow SDK-base MQTT client to receive multiple IP/host of control

**Why is this change necessary:**
Currently agent got hard coded 127.0.0.1 as address of control.
That limit clients to be run only locally.
Implementation is changed to get actual list of IP addresses how control can be reached and pass it to the agent arguments.

**How was this change tested:**
Unit test added to new method of control.
Other parts can be verified during scenario run.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
