### PR TITLE
feat(uat): add connect/disconnect implementation to MQTT 3.1.1 client

### DIFF
--- a/uat/custom-components/client-java-sdk/README.md
+++ b/uat/custom-components/client-java-sdk/README.md
@@ -1,6 +1,6 @@
-# Test MQTT5 client bases on AWS IoT Device SDK for Java v2
+# Test MQTT5/311 client bases on AWS IoT Device SDK for Java v2
 
-The controlled `test MQTT v5.0 client` is based on AWS IoT Device SDK for Java v2 is used to test Greengrass v2 MQTT v5.0 compatibility.
+The controlled `test MQTT v5.0/v3.1.1 client` is based on AWS IoT Device SDK for Java v2 is used to test Greengrass v2 MQTT v5.0 compatibility.
 
 ## How to compile
 To compile this client, use the following command:
@@ -38,3 +38,17 @@ mvn exec:java
 ```sh
 java -jar target/client-devices-auth-uat-client-java-sdk.jar agent1 127.0.0.1 47619
 ```
+
+# Limitations
+That client support both MQTT v5.0 and MQTT v3.1.1 protocols.
+But because both clients are based on separated clients implemented in IoT device SDK and CRT libraries it differs in protocol-level information provided to control.
+
+Will message not yet supported.
+
+## MQTT v5.0 client
+Currenly information from packets related to QoS2 like PUBREC PUBREL PUBCOMP is missing.
+
+## MQTT v3.1.1 client
+SDK-based client provides only session present flag of CONNACK packet.
+Connect Return code is missing.
+

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
@@ -29,6 +29,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class Mqtt311ConnectionImpl implements MqttConnection {
     private static final Logger logger = LogManager.getLogger(Mqtt311ConnectionImpl.class);
+    private static final String EXCEPTION_WHEN_CONNECTING = "Exception occurred during connect";
+    private static final String EXCEPTION_WHEN_DISCONNECTING = "Exception occurred during disconnect";
 
     private final AtomicBoolean isClosing = new AtomicBoolean();
     private final AtomicBoolean isConnected = new AtomicBoolean();
@@ -98,11 +100,11 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
             return buildConnectResult(true, sessionPresent);
         } catch (InterruptedException ex) {
             Thread.currentThread().interrupt();
-            logger.atError().withThrowable(ex).log("Exception occurred during connect");
-            throw new MqttException("Exception occurred during connect", ex);
+            logger.atError().withThrowable(ex).log(EXCEPTION_WHEN_CONNECTING);
+            throw new MqttException(EXCEPTION_WHEN_CONNECTING, ex);
         } catch (TimeoutException | ExecutionException ex) {
-            logger.atError().withThrowable(ex).log("Exception occurred during connect");
-            throw new MqttException("Exception occurred during connect", ex);
+            logger.atError().withThrowable(ex).log(EXCEPTION_WHEN_CONNECTING);
+            throw new MqttException(EXCEPTION_WHEN_CONNECTING, ex);
         }
     }
 
@@ -116,11 +118,11 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
             logger.atInfo().log("MQTT 3.1.1 connection {} has been closed", connectionId);
             } catch (InterruptedException ex) {
                 Thread.currentThread().interrupt();
-                logger.atError().withThrowable(ex).log("Failed during disconnecting");
-                throw new MqttException("Could not disconnect", ex);
+                logger.atError().withThrowable(ex).log(EXCEPTION_WHEN_DISCONNECTING);
+                throw new MqttException(EXCEPTION_WHEN_DISCONNECTING, ex);
             } catch (TimeoutException | ExecutionException ex) {
-                logger.atError().withThrowable(ex).log("Failed during disconnecting");
-                throw new MqttException("Could not disconnect", ex);
+                logger.atError().withThrowable(ex).log(EXCEPTION_WHEN_DISCONNECTING);
+                throw new MqttException(EXCEPTION_WHEN_DISCONNECTING, ex);
             } finally {
                 connection.close();
             }

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
@@ -96,7 +96,11 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
             isConnected.set(true);
             logger.atInfo().log("MQTT 3.1.1 connection {} is establisted", connectionId);
             return buildConnectResult(true, sessionPresent);
-        } catch (TimeoutException | InterruptedException | ExecutionException ex) {
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            logger.atError().withThrowable(ex).log("Exception occurred during connect");
+            throw new MqttException("Exception occurred during connect", ex);
+        } catch (TimeoutException | ExecutionException ex) {
             logger.atError().withThrowable(ex).log("Exception occurred during connect");
             throw new MqttException("Exception occurred during connect", ex);
         }
