### PR TITLE
feat(uat): extend steps to be able to use MQTT 3.1.1 protocol 

### DIFF
--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -689,11 +689,11 @@ public class MqttControlSteps {
         mqttVersions.put(MQTT_VERSION_50, MqttProtoVersion.MQTT_PROTOCOL_V50);
     }
 
-    private MqttProtoVersion convertMqttVersion(String mqqtVersion) {
-        MqttProtoVersion version = mqttVersions.get(mqqtVersion);
+    private MqttProtoVersion convertMqttVersion(String mqttVersion) {
+        MqttProtoVersion version = mqttVersions.get(mqttVersion);
 
         if (version == null) {
-            throw new IllegalArgumentException("Unknown MQTT version " + mqqtVersion);
+            throw new IllegalArgumentException("Unknown MQTT version " + mqttVersion);
         }
 
         return version;


### PR DESCRIPTION
**Issue #, if available:**
Extend steps to be able to use MQTT 3.1.1 protocol

**Description of changes:**
- Added ability to select version of MQTT protocol used for MQTT connect 
- Tune javadoc comments

**Why is this change necessary:**
Support of MQTT 3.1.1 was requested

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
