### PR TITLE
feat(uat): implement publish in mosquitto client

### DIFF
--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -52,7 +52,7 @@ class GRPCControlServer {
     private static final int TIMEOUT_MIN = 1;
 
     private static final int QOS_MIN = 0;
-    private static final int QOS_MAX = 3;
+    private static final int QOS_MAX = 2;
 
     private static final int PORT_MIN = 1;
     private static final int PORT_MAX = 65_535;
@@ -315,7 +315,7 @@ class GRPCControlServer {
             if (qos < QOS_MIN || qos > QOS_MAX) {
                 logger.atWarn().log("invalid QoS {}, must be in range [{},{}]", qos, QOS_MIN, QOS_MAX);
                 responseObserver.onError(Status.INVALID_ARGUMENT
-                                            .withDescription("invalid QoS, must be in range [0,3]")
+                                            .withDescription("invalid QoS, must be in range [0,2]")
                                             .asRuntimeException());
                 return;
             }
@@ -435,7 +435,7 @@ class GRPCControlServer {
                     logger.atWarn().log("invalid QoS {} at subscription index {}, must be in range [{},{}]",
                                             qos, index, QOS_MIN, QOS_MAX);
                     responseObserver.onError(Status.INVALID_ARGUMENT
-                                                .withDescription("invalid QoS, must be in range [0,3]")
+                                                .withDescription("invalid QoS, must be in range [0,2]")
                                                 .asRuntimeException());
                     return;
                 }

--- a/uat/custom-components/client-mosquitto-c/scripts/build_debug.sh
+++ b/uat/custom-components/client-mosquitto-c/scripts/build_debug.sh
@@ -3,4 +3,4 @@
 rm -rf build && mkdir -p build
 
 CXXFLAGS="-Wall -Wextra -g -O0" cmake -Bbuild -H.
-cmake --build build -j 4 --target all
+cmake --build build -j --target all

--- a/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
@@ -32,7 +32,7 @@
 #define SIBSCRIPTION_ID_MAX             268435455
 
 #define QOS_MIN                         0
-#define QOS_MAX                         3
+#define QOS_MAX                         2
 
 #define RETAIN_HANDLING_MIN             0
 #define RETAIN_HANDLING_MAX             2
@@ -235,7 +235,7 @@ Status GRPCControlServer::PublishMqtt(ServerContext * context, const MqttPublish
     MqttQoS qos = message.qos();
     if (qos < QOS_MIN || qos > QOS_MAX) {
         loge("PublishMqtt: invalid QoS %d, must be in range [%d,%d]\n", (int)qos, QOS_MIN, QOS_MAX);
-        return Status(StatusCode::INVALID_ARGUMENT, "invalid QoS, must be in range [0,3]");
+        return Status(StatusCode::INVALID_ARGUMENT, "invalid QoS, must be in range [0,2]");
     }
 
     const std::string & topic = message.topic();
@@ -326,7 +326,7 @@ Status GRPCControlServer::SubscribeMqtt(ServerContext * context, const MqttSubsc
         const int qos = subscription.qos();
         if (qos < QOS_MIN || qos > QOS_MAX) {
             loge("SubscribeMqtt: invalid QoS %d at subscription index %d, must be in range [{},{}]\n", qos, index, QOS_MIN, QOS_MAX);
-            return Status(StatusCode::INVALID_ARGUMENT, "invalid QoS, must be in range [0,3]");
+            return Status(StatusCode::INVALID_ARGUMENT, "invalid QoS, must be in range [0,2]");
         }
 
         int retain_handling = subscription.retainhandling();

--- a/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
@@ -43,6 +43,8 @@ using grpc::StatusCode;
 using ClientControl::MqttConnectionId;
 using ClientControl::MqttProtoVersion;
 using ClientControl::TLSSettings;
+using ClientControl::Mqtt5Message;
+using ClientControl::MqttQoS;
 
 
 std::string GRPCControlServer::buildAddress(const char * host, unsigned short port) {
@@ -180,6 +182,7 @@ Status GRPCControlServer::CreateMqttConnection(ServerContext * context, const Mq
 
         return Status::OK;
     } catch (MqttException & ex) {
+        loge("CreateMqttConnection: exception during connecting\n");
         return Status(StatusCode::INTERNAL, ex.getMessage());
     }
 }
@@ -205,6 +208,7 @@ Status GRPCControlServer::CloseMqttConnection(ServerContext * context, const Mqt
 
     MqttConnection * connection = m_mqtt->unregisterConnection(connection_id);
     if (!connection) {
+        loge("CloseMqttConnection: connection with id %d doesn't found\n", connection_id);
         return Status(StatusCode::NOT_FOUND, "connection for that id doesn't found");
     }
 
@@ -213,29 +217,75 @@ Status GRPCControlServer::CloseMqttConnection(ServerContext * context, const Mqt
         delete connection;
         return Status::OK;
     } catch (MqttException & ex) {
+        loge("CloseMqttConnection: exception during disconnecting\n");
         return Status(StatusCode::INTERNAL, ex.getMessage());
     }
 }
 
 Status GRPCControlServer::PublishMqtt(ServerContext * context, const MqttPublishRequest * request, MqttPublishReply * reply) {
     (void)context;
-    (void)reply;
+
+
+    if (!request->has_msg()) {
+        loge("PublishMqtt: message is missing\n");
+        return Status(StatusCode::INVALID_ARGUMENT, "message is missing");
+    }
+
+    const Mqtt5Message & message = request->msg();
+    MqttQoS qos = message.qos();
+    if (qos < QOS_MIN || qos > QOS_MAX) {
+        loge("PublishMqtt: invalid QoS %d, must be in range [%d,%d]\n", (int)qos, QOS_MIN, QOS_MAX);
+        return Status(StatusCode::INVALID_ARGUMENT, "invalid QoS, must be in range [0,3]");
+    }
+
+    const std::string & topic = message.topic();
+    if (topic.empty()) {
+        loge("PublishMqtt: topic is empty\n");
+        return Status(StatusCode::INVALID_ARGUMENT, "topic is empty");
+    }
+
+    int timeout = request->timeout();
+    if (timeout < TIMEOUT_MIN) {
+        loge("PublishMqtt: invalid timeout, must be at least %u second\n", TIMEOUT_MIN);
+        return Status(StatusCode::INVALID_ARGUMENT, "invalid publish timeout, must be >= 1");
+    }
 
 
     if (!request->has_connectionid()) {
+        loge("PublishMqtt: missing connection id\n");
         return Status(StatusCode::INVALID_ARGUMENT, "missing connectionId");
     }
 
     const MqttConnectionId & connection_id_obj = request->connectionid();
     int connection_id = connection_id_obj.connectionid();
-    logd("PublishMqtt connection_id %d\n", connection_id);
+
+    bool is_retain = message.retain();
+    logd("PublishMqtt connection_id %d topic %s retain %d\n", connection_id, topic.c_str(), (int)is_retain);
 
     MqttConnection * connection = m_mqtt->getConnection(connection_id);
     if (!connection) {
-        return Status(StatusCode::NOT_FOUND, "connection for that id doesn't found");
+        loge("PublishMqtt: connection with id %d doesn't found\n", connection_id);
+        return Status(StatusCode::NOT_FOUND, "PublishMqtt: connection for that id doesn't found");
     }
 
-    // TODO: implement
+    try {
+        ClientControl::MqttPublishReply * result = connection->publish(timeout, qos, is_retain, topic, message.payload());
+        if (result) {
+            if (result->has_reasoncode()) {
+                reply->set_reasoncode(result->reasoncode());
+            }
+            if (result->has_reasonstring()) {
+                reply->set_reasonstring(result->reasonstring());
+            }
+            // TODO: copy also user properties
+            delete result;
+        }
+        return Status::OK;
+    } catch (MqttException & ex) {
+        loge("PublishMqtt: exception during publishing\n");
+        return Status(StatusCode::INTERNAL, ex.getMessage());
+    }
+
     return Status::OK;
 }
 
@@ -326,6 +376,7 @@ Status GRPCControlServer::SubscribeMqtt(ServerContext * context, const MqttSubsc
 
     MqttConnection * connection = m_mqtt->getConnection(connection_id);
     if (!connection) {
+        loge("SubscribeMqtt: connection with id %d doesn't found\n", connection_id);
         return Status(StatusCode::NOT_FOUND, "connection for that id doesn't found");
     }
 
@@ -337,6 +388,7 @@ Status GRPCControlServer::SubscribeMqtt(ServerContext * context, const MqttSubsc
 
         return Status::OK;
     } catch (MqttException & ex) {
+        loge("SubscribeMqtt: exception during subscribing\n");
         return Status(StatusCode::INTERNAL, ex.getMessage());
     }
 }

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
@@ -216,8 +216,8 @@ class AgentTestScenario implements Runnable {
     private void testPublish(ConnectionControl connectionControl) {
         Mqtt5Message msg = createPublishMessage(PUBLISH_QOS, PUBLISH_RETAIN, PUBLISH_TOPIC, PUBLISH_TEXT.getBytes());
         MqttPublishReply reply = connectionControl.publishMqtt(msg);
-        logger.atInfo().log("Published connectionId {} reasonCode {} reasonString {}",
-                                connectionControl.getConnectionId(), reply.getReasonCode(), reply.getReasonCode());
+        logger.atInfo().log("Published connectionId {} reason code {} reason string '{}'",
+                                connectionControl.getConnectionId(), reply.getReasonCode(), reply.getReasonString());
     }
 
     private Mqtt5Message createPublishMessage(MqttQoS qos, boolean retain, String topic, byte[] data) {

--- a/uat/proto/mqtt_client_control.proto
+++ b/uat/proto/mqtt_client_control.proto
@@ -148,7 +148,6 @@ enum MqttQoS {
     MQTT_QOS_0 = 0;
     MQTT_QOS_1 = 1;
     MQTT_QOS_2 = 2;
-    MQTT_QOS_3 = 3;
 };
 
 // Retain handling values


### PR DESCRIPTION
**Issue #, if available:**
Implement publish in Mosquitto client

**Description of changes:**
- Implement publishing in Mosquitto based CPP client
- Tune logging in control's scenario and in mosquitto client


**Why is this change necessary:**
Mosquitto client should be able to publish MQTT messages.

**How was this change tested:**
Tested manually using IoT Core test MQTT client, when subscribe on '#' filter published message has been appeared as expected. Test run using control application for IoT core broker.

**Test log**
Control:
```
[INFO ] 2023-05-08 20:13:59.128 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] EngineControlImpl - MQTT client control gRPC server started, listening on 47619
[INFO ] 2023-05-08 20:13:59.911 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId agent_mosquitto
[INFO ] 2023-05-08 20:13:59.926 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId agent_mosquitto address 127.0.0.1 port 41989
[INFO ] 2023-05-08 20:13:59.929 [grpc-default-executor-0] EngineControlImpl - Created new agent control for agent_mosquitto on 127.0.0.1:41989
[INFO ] 2023-05-08 20:13:59.975 [grpc-default-executor-0] ExampleControl - Agent agent_mosquitto is connected
[INFO ] 2023-05-08 20:13:59.977 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id agent_mosquitto
[INFO ] 2023-05-08 20:14:03.329 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
reasonCode: 0
receiveMaximum: 100
maximumQoS: 1
retainAvailable: true
maximumPacketSize: 149504
wildcardSubscriptionsAvailable: true
subscriptionIdentifiersAvailable: false
sharedSubscriptionsAvailable: true
serverKeepAlive: 60
'
[INFO ] 2023-05-08 20:14:03.329 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-05-08 20:14:03.330 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-05-08 20:14:08.337 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-05-08 20:14:08.407 [pool-2-thread-1] AgentTestScenario - Subscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-05-08 20:14:13.417 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic test/topic
[INFO ] 2023-05-08 20:14:13.463 [pool-2-thread-1] AgentTestScenario - Published connectionId 1 reason code 0 reason string ''
[INFO ] 2023-05-08 20:14:18.469 [pool-2-thread-1] AgentControlImpl - UnsubscribeMqtt: unsubscribe on connectionId 1
[INFO ] 2023-05-08 20:14:18.478 [pool-2-thread-1] AgentTestScenario - Unsubscribe response: connectionId 1 reason codes [] reason string ''
[INFO ] 2023-05-08 20:14:33.488 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-05-08 20:14:33.498 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-05-08 20:14:33.506 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId agent_mosquitto reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-05-08 20:14:33.510 [grpc-default-executor-0] ExampleControl - Agent agent_mosquitto is disconnected
```

Client:
```
Initialize gRPC library
Making gPRC link with 127.0.0.1:47619 as agent_id 'agent_mosquitto'
Sending RegisterAgent request with agent_id agent_mosquitto
Local address is 127.0.0.1
GRPCControlServer created and listed on 127.0.0.1:41989
Sending DiscoveryAgent request agent_id 'agent_mosquitto' host:port 127.0.0.1:41989
gPRC link established with 127.0.0.1:47619 as agent_id 'agent_mosquitto'
Initialize Mosquitto MQTT library
Mosquitto library version 2.0.15
Handle gRPC requests
CreateMqttConnection client_id 'GGMQ-test-device2' broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
Creating Mosquitto MQTT connection for a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
Establishing Mosquitto MQTT connection to a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883 in 10 seconds
Use provided TLS credentials
on_log level 16: Client GGMQ-test-device2 sending CONNECT
on_log level 16: Client GGMQ-test-device2 received CONNACK (0)
onConnect rc 0 flags 0 props 0x7f4e58010780
Unhandled CONNACK property with id 34
Establishing MQTT connection to a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883 completed with reason code 0
Connection registered with id 1
Subscription: filter test/topic QoS 0 noLocal 0 retainAsPublished 0 retainHandling 2
SubscribeMqtt connection_id 1
on_log level 16: Client GGMQ-test-device2 sending SUBSCRIBE (Mid: 1, Topic: test/topic, QoS: 0, Options: 0x20)
on_log level 16: Client GGMQ-test-device2 received SUBACK
onSubscribe mid 1 qos_count 1 granted_qos 0x7f4e58013dd0 props (nil)
Subscribed on 'test/topic ' filters QoS 0 message id 1
PublishMqtt connection_id 1 topic test/topic retain 0
on_log level 16: Client GGMQ-test-device2 sending PUBLISH (d0, q1, r0, m2, 'test/topic', ... (12 bytes))
on_log level 16: Client GGMQ-test-device2 received PUBACK (Mid: 2, RC:0)
onPublish mid 2 rc 0 props (nil)
Published to 'test/topic' QoS 1  id 2
on_log level 16: Client GGMQ-test-device2 received PUBLISH (d0, q0, r0, m0, 'test/topic', ... (12 bytes))
on_message
UnsubscribeMqtt connection_id 1
CloseMqttConnection connection_id 1 reason 4
Disconnect Mosquitto MQTT connection with reason code 4
on_log level 16: Client GGMQ-test-device2 sending DISCONNECT
onDisconnect rc 0 props (nil)
Destroy Mosquitto MQTT connection
ShutdownAgent with reason 'That's it.'
Shutdown gPRC link
Sending UnregisterAgent request agent_id 'agent_mosquitto' reason 'Agent shutdown by OTF request 'That's it.''
Shutdown MQTT library
Shutdown gRPC library
Execution done
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