@@ -110,7 +114,11 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
             try {
                 disconnected.get(timeout, TimeUnit.SECONDS);
             logger.atInfo().log("MQTT 3.1.1 connection {} has been closed", connectionId);
-            } catch (TimeoutException | InterruptedException | ExecutionException ex) {
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                logger.atError().withThrowable(ex).log("Failed during disconnecting");
+                throw new MqttException("Could not disconnect", ex);
+            } catch (TimeoutException | ExecutionException ex) {
                 logger.atError().withThrowable(ex).log("Failed during disconnecting");
                 throw new MqttException("Could not disconnect", ex);
             } finally {

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -47,6 +47,16 @@ public interface MqttConnection {
         // TODO: Authentication Method
         // TODO: Authentication Data
         // TODO: user's Properties
+
+        /**
+         * Creates ConnAckInfo for result of MQTT 3.1.1 connect.
+         *
+         * @param sessionPresent the session present flag of MQTT 3.1.1
+         */
+        public ConnAckInfo(Boolean sessionPresent) {
+            super();
+            this.sessionPresent = sessionPresent;
+        }
     }
 
     /**

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttConnectionImpl.java
@@ -47,7 +47,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 /**
- * Implementation of MQTT5 connection.
+ * Implementation of MQTT5 connection based on AWS IoT device SDK.
  */
 public class MqttConnectionImpl implements MqttConnection {
     private static final long MIN_SHUTDOWN_NS = 200_000_000;      // 200ms

--- a/uat/mqtt-client-control/README.md
+++ b/uat/mqtt-client-control/README.md
@@ -59,8 +59,13 @@ By default control will starting gRPC server on port 47619 and any address.
 
 ### Use TLS
 Is a second command line argument.
-By default control will requires to agent to establish TLS connection with broker.
+By default control will requires to agent to establish TLS-secured connection with broker.
 That can be changes by using false keyword for second argument.
+
+### Use MQTT 5.0
+Is a third command line argument.
+By default control will requires to agent to establish MQTT 5.0 connection with broker.
+That can be changes by using false keyword for third argument. In that case MQTT v3.1.1 will be used.
 
 ### Examples
 ```sh

--- a/uat/proto/mqtt_client_control.proto
+++ b/uat/proto/mqtt_client_control.proto
@@ -222,7 +222,7 @@ message MqttConnectReply {
     bool connected = 1;                                 // true when connection has been established
     MqttConnectionId connectionId = 2;                  // id of establisted connection
     optional Mqtt5ConnAck connAck = 3;                  // information from CONNACK packet
-    string error = 4;                                   // on TCP/TLS error contains error string
+    optional string error = 4;                          // error string if available, has sense on connected = false
     // TODO: add user properties
 }
 


### PR DESCRIPTION
**Issue #, if available:**
Implement MQTT 3.1.1 connect
Implement MQTT 3.1.1 disconnect

**Description of changes:**
- Implement Mqtt311ConnectionImpl.start() and .disconnect() methods.
- Update README of control to describe third argument 
- Update README of client to describe limimtations
- Update protocol to mark MqttConnectReply.error as optional

**Why is this change necessary:**
Connect and disconnect methods are required to provide full functionality of MQTT 3.1.1 client

**How was this change tested:**
Manually until unit tests and full client's logic will be used in scenarios
**Test results:**

Note: publish/subscribe/unsubscribe not yet implemented and do nothing

To local mosquitto broker:
Control:
```
$ ./run_for_mosquitto_311.sh
[INFO ] 2023-04-24 14:22:37.694 [main] EngineControlImpl - MQTT client control gRPC server started, listening on 47619
[INFO ] 2023-04-24 14:22:48.026 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId agent1
[INFO ] 2023-04-24 14:22:48.079 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId agent1 address 127.0.0.1 port 42097
[INFO ] 2023-04-24 14:22:48.082 [grpc-default-executor-0] EngineControlImpl - Created new agent control for agent1 on 127.0.0.1:42097
[INFO ] 2023-04-24 14:22:48.119 [grpc-default-executor-0] ExampleControl - Agent agent1 is connected
[INFO ] 2023-04-24 14:22:48.131 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id agent1
[INFO ] 2023-04-24 14:22:51.547 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
'
[INFO ] 2023-04-24 14:22:51.548 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-04-24 14:22:51.548 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-04-24 14:22:56.556 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-04-24 14:22:56.567 [pool-2-thread-1] AgentTestScenario - Subscribe response: connectionId 1 reason codes [] reason string ''
[INFO ] 2023-04-24 14:23:01.575 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic test/topic
[INFO ] 2023-04-24 14:23:01.588 [pool-2-thread-1] AgentTestScenario - Published connectionId 1 reasonCode 0 reasonString 0
[INFO ] 2023-04-24 14:23:06.594 [pool-2-thread-1] AgentControlImpl - UnsubscribeMqtt: unsubscribe on connectionId 1
[INFO ] 2023-04-24 14:23:06.600 [pool-2-thread-1] AgentTestScenario - Unsubscribe response: connectionId 1 reason codes [] reason string ''
[INFO ] 2023-04-24 14:23:21.616 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-04-24 14:23:21.624 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-04-24 14:23:21.636 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId agent1 reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-04-24 14:23:21.639 [grpc-default-executor-0] ExampleControl - Agent agent1 is disconnected
```

Client:
```
[INFO ] 2023-04-24 14:22:47.565 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Making gPRC client connection with 127.0.0.1:47619 as agent1...
[INFO ] 2023-04-24 14:22:48.045 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Client connection with Control is established, local address is 127.0.0.1
[INFO ] 2023-04-24 14:22:48.075 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - GRPCControlServer created and listed on 127.0.0.1:42097
[INFO ] 2023-04-24 14:22:48.134 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Handle gRPC requests
[INFO ] 2023-04-24 14:22:48.135 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - Server awaitTermination
[INFO ] 2023-04-24 14:22:51.212 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId client broker server:8883
[INFO ] 2023-04-24 14:22:51.216 [grpc-default-executor-0] Mqtt311ConnectionImpl - Creating AwsIotMqttConnectionBuilder with TLS
[INFO ] 2023-04-24 14:22:51.420 [grpc-default-executor-0] Mqtt311ConnectionImpl - MQTT 3.1.1 connection 1 is establisted
[INFO ] 2023-04-24 14:22:56.563 [grpc-default-executor-0] GRPCControlServer - Subscription: filter test/topic QoS 0 noLocal false retainAsLocal false retainHandling 2
[INFO ] 2023-04-24 14:22:56.563 [grpc-default-executor-0] GRPCControlServer - Subscribe: connectionId 1 subscriptionId null for 1 filters
[INFO ] 2023-04-24 14:23:01.584 [grpc-default-executor-0] GRPCControlServer - Publish: connectionId 1 topic test/topic QoS 1 retain false
[INFO ] 2023-04-24 14:23:06.598 [grpc-default-executor-0] GRPCControlServer - Unsubscribe: connectionId 1 for [test/topic] filters
[INFO ] 2023-04-24 14:23:21.612 [grpc-default-executor-0] GRPCControlServer - closeMqttConnection: connectionId 1 reason 4
[INFO ] 2023-04-24 14:23:21.612 [grpc-default-executor-0] Mqtt311ConnectionImpl - MQTT 3.1.1 connection 1 has been closed
[INFO ] 2023-04-24 14:23:21.612 [Thread-2] Mqtt311ConnectionImpl - MQTT connection 1 interrupted, error code 0
[INFO ] 2023-04-24 14:23:21.621 [grpc-default-executor-0] GRPCControlServer - shutdownAgent: reason That's it.
[INFO ] 2023-04-24 14:23:21.632 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - Server awaitTermination done
[INFO ] 2023-04-24 14:23:21.632 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Shutdown gPRC link
[INFO ] 2023-04-24 14:23:21.643 [com.aws.greengrass.testing.mqtt5.client.Main.main()] Main - Execution done successfully
```

Broker:
```
1682338951: The 'port' option is now deprecated and will be removed in a future version. Please use 'listener' instead.
1682338951: mosquitto version 2.0.15 starting
1682338951: Config loaded from ./mosquitto.conf.
1682338951: Opening ipv4 listen socket on port 8883.
1682338951: Opening ipv6 listen socket on port 8883.
1682338951: mosquitto version 2.0.15 running
1682338971: New connection from 127.0.0.1:59442 on port 8883.
1682338971: New client connected from 127.0.0.1:59442 as client (p2, c1, k1200, u'client').
1682338971: No will message specified.
1682338971: Sending CONNACK to client (0, 0)
1682339001: Received DISCONNECT from client
1682339001: Client client disconnected.
```
Here: procotol versions are defined as:
```
enum mosquitto__protocol {
        mosq_p_invalid = 0,
        mosq_p_mqtt31 = 1,
        mosq_p_mqtt311 = 2,
        mosq_p_mqtts = 3,
        mosq_p_mqtt5 = 5,
};
```

Connecting to IoT Core:

Control:
```
./run_for_IoTCore_311.sh
[INFO ] 2023-04-24 14:43:33.203 [main] EngineControlImpl - MQTT client control gRPC server started, listening on 47619
[INFO ] 2023-04-24 14:43:45.381 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId agent1
[INFO ] 2023-04-24 14:43:45.433 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId agent1 address 127.0.0.1 port 40265
[INFO ] 2023-04-24 14:43:45.436 [grpc-default-executor-0] EngineControlImpl - Created new agent control for agent1 on 127.0.0.1:40265
[INFO ] 2023-04-24 14:43:45.475 [grpc-default-executor-0] ExampleControl - Agent agent1 is connected
[INFO ] 2023-04-24 14:43:45.478 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id agent1
[INFO ] 2023-04-24 14:43:49.030 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
'
[INFO ] 2023-04-24 14:43:49.031 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-04-24 14:43:49.031 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-04-24 14:43:54.039 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-04-24 14:43:54.051 [pool-2-thread-1] AgentTestScenario - Subscribe response: connectionId 1 reason codes [] reason string ''
[INFO ] 2023-04-24 14:43:59.057 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic test/topic
[INFO ] 2023-04-24 14:43:59.069 [pool-2-thread-1] AgentTestScenario - Published connectionId 1 reasonCode 0 reasonString 0
[INFO ] 2023-04-24 14:44:04.075 [pool-2-thread-1] AgentControlImpl - UnsubscribeMqtt: unsubscribe on connectionId 1
[INFO ] 2023-04-24 14:44:04.083 [pool-2-thread-1] AgentTestScenario - Unsubscribe response: connectionId 1 reason codes [] reason string ''
[INFO ] 2023-04-24 14:44:19.096 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-04-24 14:44:19.104 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-04-24 14:44:19.118 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId agent1 reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-04-24 14:44:19.121 [grpc-default-executor-0] ExampleControl - Agent agent1 is disconnected

```

Client:
```
[INFO ] 2023-04-24 14:43:44.930 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Making gPRC client connection with 127.0.0.1:47619 as agent1...
[INFO ] 2023-04-24 14:43:45.400 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Client connection with Control is established, local address is 127.0.0.1
[INFO ] 2023-04-24 14:43:45.429 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - GRPCControlServer created and listed on 127.0.0.1:40265
[INFO ] 2023-04-24 14:43:45.481 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Handle gRPC requests
[INFO ] 2023-04-24 14:43:45.481 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - Server awaitTermination
[INFO ] 2023-04-24 14:43:48.559 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId GGMQ-test-device2 broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[INFO ] 2023-04-24 14:43:48.562 [grpc-default-executor-0] Mqtt311ConnectionImpl - Creating AwsIotMqttConnectionBuilder with TLS
[INFO ] 2023-04-24 14:43:48.917 [grpc-default-executor-0] Mqtt311ConnectionImpl - MQTT 3.1.1 connection 1 is establisted
[INFO ] 2023-04-24 14:43:54.047 [grpc-default-executor-0] GRPCControlServer - Subscription: filter test/topic QoS 0 noLocal false retainAsLocal false retainHandling 2
[INFO ] 2023-04-24 14:43:54.047 [grpc-default-executor-0] GRPCControlServer - Subscribe: connectionId 1 subscriptionId null for 1 filters
[INFO ] 2023-04-24 14:43:59.066 [grpc-default-executor-0] GRPCControlServer - Publish: connectionId 1 topic test/topic QoS 1 retain false
[INFO ] 2023-04-24 14:44:04.078 [grpc-default-executor-0] GRPCControlServer - Unsubscribe: connectionId 1 for [test/topic] filters
[INFO ] 2023-04-24 14:44:19.092 [grpc-default-executor-0] GRPCControlServer - closeMqttConnection: connectionId 1 reason 4
[INFO ] 2023-04-24 14:44:19.093 [grpc-default-executor-0] Mqtt311ConnectionImpl - MQTT 3.1.1 connection 1 has been closed
[INFO ] 2023-04-24 14:44:19.093 [Thread-2] Mqtt311ConnectionImpl - MQTT connection 1 interrupted, error code 0
[INFO ] 2023-04-24 14:44:19.101 [grpc-default-executor-0] GRPCControlServer - shutdownAgent: reason That's it.
[INFO ] 2023-04-24 14:44:19.112 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - Server awaitTermination done
[INFO ] 2023-04-24 14:44:19.112 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Shutdown gPRC link
[INFO ] 2023-04-24 14:44:19.125 [com.aws.greengrass.testing.mqtt5.client.Main.main()] Main - Execution done successfully
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
