### PR TITLE
feat(uat): added step disconnect in MqttControlSteps

### DIFF
--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -25,6 +25,7 @@ import com.aws.greengrass.testing.mqtt.client.control.api.ConnectionControl;
 import com.aws.greengrass.testing.mqtt.client.control.api.EngineControl;
 import com.aws.greengrass.testing.mqtt.client.control.api.addon.Event;
 import com.aws.greengrass.testing.mqtt.client.control.api.addon.EventFilter;
+import com.aws.greengrass.testing.mqtt.client.control.implementation.DisconnectReasonCode;
 import com.aws.greengrass.testing.mqtt.client.control.implementation.addon.EventStorageImpl;
 import com.aws.greengrass.testing.mqtt.client.control.implementation.addon.MqttMessageEvent;
 import com.aws.greengrass.testing.resources.AWSResources;
@@ -61,6 +62,8 @@ import static software.amazon.awssdk.iot.discovery.DiscoveryClient.TLS_EXT_ALPN;
 @ScenarioScoped
 public class MqttControlSteps {
     private static final String DEFAULT_CLIENT_DEVICE_POLICY_CONFIG = "/configs/iot/basic_client_device_policy.yaml";
+    private static final DisconnectReasonCode DEFAULT_DISCONNECT_REASON
+            = DisconnectReasonCode.NORMAL_DISCONNECTION;
 
     private static final int DEFAULT_MQTT_TIMEOUT_SEC = 30;
 
@@ -261,6 +264,22 @@ public class MqttControlSteps {
             throw new RuntimeException("No addresses to connect");
         }
         throw lastException;
+    }
+
+    /**
+     * Disconnect IoT Thing.
+     *
+     * @param clientDeviceId string user defined client device id
+     */
+    @And("I disconnect device {string}")
+    public void disconnect(String clientDeviceId) {
+        // getting connectionControl by clientDeviceId
+        final String clientDeviceThingName = getClientDeviceThingName(clientDeviceId);
+        ConnectionControl connectionControl = getConnectionControl(clientDeviceThingName);
+
+        //do disconnect
+        connectionControl.closeMqttConnection(DEFAULT_DISCONNECT_REASON.getValue());
+        log.info("Thing {} was disconnected", clientDeviceId);
     }
 
     /**

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -62,8 +62,6 @@ import static software.amazon.awssdk.iot.discovery.DiscoveryClient.TLS_EXT_ALPN;
 @ScenarioScoped
 public class MqttControlSteps {
     private static final String DEFAULT_CLIENT_DEVICE_POLICY_CONFIG = "/configs/iot/basic_client_device_policy.yaml";
-    private static final DisconnectReasonCode DEFAULT_DISCONNECT_REASON
-            = DisconnectReasonCode.NORMAL_DISCONNECTION;
 
     private static final int DEFAULT_MQTT_TIMEOUT_SEC = 30;
 
@@ -278,7 +276,7 @@ public class MqttControlSteps {
         ConnectionControl connectionControl = getConnectionControl(clientDeviceThingName);
 
         //do disconnect
-        connectionControl.closeMqttConnection(DEFAULT_DISCONNECT_REASON.getValue());
+        connectionControl.closeMqttConnection(DisconnectReasonCode.NORMAL_DISCONNECTION.getValue());
         log.info("Thing {} was disconnected", clientDeviceId);
     }
 


### PR DESCRIPTION
**Issue #, if available:**
Disconnect thing

**Description of changes:**
- Added new step to disconnect

**Why is this change necessary:**
to use in feature testing

**How was this change tested:**
On CI

**Test results:**
```log
And my device is running Greengrass.........................................passed
When I create a Greengrass deployment with components.......................passed
And I create client device "clientDeviceTest"...............................passed
When I associate "clientDeviceTest" with ggc................................passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:.passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.client.Mqtt5JavaSdkClient configuration to:.passed
And I deploy the Greengrass deployment configuration........................passed
Then the Greengrass deployment is COMPLETED on the device after 300 seconds.passed
And I discover core device broker as "default_broker" from "clientDeviceTest".passed
And I connect device "clientDeviceTest" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker".passed
When I subscribe "clientDeviceTest" to "iot_data_0" with qos 0..............passed
When I publish from "clientDeviceTest" to "iot_data_0" with qos 0 and message "Test message".passed
And message "Test message" received on "clientDeviceTest" from "iot_data_0" topic within 5 seconds.passed
And I disconnect device "clientDeviceTest"..................................passed
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
