### PR TITLE
feat(uat): implement sending OnReceiveMessage and OnMqttDisconnect in mosquitto client

### DIFF
--- a/uat/custom-components/client-java-sdk/README.md
+++ b/uat/custom-components/client-java-sdk/README.md
@@ -48,6 +48,8 @@ Will message not yet supported.
 ## MQTT v5.0 client
 Currenly information from packets related to QoS2 like PUBREC PUBREL PUBCOMP is missing.
 
+Topic alias maximum is not provided by [ConnAckPacket](https://awslabs.github.io/aws-crt-java/software/amazon/awssdk/crt/mqtt5/packets/ConnAckPacket.html).
+
 ## MQTT v3.1.1 client
 String result code is not available in MQTT 3.1.1, corresponding fields of gRPC messages will not be set.
 

--- a/uat/custom-components/client-mosquitto-c/Dockerfile
+++ b/uat/custom-components/client-mosquitto-c/Dockerfile
@@ -26,7 +26,7 @@ COPY proto          /usr/src/aws-greengrass-client-device-auth/uat/proto
 RUN set -ex; \
     cd /usr/src/aws-greengrass-client-device-auth/uat/custom-components/client-mosquitto-c && \
     CXXFLAGS="-Wall -Wextra -O2" cmake -Bbuild -H. && \
-    cmake --build build -j --target all && \
+    cmake --build build -j `nproc` --target all && \
     cmake --install build --prefix "/usr/local"
 
 # Define the default command

--- a/uat/custom-components/client-mosquitto-c/scripts/build_debug.sh
+++ b/uat/custom-components/client-mosquitto-c/scripts/build_debug.sh
@@ -3,4 +3,4 @@
 rm -rf build && mkdir -p build
 
 CXXFLAGS="-Wall -Wextra -g -O0" cmake -Bbuild -H.
-cmake --build build -j --target all
+cmake --build build -j `nproc` --target all

--- a/uat/custom-components/client-mosquitto-c/scripts/build_prod.sh
+++ b/uat/custom-components/client-mosquitto-c/scripts/build_prod.sh
@@ -3,4 +3,4 @@
 rm -rf build && mkdir -p build
 
 CXXFLAGS="-Wall -Wextra -O2" cmake -Bbuild -H.
-cmake --build build -j 4 --target all
+cmake --build build -j `nproc` --target all

--- a/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
@@ -169,7 +169,7 @@ Status GRPCControlServer::CreateMqttConnection(ServerContext * context, const Mq
     }
 
     try {
-        MqttConnection * connection = m_mqtt->createConnection(client_id, host, port, keepalive, request->cleansession(), ca_char, cert_char, key_char, v5);
+        MqttConnection * connection = m_mqtt->createConnection(m_client, client_id, host, port, keepalive, request->cleansession(), ca_char, cert_char, key_char, v5);
         ClientControl::Mqtt5ConnAck * conn_ack = connection->start(timeout);
         int connection_id = m_mqtt->registerConnection(connection);
 
@@ -311,10 +311,10 @@ Status GRPCControlServer::SubscribeMqtt(ServerContext * context, const MqttSubsc
     }
 
     std::list<std::string> filters;
-    int common_qos;
-    int common_retain_handling;
-    bool common_no_local;
-    bool common_retain_as_published;
+    int common_qos = 0;
+    int common_retain_handling = 0;
+    bool common_no_local = false;
+    bool common_retain_as_published = false;
     int index = 0;
     for (auto const & subscription : request->subscriptions()) {
         const std::string filter = subscription.filter();

--- a/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.h
+++ b/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.h
@@ -14,6 +14,11 @@ using grpc::Server;
 using grpc::ServerContext;
 using grpc::Status;
 
+namespace ClientControl {
+    class Mqtt5ConnAck;
+    class MqttPublishReply;
+}
+
 using ClientControl::Empty;
 using ClientControl::MqttConnectReply;
 using ClientControl::MqttConnectRequest;

--- a/uat/custom-components/client-mosquitto-c/src/GRPCDiscoveryClient.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/GRPCDiscoveryClient.cpp
@@ -13,6 +13,11 @@ using ClientControl::RegisterReply;
 using ClientControl::RegisterRequest;
 using ClientControl::DiscoveryRequest;
 using ClientControl::UnregisterRequest;
+using ClientControl::OnReceiveMessageRequest;
+using ClientControl::MqttConnectionId;
+using ClientControl::OnMqttDisconnectRequest;
+
+
 
 bool GRPCDiscoveryClient::RegisterAgent(std::string & local_ip) {
     RegisterRequest request;
@@ -57,6 +62,47 @@ bool GRPCDiscoveryClient::UnregisterAgent(const std::string & reason) {
 
     logd("Sending UnregisterAgent request agent_id '%s' reason '%s'\n", m_agent_id.c_str(), reason.c_str());
     Status status = m_stub->UnregisterAgent(&context, request, &reply);
+    return checkStatus(status);
+}
+
+bool GRPCDiscoveryClient::onReceiveMqttMessage(int connection_id, Mqtt5Message * message) {
+    OnReceiveMessageRequest request;
+
+    request.set_agentid(m_agent_id);
+    MqttConnectionId * mqtt_connection_id = new MqttConnectionId();
+    mqtt_connection_id->set_connectionid(connection_id);
+    request.set_allocated_connectionid(mqtt_connection_id);
+
+    request.set_allocated_msg(message);
+
+    Empty reply;
+    ClientContext context;
+
+    // TODO: log also details of message
+    logd("Sending OnReceiveMessage request agent_id '%s' connection_id %d\n", m_agent_id.c_str(), connection_id);
+    Status status = m_stub->OnReceiveMessage(&context, request, &reply);
+    return checkStatus(status);
+}
+
+bool GRPCDiscoveryClient::onMqttDisconnect(int connection_id, Mqtt5Disconnect * disconnect, const char * error) {
+    OnMqttDisconnectRequest request;
+
+    request.set_agentid(m_agent_id);
+    MqttConnectionId * mqtt_connection_id = new MqttConnectionId();
+    mqtt_connection_id->set_connectionid(connection_id);
+    request.set_allocated_connectionid(mqtt_connection_id);
+
+    request.set_allocated_disconnect(disconnect);
+    if (error) {
+        request.set_error(error);
+    }
+
+    Empty reply;
+    ClientContext context;
+
+    // TODO: also details of disconnect
+    logd("Sending OnMqttDisconnect request agent_id '%s' connection_id %d error '%s'\n", m_agent_id.c_str(), connection_id, error);
+    Status status = m_stub->OnMqttDisconnect(&context, request, &reply);
     return checkStatus(status);
 }
 

--- a/uat/custom-components/client-mosquitto-c/src/GRPCDiscoveryClient.h
+++ b/uat/custom-components/client-mosquitto-c/src/GRPCDiscoveryClient.h
@@ -14,6 +14,8 @@
 using grpc::Channel;
 using grpc::Status;
 using ClientControl::MqttAgentDiscovery;
+using ClientControl::Mqtt5Message;
+using ClientControl::Mqtt5Disconnect;
 
 class Status;
 
@@ -30,9 +32,27 @@ public:
     bool DiscoveryAgent(const char * address, unsigned short port);
     bool UnregisterAgent(const std::string & reason);
 
+    /**
+     * Sends OnReceiveMqttMessage request to the control.
+     *
+     * @param connection_id the id MQTT connection
+     * @param message the gRPC presentation of MQTT message, that function gets ownership of the pointer
+     * @return true on success
+     */
+    bool onReceiveMqttMessage(int connection_id, Mqtt5Message * message);
+
+    /**
+     * Sends OnMqttDisconnect request to the control.
+     *
+     * @param connection_id the id MQTT connection
+     * @param disconnect the gRPC presentation of DISCONNECT package info, that function gets ownership of the pointer
+     * @param error the optional OS error string
+     * @return true on success
+     */
+    bool onMqttDisconnect(int connection_id, Mqtt5Disconnect * disconnect, const char * error);
+
 private:
     bool checkStatus(const Status & status);
-
 
     std::string m_agent_id;
     std::unique_ptr<MqttAgentDiscovery::Stub> m_stub;

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.cpp
@@ -17,6 +17,7 @@
 #include "mqtt_client_control.grpc.pb.h"
 
 #include "MqttConnection.h"                     /* self header */
+#include "GRPCDiscoveryClient.h"                /* class GRPCDiscoveryClient */
 #include "MqttException.h"
 #include "logger.h"                             /* logd() */
 
@@ -91,10 +92,6 @@ private:
 };
 
 
-static void on_message(struct mosquitto *, void *, const struct mosquitto_message *, const mosquitto_property *) {
-    logd("on_message\n");
-}
-
 static void on_unsubscribe(struct mosquitto *, void *, int, const mosquitto_property *) {
     logd("on_unsubscribe\n");
 }
@@ -103,8 +100,8 @@ static void on_log(struct mosquitto *, void *, int level, const char * str) {
     logd("on_log level %d: %s\n", level, str);
 }
 
-MqttConnection::MqttConnection(const std::string & client_id, const std::string & host, unsigned short port, unsigned short keepalive, bool clean_session, const char * ca, const char * cert, const char * key, bool v5)
-    : m_mutex(), m_client_id(client_id), m_host(host), m_port(port), m_keepalive(keepalive), m_clean_session(clean_session), m_v5(v5), m_mosq(0) {
+MqttConnection::MqttConnection(GRPCDiscoveryClient & grpc_client, const std::string & client_id, const std::string & host, unsigned short port, unsigned short keepalive, bool clean_session, const char * ca, const char * cert, const char * key, bool v5)
+    : m_mutex(), m_grpc_client(grpc_client), m_client_id(client_id), m_host(host), m_port(port), m_keepalive(keepalive), m_clean_session(clean_session), m_v5(v5), m_connection_id(0), m_mosq(0), m_requests() {
 
     logd("Creating Mosquitto MQTT connection for %s:%hu\n", m_host.c_str(), m_port);
 
@@ -270,6 +267,9 @@ void MqttConnection::on_disconnect(struct mosquitto *, void * obj, int rc, const
 void MqttConnection::onDisconnect(int rc, const mosquitto_property * props) {
     logd("onDisconnect rc %d props %p\n", rc, props);
 
+    ClientControl::Mqtt5Disconnect * disconnect = convertToDisconnect(rc, props);
+    m_grpc_client.onMqttDisconnect(m_connection_id, disconnect, NULL);
+
     std::lock_guard<std::mutex> lk(m_mutex);
 
     PendingRequest * request = getValidPendingRequestLocked(DISCONNECT_REQUEST_ID);
@@ -410,6 +410,16 @@ void MqttConnection::onPublish(int mid, int rc, const mosquitto_property * props
 }
 
 
+void MqttConnection::on_message(struct mosquitto *, void * obj, const struct mosquitto_message * message, const mosquitto_property * props) {
+    ((MqttConnection*)obj)->onMessage(message, props);
+}
+
+void MqttConnection::onMessage(const struct mosquitto_message * message, const mosquitto_property * props) {
+    logd("onMessage message %p props %p\n", message, props);
+    ClientControl::Mqtt5Message * msg = convertToMqtt5Message(message, props);
+    m_grpc_client.onReceiveMqttMessage(m_connection_id, msg);
+}
+
 void MqttConnection::destroyLocked() {
     if (m_mosq) {
         mosquitto_destroy(m_mosq);
@@ -511,7 +521,7 @@ void MqttConnection::removePendingRequestLocked(int request_id) {
     }
 }
 
-ClientControl::Mqtt5ConnAck * MqttConnection::convertToConnack(int reason_code, int flags, const mosquitto_property * proplist) {
+ClientControl::Mqtt5ConnAck * MqttConnection::convertToConnack(int reason_code, int flags, const mosquitto_property * props) {
     uint32_t value32;
     uint16_t value16;
     uint8_t value8;
@@ -523,7 +533,7 @@ ClientControl::Mqtt5ConnAck * MqttConnection::convertToConnack(int reason_code, 
 
     conn_ack->set_sessionpresent(flags & 0x1);
 
-    for (const mosquitto_property * prop = proplist; prop != NULL; prop = mosquitto_property_next(prop)) {
+    for (const mosquitto_property * prop = props; prop != NULL; prop = mosquitto_property_next(prop)) {
         int id = mosquitto_property_identifier(prop);
         switch (id) {
             case MQTT_PROP_SESSION_EXPIRY_INTERVAL:
@@ -578,21 +588,26 @@ ClientControl::Mqtt5ConnAck * MqttConnection::convertToConnack(int reason_code, 
                 mosquitto_property_read_string(prop, id, &value_str, false);
                 conn_ack->set_serverreference(value_str);
                 break;
+            case MQTT_PROP_TOPIC_ALIAS_MAXIMUM:
+                mosquitto_property_read_int16(prop, id, &value16, false);
+                conn_ack->set_topicaliasmaximum(value16);
+                break;
             default:
                 logw("Unhandled CONNACK property with id %d\n", id);
                 break;
         }
     }
+
     return conn_ack;
 }
 
-ClientControl::MqttPublishReply * MqttConnection::convertToPublishReply(int reason_code, const mosquitto_property * proplist) {
+ClientControl::MqttPublishReply * MqttConnection::convertToPublishReply(int reason_code, const mosquitto_property * props) {
     char * value_str;
 
     ClientControl::MqttPublishReply * reply = new ClientControl::MqttPublishReply();
     reply->set_reasoncode(reason_code);
 
-    for (const mosquitto_property * prop = proplist; prop != NULL; prop = mosquitto_property_next(prop)) {
+    for (const mosquitto_property * prop = props; prop != NULL; prop = mosquitto_property_next(prop)) {
         int id = mosquitto_property_identifier(prop);
         switch (id) {
             case MQTT_PROP_REASON_STRING:
@@ -606,4 +621,64 @@ ClientControl::MqttPublishReply * MqttConnection::convertToPublishReply(int reas
     }
 
     return reply;
+}
+
+ClientControl::Mqtt5Message * MqttConnection::convertToMqtt5Message(const struct mosquitto_message * message, const mosquitto_property * props) {
+
+    (void)props;
+
+    ClientControl::Mqtt5Message * msg = new ClientControl::Mqtt5Message();
+
+    if (message) {
+        if (message->topic) {
+            msg->set_topic(message->topic);
+        }
+
+        if (message->payload && message->payloadlen > 0) {
+            std::string payload_copy(std::string(static_cast<const char*>(message->payload), message->payloadlen));
+            msg->set_payload(payload_copy);
+        }
+
+        if (ClientControl::MqttQoS_IsValid(message->qos)) {
+            msg->set_qos(static_cast<ClientControl::MqttQoS>(message->qos));
+        }
+        msg->set_retain(message->retain);
+    }
+
+    // TODO: handle also props to find and copy user properties
+
+    return msg;
+}
+
+ClientControl::Mqtt5Disconnect * MqttConnection::convertToDisconnect(int reason_code, const mosquitto_property * props) {
+    uint32_t value32;
+    char * value_str;
+
+    ClientControl::Mqtt5Disconnect * disconnect = new ClientControl::Mqtt5Disconnect();
+
+    disconnect->set_reasoncode(reason_code);
+
+    for (const mosquitto_property * prop = props; prop != NULL; prop = mosquitto_property_next(prop)) {
+        int id = mosquitto_property_identifier(prop);
+        switch (id) {
+            case MQTT_PROP_SESSION_EXPIRY_INTERVAL:
+                mosquitto_property_read_int32(prop, id, &value32, false);
+                disconnect->set_sessionexpiryinterval(value32);
+                break;
+            case MQTT_PROP_REASON_STRING:
+                mosquitto_property_read_string(prop, id, &value_str, false);
+                disconnect->set_reasonstring(value_str);
+                break;
+            case MQTT_PROP_SERVER_REFERENCE:
+                mosquitto_property_read_string(prop, id, &value_str, false);
+                disconnect->set_serverreference(value_str);
+                break;
+            // TODO: handle also user properties
+            default:
+                logw("Unhandled DISCONNECT property with id %d\n", id);
+                break;
+        }
+    }
+
+    return disconnect;
 }

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
@@ -13,9 +13,12 @@
 
 namespace ClientControl {
     class Mqtt5ConnAck;
+    class Mqtt5Disconnect;
+    class Mqtt5Message;
     class MqttPublishReply;
 }
 class PendingRequest;
+class GRPCDiscoveryClient;
 
 extern "C" struct mosquitto;
 extern "C" typedef struct mqtt5__property mosquitto_property;
@@ -31,6 +34,7 @@ public:
     /**
      * Creates a MQTT connection.
      *
+     * @param grpc_client the reference to gRPC client
      * @param client_id MQTT client id
      * @param host hostname of IP address of MQTT broker
      * @param port port of MQTT broker
@@ -42,8 +46,13 @@ public:
      * @param v5 use MQTT v5.0
      * @throw MqttException on errors
      */
-    MqttConnection(const std::string & client_id, const std::string & host, unsigned short port, unsigned short keepalive, bool clean_session, const char * ca, const char * cert, const char * key, bool v5);
+    MqttConnection(GRPCDiscoveryClient & grpc_client, const std::string & client_id, const std::string & host, unsigned short port, unsigned short keepalive, bool clean_session, const char * ca, const char * cert, const char * key, bool v5);
     ~MqttConnection();
+
+
+    void setConnectionId(int connection_id) {
+        m_connection_id = connection_id;
+    }
 
     /**
      * Starts a MQTT connection.
@@ -104,6 +113,8 @@ private:
 
     static void on_disconnect(struct mosquitto *, void * obj, int rc, const mosquitto_property * props);
     void onDisconnect(int rc, const mosquitto_property * props);
+    ClientControl::Mqtt5Disconnect * convertToDisconnect(int reason_code, const mosquitto_property * props);
+
 
     static void on_subscribe(struct mosquitto *, void * obj, int mid, int qos_count, const int * granted_qos, const mosquitto_property *props);
     void onSubscribe(int mid, int qos_count, const int * granted_qos, const mosquitto_property *props);
@@ -111,6 +122,10 @@ private:
     static void on_publish(struct mosquitto *, void * obj, int mid, int rc, const mosquitto_property * props);
     void onPublish(int mid, int rc, const mosquitto_property * props);
     ClientControl::MqttPublishReply * convertToPublishReply(int reason_code, const mosquitto_property * proplist);
+
+    static void on_message(struct mosquitto *, void * obj, const struct mosquitto_message * message, const mosquitto_property * props);
+    void onMessage(const struct mosquitto_message * message, const mosquitto_property * props);
+    ClientControl::Mqtt5Message * convertToMqtt5Message(const struct mosquitto_message * message, const mosquitto_property * props);
 
 
     static void removeFile(std::string & file);
@@ -122,12 +137,14 @@ private:
 
 
     std::mutex m_mutex;
+    GRPCDiscoveryClient & m_grpc_client;
     std::string m_client_id;
     std::string m_host;
     unsigned short m_port;
     unsigned short m_keepalive;
     bool m_clean_session;
     bool m_v5;
+    int m_connection_id;
 
     std::string m_ca;
     std::string m_cert;

--- a/uat/custom-components/client-mosquitto-c/src/MqttLib.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/MqttLib.cpp
@@ -30,8 +30,8 @@ MqttLib::~MqttLib() {
     logd("Shutdown MQTT library\n");
 }
 
-MqttConnection * MqttLib::createConnection(const std::string & client_id, const std::string & host, unsigned short port, unsigned short keepalive, bool clean_session, const char * ca, const char * cert, const char * key, bool v5) {
-    return new MqttConnection(client_id, host, port, keepalive, clean_session, ca, cert, key, v5);
+MqttConnection * MqttLib::createConnection(GRPCDiscoveryClient & grpc_client, const std::string & client_id, const std::string & host, unsigned short port, unsigned short keepalive, bool clean_session, const char * ca, const char * cert, const char * key, bool v5) {
+    return new MqttConnection(grpc_client, client_id, host, port, keepalive, clean_session, ca, cert, key, v5);
 }
 
 
@@ -45,6 +45,7 @@ int MqttLib::registerConnection(MqttConnection * connection) {
         if (it == m_connections.end()) {
             m_connections.insert(std::make_pair(connection_id, connection));
             logd("Connection registered with id %d\n", connection_id);
+            connection->setConnectionId(connection_id);
             return connection_id;
         } else {
             // test next connection_id;

--- a/uat/custom-components/client-mosquitto-c/src/MqttLib.h
+++ b/uat/custom-components/client-mosquitto-c/src/MqttLib.h
@@ -11,6 +11,7 @@
 #include <unordered_map>
 
 class MqttConnection;
+class GRPCDiscoveryClient;
 
 /**
  * MQTT library class.
@@ -21,7 +22,9 @@ public:
     ~MqttLib();
 
     /**
-     * Create a MQTT connection.
+     * Creates a MQTT connection.
+     *
+     * @param grpc_client the reference to gRPC client
      * @param client_id MQTT client id
      * @param host hostname of IP address of MQTT broker
      * @param port port of MQTT broker
@@ -34,7 +37,7 @@ public:
      * @return MqttConnection on success
      * @throw MqttException on errors
      */
-    MqttConnection * createConnection(const std::string & client_id, const std::string & host, unsigned short port, unsigned short keepalive, bool clean_session, const char * ca, const char * cert, const char * key, bool v5);
+    MqttConnection * createConnection(GRPCDiscoveryClient & grpc_client, const std::string & client_id, const std::string & host, unsigned short port, unsigned short keepalive, bool clean_session, const char * ca, const char * cert, const char * key, bool v5);
 
 
     int registerConnection(MqttConnection * connection);

--- a/uat/custom-components/client-mosquitto-c/src/logger.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/logger.cpp
@@ -10,23 +10,26 @@
 void logd(const char *fmt, ...) {
     va_list args;
 
+    fprintf(stdout, "[DEBUG]: ");
     va_start(args, fmt);
-    vfprintf(stderr, fmt, args);
+    vfprintf(stdout, fmt, args);
     va_end(args);
 }
 
 void logw(const char *fmt, ...) {
     va_list args;
 
+    fprintf(stdout, "[WARN]: ");
     va_start(args, fmt);
-    vfprintf(stderr, fmt, args);
+    vfprintf(stdout, fmt, args);
     va_end(args);
 }
 
 void loge(const char *fmt, ...) {
     va_list args;
 
+    fprintf(stdout, "[ERROR]: ");
     va_start(args, fmt);
-    vfprintf(stdout, fmt, args);
+    vfprintf(stderr, fmt, args);
     va_end(args);
 }

--- a/uat/proto/mqtt_client_control.proto
+++ b/uat/proto/mqtt_client_control.proto
@@ -174,8 +174,8 @@ message Mqtt5ConnAck {
     optional int32 serverKeepAlive = 13;
     optional string responseInformation = 14;
     optional string serverReference = 15;
+    optional int32 topicAliasMaximum = 16;
 
-    // TODO: int32 topicAliasMaximum;
     // TODO: Authentication Method
     // TODO: Authentication Data
     // TODO: user's Properties


### PR DESCRIPTION

**Issue #, if available:**
Implement receive events and forward to control in Mosquitto client

**Description of changes:**
TODO

**Why is this change necessary:**
Mosquitto-based client should be able to forward receive messages and disconnect events to the Control 

**How was this change tested:**
At the moment manually by using a control as standalone program with hard-coded scenario inside.

**Test results:**
Control:
```
[INFO ] 2023-05-09 19:05:42.285 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId agent_mosquitto
[INFO ] 2023-05-09 19:05:42.300 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId agent_mosquitto address 127.0.0.1 port 40603
[INFO ] 2023-05-09 19:05:42.303 [grpc-default-executor-0] EngineControlImpl - Created new agent control for agent_mosquitto on 127.0.0.1:40603
[INFO ] 2023-05-09 19:05:42.349 [grpc-default-executor-0] ExampleControl - Agent agent_mosquitto is connected
[INFO ] 2023-05-09 19:05:42.351 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id agent_mosquitto
[INFO ] 2023-05-09 19:05:45.753 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
reasonCode: 0
receiveMaximum: 100
maximumQoS: 1
retainAvailable: true
maximumPacketSize: 149504
wildcardSubscriptionsAvailable: true
subscriptionIdentifiersAvailable: false
sharedSubscriptionsAvailable: true
serverKeepAlive: 60
topicAliasMaximum: 8
'
[INFO ] 2023-05-09 19:05:45.753 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-05-09 19:05:45.753 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-05-09 19:05:50.767 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-05-09 19:05:50.851 [pool-2-thread-1] AgentTestScenario - Subscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-05-09 19:05:55.866 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic test/topic
[INFO ] 2023-05-09 19:05:55.910 [pool-2-thread-1] AgentTestScenario - Published connectionId 1 reason code 0 reason string ''
[INFO ] 2023-05-09 19:05:55.915 [grpc-default-executor-0] GRPCDiscoveryServer - OnReceiveMessage: agentId agent_mosquitto connectionId 1 topic test/topic QoS 0
[INFO ] 2023-05-09 19:05:55.921 [grpc-default-executor-0] AgentTestScenario - Message received on agentId agent_mosquitto connectionId 1 topic test/topic QoS 0 content <ByteString@2eb1de82 size=12 contents="Hello World!">
[INFO ] 2023-05-09 19:06:00.920 [pool-2-thread-1] AgentControlImpl - UnsubscribeMqtt: unsubscribe on connectionId 1
[INFO ] 2023-05-09 19:06:00.928 [pool-2-thread-1] AgentTestScenario - Unsubscribe response: connectionId 1 reason codes [] reason string ''
[INFO ] 2023-05-09 19:06:15.964 [grpc-default-executor-0] GRPCDiscoveryServer - OnMqttDisconnect: agentId agent_mosquitto connectionId 1 disconnect 'reasonCode: 0
' error ''
[INFO ] 2023-05-09 19:06:15.965 [grpc-default-executor-0] AgentTestScenario - MQTT disconnected on agentId agent_mosquitto connectionId 1 disconnect 'reasonCode: 0
' error ''
[INFO ] 2023-05-09 19:06:15.975 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-05-09 19:06:15.998 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-05-09 19:06:16.020 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId agent_mosquitto reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-05-09 19:06:16.034 [grpc-default-executor-0] ExampleControl - Agent agent_mosquitto is disconnected
```
Client:
```
[DEBUG]: Initialize gRPC library
[DEBUG]: Making gPRC link with 127.0.0.1:47619 as agent_id 'agent_mosquitto'
[DEBUG]: Sending RegisterAgent request with agent_id agent_mosquitto
[DEBUG]: Local address is 127.0.0.1
[DEBUG]: GRPCControlServer created and listed on 127.0.0.1:40603
[DEBUG]: Sending DiscoveryAgent request agent_id 'agent_mosquitto' host:port 127.0.0.1:40603
[DEBUG]: gPRC link established with 127.0.0.1:47619 as agent_id 'agent_mosquitto'
[DEBUG]: Initialize Mosquitto MQTT library
[DEBUG]: Mosquitto library version 2.0.15
[DEBUG]: Handle gRPC requests
[DEBUG]: CreateMqttConnection client_id 'GGMQ-test-device2' broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[DEBUG]: Creating Mosquitto MQTT connection for a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[DEBUG]: Establishing Mosquitto MQTT connection to a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883 in 10 seconds
[DEBUG]: Use provided TLS credentials
[DEBUG]: on_log level 16: Client GGMQ-test-device2 sending CONNECT
[DEBUG]: on_log level 16: Client GGMQ-test-device2 received CONNACK (0)
[DEBUG]: onConnect rc 0 flags 0 props 0x7f2548010780
[DEBUG]: Establishing MQTT connection to a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883 completed with reason code 0
[DEBUG]: Connection registered with id 1
[DEBUG]: Subscription: filter test/topic QoS 0 noLocal 0 retainAsPublished 0 retainHandling 2
[DEBUG]: SubscribeMqtt connection_id 1
[DEBUG]: on_log level 16: Client GGMQ-test-device2 sending SUBSCRIBE (Mid: 1, Topic: test/topic, QoS: 0, Options: 0x20)
[DEBUG]: on_log level 16: Client GGMQ-test-device2 received SUBACK
[DEBUG]: onSubscribe mid 1 qos_count 1 granted_qos 0x7f2548013dd0 props (nil)
[DEBUG]: Subscribed on 'test/topic ' filters QoS 0 message id 1
[DEBUG]: PublishMqtt connection_id 1 topic test/topic retain 0
[DEBUG]: on_log level 16: Client GGMQ-test-device2 sending PUBLISH (d0, q1, r0, m2, 'test/topic', ... (12 bytes))
[DEBUG]: on_log level 16: Client GGMQ-test-device2 received PUBACK (Mid: 2, RC:0)
[DEBUG]: onPublish mid 2 rc 0 props (nil)
[DEBUG]: Published to 'test/topic' QoS 1  id 2
[DEBUG]: on_log level 16: Client GGMQ-test-device2 received PUBLISH (d0, q0, r0, m0, 'test/topic', ... (12 bytes))
[DEBUG]: onMessage message 0x7f2548015908 props (nil)
[DEBUG]: Sending OnReceiveMessage request agent_id 'agent_mosquitto' connection_id 1
[DEBUG]: UnsubscribeMqtt connection_id 1
[DEBUG]: CloseMqttConnection connection_id 1 reason 4
[DEBUG]: Disconnect Mosquitto MQTT connection with reason code 4
[DEBUG]: on_log level 16: Client GGMQ-test-device2 sending DISCONNECT
[DEBUG]: onDisconnect rc 0 props (nil)
[DEBUG]: Sending OnMqttDisconnect request agent_id 'agent_mosquitto' connection_id 1 error '(null)'
[DEBUG]: Destroy Mosquitto MQTT connection
[DEBUG]: ShutdownAgent with reason 'That's it.'
[DEBUG]: Shutdown gPRC link
[DEBUG]: Sending UnregisterAgent request agent_id 'agent_mosquitto' reason 'Agent shutdown by OTF request 'That's it.''
[DEBUG]: Shutdown MQTT library
[DEBUG]: Shutdown gRPC library
[DEBUG]: Execution done
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
