### PR TITLE
feat(uat): allow requests with MQTT v3.1.1 proto version

### DIFF
--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.testing.mqtt311.client.sdkmqtt;
+
+import com.aws.greengrass.testing.mqtt5.client.GRPCClient;
+import com.aws.greengrass.testing.mqtt5.client.MqttConnection;
+import com.aws.greengrass.testing.mqtt5.client.MqttLib;
+import com.aws.greengrass.testing.mqtt5.client.exceptions.MqttException;
+import lombok.NonNull;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.crt.mqtt.MqttClientConnection;
+import software.amazon.awssdk.crt.mqtt.MqttClientConnectionEvents;
+import software.amazon.awssdk.iot.AwsIotMqttConnectionBuilder;
+
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Implementation of MQTT 3.1.1 connection.
+ */
+public class Mqtt311ConnectionImpl implements MqttConnection {
+    private static final Logger logger = LogManager.getLogger(Mqtt311ConnectionImpl.class);
+
+    private final AtomicBoolean isClosing = new AtomicBoolean();
+    private final AtomicBoolean isConnected = new AtomicBoolean();
+
+    @SuppressWarnings("PMD.UnusedPrivateField")
+    private final GRPCClient grpcClient;
+
+    @SuppressWarnings("PMD.UnusedPrivateField")
+    private final MqttClientConnection connection;
+
+    @SuppressWarnings("PMD.UnusedPrivateField")
+    private int connectionId = 0;
+
+    @SuppressWarnings("PMD.UnusedPrivateField")
+    private final ClientConnectionEvents connectionEvents = new ClientConnectionEvents();
+
+    class ClientConnectionEvents implements MqttClientConnectionEvents {
+        @Override
+        public void onConnectionInterrupted(int errorCode) {
+            logger.atInfo().log("MQTT connection interrupted, error code {}", errorCode);
+        }
+
+        @Override
+        public void onConnectionResumed(boolean sessionPresent) {
+            logger.atInfo().log("MQTT connection resumed, sessionPresent {}", sessionPresent);
+        }
+    }
+
+
+    /**
+     * Creates a MQTT 3.1.1 connection.
+     *
+     * @param connectionParams the connection parameters
+     * @param grpcClient the consumer of received messages and disconnect events
+     * @throws MqttException on errors
+     */
+    public Mqtt311ConnectionImpl(@NonNull MqttLib.ConnectionParams connectionParams, @NonNull GRPCClient grpcClient)
+                    throws MqttException {
+        super();
+        this.grpcClient = grpcClient;
+        this.connection = createConnection(connectionParams);
+    }
+
+    /**
+     * Creates a MQTT 3.1.1 connection for tests.
+     *
+     * @param grpcClient the consumer of received messages and disconnect events
+     * @param connection the connection backend
+     * @throws MqttException on errors
+     */
+    Mqtt311ConnectionImpl(@NonNull GRPCClient grpcClient, @NonNull MqttClientConnection connection) {
+        super();
+        this.grpcClient = grpcClient;
+        this.connection = connection;
+    }
+
+    @Override
+    public ConnectResult start(long timeout, int connectionId) throws MqttException {
+        this.connectionId = connectionId;
+        return null;
+    }
+
+    @Override
+    public void disconnect(long timeout, int reasonCode) throws MqttException {
+
+        // if (!isClosing.getAndSet(true)) {
+        // 
+    }
+
+    @Override
+    public PubAckInfo publish(long timeout, final @NonNull Message message)
+                    throws MqttException {
+
+        stateCheck();
+
+        return null;
+    }
+
+    @Override
+    public SubAckInfo subscribe(long timeout, Integer subscriptionId, final @NonNull List<Subscription> subscriptions)
+            throws MqttException {
+
+        stateCheck();
+
+        return null;
+    }
+
+    @Override
+    public UnsubAckInfo unsubscribe(long timeout, final @NonNull List<String> filters)
+            throws MqttException {
+
+        stateCheck();
+
+        return null;
+    }
+
+    /**
+     * Creates a MQTT 311 connection.
+     *
+     * @param connectionParams connection parameters
+     * @return MQTT 3.1.1 connection
+     * @throws MqttException on errors
+     */
+    private MqttClientConnection createConnection(MqttLib.ConnectionParams connectionParams) throws MqttException {
+
+        try (AwsIotMqttConnectionBuilder builder = getConnectionBuilder(connectionParams)) {
+            builder.withEndpoint(connectionParams.getHost())
+                .withPort((short)connectionParams.getPort())
+                .withClientId(connectionParams.getClientId())
+                .withCleanSession(connectionParams.isCleanSession())
+                .withConnectionEventCallbacks(connectionEvents);
+
+            /* TODO: other options:
+                withKeepAliveMs() / withKeepAliveSecs()
+                withPingTimeoutMs()
+                withProtocolOperationTimeoutMs()
+                withTimeoutMs()
+                withReconnectTimeoutSecs()
+                withSocketOptions()
+                withUsername()
+                withPassword()
+                withWill(...)
+                withBootstrap()
+                withHttpProxyOptions()
+            */
+
+            return builder.build();
+        }
+    }
+
+    /**
+     * Creates a MQTT 3.1.1 connection builder.
+     *
+     * @param connectionParams connection parameters
+     * @return builder of MQTT v3.1.1 connection
+     * @throws MqttException on errors
+     */
+    private AwsIotMqttConnectionBuilder getConnectionBuilder(MqttLib.ConnectionParams connectionParams)
+                throws MqttException {
+        try {
+            if (connectionParams.getKey() == null) {
+                // TODO: check is unsecured mode supported by SDK/CRT for MQTT 3.1.1 client
+                logger.atInfo().log("Creating MqttClientConnection without TLS");
+                return AwsIotMqttConnectionBuilder.newDefaultBuilder();
+            } else {
+                logger.atInfo().log("Creating AwsIotMqttConnectionBuilder with TLS");
+                return AwsIotMqttConnectionBuilder.newMtlsBuilder(connectionParams.getCert(), connectionParams.getKey())
+                                                    .withCertificateAuthority(connectionParams.getCa());
+            }
+        } catch (UnsupportedEncodingException ex) {
+            logger.atWarn().withThrowable(ex).log("Couldn't create MQTT connection builder");
+            throw new MqttException("Couldn't create MQTT connection builder", ex);
+        }
+    }
+
+    /**
+     * Checks connection state.
+     *
+     * @throws MqttException when connection state is not allow opertation
+     */
+    private void stateCheck() throws MqttException {
+        if (!isConnected.get()) {
+            throw new MqttException("MQTT client is not in connected state");
+        }
+
+        if (isClosing.get()) {
+            throw new MqttException("MQTT connection is closing");
+        }
+    }
+}

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
@@ -44,6 +44,9 @@ public interface MqttLib extends AutoCloseable {
 
         /** Content of MQTT client's private key, optional. */
         private String key;
+
+        /** The true MQTT v5.0 connection is requested. */
+        private boolean mqtt50;
     }
 
     /**

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -145,11 +145,14 @@ class GRPCControlServer {
             }
 
             MqttProtoVersion version = request.getProtocolVersion();
-            if (version != MqttProtoVersion.MQTT_PROTOCOL_V50) {
-                logger.atWarn().log("invalid protocolVersion {}, {} is only supported",
-                                        version, MqttProtoVersion.MQTT_PROTOCOL_V50);
+            if (version != MqttProtoVersion.MQTT_PROTOCOL_V311 && version != MqttProtoVersion.MQTT_PROTOCOL_V50) {
+                logger.atWarn().log("invalid protocolVersion {}, {} and {} are only supported",
+                                        version,
+                                        MqttProtoVersion.MQTT_PROTOCOL_V311,
+                                        MqttProtoVersion.MQTT_PROTOCOL_V50);
                 responseObserver.onError(Status.INVALID_ARGUMENT
-                                .withDescription("invalid protocolVersion, only MQTT_PROTOCOL_V50 supported")
+                                .withDescription("invalid protocolVersion, only "
+                                                    + "MQTT_PROTOCOL_V311 and MQTT_PROTOCOL_V50 are supported")
                                 .asRuntimeException());
                 return;
             }
@@ -179,7 +182,8 @@ class GRPCControlServer {
                             .host(host)
                             .port(port)
                             .keepalive(keepalive)
-                            .cleanSession(request.getCleanSession());
+                            .cleanSession(request.getCleanSession())
+                            .mqtt50(version == MqttProtoVersion.MQTT_PROTOCOL_V50);
 
             // check TLS optional settings
             if (request.hasTls()) {

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttLibImpl.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttLibImpl.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.testing.mqtt5.client.sdkmqtt;
 
+import com.aws.greengrass.testing.mqtt311.client.sdkmqtt.Mqtt311ConnectionImpl;
 import com.aws.greengrass.testing.mqtt5.client.GRPCClient;
 import com.aws.greengrass.testing.mqtt5.client.MqttConnection;
 import com.aws.greengrass.testing.mqtt5.client.MqttLib;
@@ -33,7 +34,7 @@ public class MqttLibImpl implements MqttLib {
 
 
     interface ConnectionFactory {
-        MqttConnectionImpl newConnection(@NonNull ConnectionParams connectionParams, @NonNull GRPCClient grpcClient)
+        MqttConnection newConnection(@NonNull ConnectionParams connectionParams, @NonNull GRPCClient grpcClient)
                             throws MqttException;
     }
 
@@ -43,9 +44,13 @@ public class MqttLibImpl implements MqttLib {
     public MqttLibImpl() {
         this(new ConnectionFactory() {
             @Override
-            public MqttConnectionImpl newConnection(@NonNull ConnectionParams connectionParams,
+            public MqttConnection newConnection(@NonNull ConnectionParams connectionParams,
                                                     @NonNull GRPCClient grpcClient) throws MqttException {
-                return new MqttConnectionImpl(connectionParams, grpcClient);
+                if (connectionParams.isMqtt50()) {
+                    return new MqttConnectionImpl(connectionParams, grpcClient);
+                } else {
+                    return new Mqtt311ConnectionImpl(connectionParams, grpcClient);
+                }
             }
         });
     }
@@ -94,7 +99,6 @@ public class MqttLibImpl implements MqttLib {
     public void close() {
         cleaupConnections();
     }
-
 
     /**
      * Dry connections.

--- a/uat/custom-components/client-java-sdk/src/test/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttLibImplTest.java
+++ b/uat/custom-components/client-java-sdk/src/test/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttLibImplTest.java
@@ -41,7 +41,7 @@ class MqttLibImplTest {
     @Test
     void GIVEN_factory_provides_connection_WHEN_create_connection_THEN_factory_is_called() throws MqttException {
         // GIVEN
-        final MqttConnectionImpl expectedMqttConnection = mock(MqttConnectionImpl.class);
+        final MqttConnection expectedMqttConnection = mock(MqttConnection.class);
         when(connectionFactory.newConnection(any(ConnectionParams.class), any(GRPCClient.class))).thenReturn(expectedMqttConnection);
 
         final ConnectionParams connectionParams = mock(ConnectionParams.class);

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
@@ -84,6 +84,7 @@ class AgentTestScenario implements Runnable {
     private static final Logger logger = LogManager.getLogger(AgentTestScenario.class);
 
     private boolean useTLS;
+    private final boolean mqtt50;
     private final AgentControl agentControl;
     private final EventStorageImpl eventStorage;
 
@@ -114,10 +115,11 @@ class AgentTestScenario implements Runnable {
         }
     };
 
-    public AgentTestScenario(boolean useTLS, AgentControl agentControl, EventStorageImpl eventStorage) {
+    public AgentTestScenario(boolean useTLS, boolean mqtt50, AgentControl agentControl, EventStorageImpl eventStorage) {
         super();
 
         this.useTLS = useTLS;
+        this.mqtt50 = mqtt50;
         this.agentControl = agentControl;
         this.eventStorage = eventStorage;
 
@@ -176,7 +178,8 @@ class AgentTestScenario implements Runnable {
                     .setKeepalive(KEEP_ALIVE)
                     .setCleanSession(CLEAN_SESSION)
                     .setTimeout(CONNECT_TIMEOUT)
-                    .setProtocolVersion(MqttProtoVersion.MQTT_PROTOCOL_V50);
+                    .setProtocolVersion(mqtt50  ? MqttProtoVersion.MQTT_PROTOCOL_V50
+                                                : MqttProtoVersion.MQTT_PROTOCOL_V311);
 
         if (useTLS) {
             TLSSettings tlsSettings = TLSSettings.newBuilder().addCaList(ca).setCert(cert).setKey(key).build();

--- a/uat/proto/mqtt_client_control.proto
+++ b/uat/proto/mqtt_client_control.proto
@@ -136,9 +136,9 @@ service MqttClientControl {
 // Versions of MQTT protocol, used for compatibility, only MQTT_PROTOCOL_V50 actually supported
 enum MqttProtoVersion {
     MQTT_PROTOCOL_V0    = 0;
-    MQTT_PROTOCOL_V31   = 3;
-    MQTT_PROTOCOL_V311  = 4;
-    MQTT_PROTOCOL_V50   = 5;         // only that is supported
+    MQTT_PROTOCOL_V31   = 3;            // unsupported
+    MQTT_PROTOCOL_V311  = 4;            // supported
+    MQTT_PROTOCOL_V50   = 5;            // supported
 };
 
 // MQTT QoS values

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -583,5 +583,4 @@ public class MqttControlSteps {
                             .setRetain(retain)
                             .build();
     }
-
 }

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -503,6 +503,20 @@ public class MqttControlSteps {
             throw new IllegalStateException("Groups are missing in discovery response");
         }
 
+        log.info("Discovered data for broker {}: ", brokerId);
+        groups.stream().forEach(group -> {
+            log.info("groupId {} with {} CA", group.getGGGroupId(), group.getCAs().size());
+            group.getCores().stream().forEach(core -> {
+                log.info("Core with thing Arn {}", core.getThingArn());
+                core.getConnectivity().stream().forEach(ci -> {
+                    log.info("Connectivity info: id {} host {} port {}",
+                                ci. getId(),
+                                ci.getHostAddress(),
+                                ci.getPortNumber());
+                });
+            });
+        });
+
         brokers.put(brokerId, groups);
     }
 


### PR DESCRIPTION
**Issue #, if available:**
Update control and SDK client to request MQTT 3.1.1 connections

**Description of changes:**
- Add Mqtt311ConnectionImpl.java with frame code of the MQTT 3.1.1 connection
- Add mqtt50 flag in MqttLib.ConnectionParams
- Update check of version in incoming gRPC connect request
- Update connection factory to produce Mqtt311ConnectionImpl
- Update unit tests of MqttLibImpl
- Update control's scenario and main to receive and handle use mqtt 5.0 flag
- Add logging of discovered info about broker for manual testing


**Why is this change necessary:**
We are going to add posibility to establish MQTT 3.1.1 connections to existing SDK-based agent.
As a first step we need update control used as manual testing tool and agent common code to allow protocol version 3.1.1

**How was this change tested:**
Whole feature is not yet finished, can test only manually. Logs are below

**Test output:**
Control:
```
export MQTT_CLIENT_ID=GGMQ-test-device2
export MQTT_BROKER_ADDR=a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com
#export MQTT_BROKER_PORT=8883
export MQTT_CLIENT_CA_FILE=../GGMQ-test-device2.creds/rootCA.pem
export MQTT_CLIENT_CERT_FILE=../GGMQ-test-device2.creds/thingCert.crt
export MQTT_CLIENT_KEY_FILE=../GGMQ-test-device2.creds/privKey.key

java -jar target/aws-greengrass-testing-mqtt-client-control-1.0-SNAPSHOT.jar  47619 true false
```

```
[INFO ] 2023-04-21 14:07:29.945 [main] EngineControlImpl - MQTT client control gRPC server started, listening on 47619
[INFO ] 2023-04-21 14:07:37.457 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId agent1
[INFO ] 2023-04-21 14:07:37.512 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId agent1 address 127.0.0.1 port 34175
[INFO ] 2023-04-21 14:07:37.516 [grpc-default-executor-0] EngineControlImpl - Created new agent control for agent1 on 127.0.0.1:34175
[INFO ] 2023-04-21 14:07:37.553 [grpc-default-executor-0] ExampleControl - Agent agent1 is connected
[INFO ] 2023-04-21 14:07:37.556 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id agent1
[ERROR] 2023-04-21 14:07:40.816 [pool-2-thread-1] AgentControlImpl - Couldn't create MQTT connection error '' CONNACK ''
[INFO ] 2023-04-21 14:07:40.824 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-04-21 14:07:40.833 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId agent1 reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-04-21 14:07:40.836 [grpc-default-executor-0] ExampleControl - Agent agent1 is disconnected
^C[INFO ] 2023-04-21 14:07:54.103 [Thread-0] ExampleControl - *** shutting down gRPC server since JVM is shutting down
```

Client:
```
[INFO ] 2023-04-21 14:07:37.000 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Making gPRC client connection with 127.0.0.1:47619 as agent1...
[INFO ] 2023-04-21 14:07:37.476 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Client connection with Control is established, local address is 127.0.0.1
[INFO ] 2023-04-21 14:07:37.507 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - GRPCControlServer created and listed on 127.0.0.1:34175
[INFO ] 2023-04-21 14:07:37.560 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Handle gRPC requests
[INFO ] 2023-04-21 14:07:37.560 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - Server awaitTermination
[INFO ] 2023-04-21 14:07:40.639 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId GGMQ-test-device2 broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[INFO ] 2023-04-21 14:07:40.642 [grpc-default-executor-0] Mqtt311ConnectionImpl - Creating AwsIotMqttConnectionBuilder with TLS
[INFO ] 2023-04-21 14:07:40.820 [grpc-default-executor-0] GRPCControlServer - shutdownAgent: reason That's it.
[INFO ] 2023-04-21 14:07:40.829 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - Server awaitTermination done
[INFO ] 2023-04-21 14:07:40.829 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Shutdown gPRC link
[INFO ] 2023-04-21 14:07:40.839 [com.aws.greengrass.testing.mqtt5.client.Main.main()] Main - Execution done successfully
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
