### PR TITLE
feat(uat): added parameters in T1 scenario and reason code for disconnect

### DIFF
--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -25,7 +25,6 @@ import com.aws.greengrass.testing.mqtt.client.control.api.ConnectionControl;
 import com.aws.greengrass.testing.mqtt.client.control.api.EngineControl;
 import com.aws.greengrass.testing.mqtt.client.control.api.addon.Event;
 import com.aws.greengrass.testing.mqtt.client.control.api.addon.EventFilter;
-import com.aws.greengrass.testing.mqtt.client.control.implementation.DisconnectReasonCode;
 import com.aws.greengrass.testing.mqtt.client.control.implementation.addon.EventStorageImpl;
 import com.aws.greengrass.testing.mqtt.client.control.implementation.addon.MqttMessageEvent;
 import com.aws.greengrass.testing.resources.AWSResources;
@@ -295,16 +294,17 @@ public class MqttControlSteps {
      * Disconnect IoT Thing.
      *
      * @param clientDeviceId string user defined client device id
+     * @param reasonCode int disconnect reason code
      */
-    @And("I disconnect device {string}")
-    public void disconnect(String clientDeviceId) {
+    @And("I disconnect device {string} with reason code {int}")
+    public void disconnect(String clientDeviceId, int reasonCode) {
         // getting connectionControl by clientDeviceId
         final String clientDeviceThingName = getClientDeviceThingName(clientDeviceId);
         ConnectionControl connectionControl = getConnectionControl(clientDeviceThingName);
 
         //do disconnect
-        connectionControl.closeMqttConnection(DisconnectReasonCode.NORMAL_DISCONNECTION.getValue());
-        log.info("Thing {} was disconnected", clientDeviceId);
+        connectionControl.closeMqttConnection(reasonCode);
+        log.info("Thing {} was disconnected with reason code {}", clientDeviceId, reasonCode);
     }
 
     /**

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -7,7 +7,7 @@ Feature: GGMQ-1
     Given my device is registered as a Thing
     And my device is running Greengrass
 
-  Scenario: GGMQ-1-T1: As a customer, I can connect, subscribe, publish and receive using client application to MQTT topic
+  Scenario Outline: GGMQ-1-T1-<mqtt-v>: As a customer, I can connect, subscribe, publish and receive using client application to MQTT topic
     When I create a Greengrass deployment with components
       | aws.greengrass.clientdevices.Auth        | LATEST                                                        |
       | aws.greengrass.clientdevices.mqtt.EMQX   | LATEST                                                        |
@@ -57,10 +57,15 @@ Feature: GGMQ-1
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 300 seconds
     And I discover core device broker as "default_broker" from "clientDeviceTest"
-    And I connect device "clientDeviceTest" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker"
+    And I connect device "clientDeviceTest" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker" using mqtt "<mqtt-v>"
     When I subscribe "clientDeviceTest" to "iot_data_0" with qos 0
     When I publish from "clientDeviceTest" to "iot_data_0" with qos 0 and message "Test message"
     And message "Test message" received on "clientDeviceTest" from "iot_data_0" topic within 5 seconds
+
+    Examples:
+      | mqtt-v |
+      | v3     |
+      | v5     |
 
   Scenario: GGMQ-1-T14: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic
     When I create a Greengrass deployment with components


### PR DESCRIPTION
**Issue #, if available:**
T1 was parameterized by version of MQTT protocol: “v5” and “v3”

**Description of changes:**
- added  parameters for scenario GGMQ-1-T1;
- added reason code for disconnect.

**Why is this change necessary:**
- required step for several test features

**How was this change tested:**
```
java -Dggc.archive=./greengrass-nucleus-latest.zip -Dtest.log.path=./logs -Dtags=GGMQ -jar uat/testing-features/target/client-devices-auth-testing-features.jar
```

**Test results:**
```
Given my device is registered as a Thing....................................passed
And my device is running Greengrass.........................................passed
When I create a Greengrass deployment with components.......................passed
And I create client device "clientDeviceTest"...............................passed
When I associate "clientDeviceTest" with ggc................................passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:.passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.client.Mqtt5JavaSdkClient configuration to:.passed
And I deploy the Greengrass deployment configuration........................passed
Then the Greengrass deployment is COMPLETED on the device after 300 seconds.passed
And I discover core device broker as "default_broker" from "clientDeviceTest".passed
And I connect device "clientDeviceTest" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker" using mqtt "v3".passed
When I subscribe "clientDeviceTest" to "iot_data_0" with qos 0..............passed
When I publish from "clientDeviceTest" to "iot_data_0" with qos 0 and message "Test message".passed
And message "Test message" received on "clientDeviceTest" from "iot_data_0" topic within 5 seconds.passed
Given my device is registered as a Thing....................................passed
And my device is running Greengrass.........................................passed
When I create a Greengrass deployment with components.......................passed
And I create client device "clientDeviceTest"...............................passed
When I associate "clientDeviceTest" with ggc................................passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:.passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.client.Mqtt5JavaSdkClient configuration to:.passed
And I deploy the Greengrass deployment configuration........................passed
Then the Greengrass deployment is COMPLETED on the device after 300 seconds.passed
And I discover core device broker as "default_broker" from "clientDeviceTest".passed
And I connect device "clientDeviceTest" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker" using mqtt "v5".passed
When I subscribe "clientDeviceTest" to "iot_data_0" with qos 0..............passed
When I publish from "clientDeviceTest" to "iot_data_0" with qos 0 and message "Test message".passed
And message "Test message" received on "clientDeviceTest" from "iot_data_0" topic within 5 seconds.passed     
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
