### PR TITLE
feat(uat): implement unsubscription in mosquitto-based client

### DIFF
--- a/uat/custom-components/client-mosquitto-c/README.md
+++ b/uat/custom-components/client-mosquitto-c/README.md
@@ -49,3 +49,6 @@ It violates MQTT v5.0 where topic filters have separate QoS and other properties
 At same time usage mosquitto_subscribe_v5() in a loop can can break logic of subscription id.
 In result we check all values of QoS and properties in gRPC SubscribeMqtt request and if are not the same report an error in that client.
 
+
+3. Unsubscription
+In Mosquitto API call mosquitto_unsubscribe_v5_callback_set() callback does not provides result codes, instead repeated zero code will be returned on success.

--- a/uat/custom-components/client-mosquitto-c/scripts/build_docker.sh
+++ b/uat/custom-components/client-mosquitto-c/scripts/build_docker.sh
@@ -1,9 +1,7 @@
 #!/bin/sh
 
-cp -a ../../proto proto
+rm -rf proto && cp -a ../../proto proto
 
 docker build -f Dockerfile -t client-mosquitto-c .
 
-# docker run -it --rm --name=client-mosquitto-c --mount type=bind,source=${PWD},target=/src client-mosquitto-c bash
 docker run -it --rm --name=client-mosquitto-c client-mosquitto-c bash
-

--- a/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
@@ -81,10 +81,7 @@ void GRPCControlServer::wait(MqttLib & mqtt) {
     separate_thread.join();
 }
 
-Status GRPCControlServer::ShutdownAgent(ServerContext * context, const ShutdownRequest * request, Empty * reply) {
-    (void)context;
-    (void)reply;
-
+Status GRPCControlServer::ShutdownAgent(ServerContext *, const ShutdownRequest * request, Empty *) {
     m_shutdown_reason = request->reason();
     logd("ShutdownAgent with reason '%s'\n", m_shutdown_reason.c_str());
 
@@ -92,9 +89,7 @@ Status GRPCControlServer::ShutdownAgent(ServerContext * context, const ShutdownR
     return Status::OK;
 }
 
-Status GRPCControlServer::CreateMqttConnection(ServerContext * context, const MqttConnectRequest * request, MqttConnectReply * reply) {
-    (void)context;
-
+Status GRPCControlServer::CreateMqttConnection(ServerContext *, const MqttConnectRequest * request, MqttConnectReply * reply) {
     const std::string & client_id = request->clientid();
     const std::string & host = request->host();
     int port = request->port();
@@ -187,10 +182,7 @@ Status GRPCControlServer::CreateMqttConnection(ServerContext * context, const Mq
     }
 }
 
-Status GRPCControlServer::CloseMqttConnection(ServerContext * context, const MqttCloseRequest * request, Empty * reply) {
-    (void)context;
-    (void)reply;
-
+Status GRPCControlServer::CloseMqttConnection(ServerContext *, const MqttCloseRequest * request, Empty *) {
     int timeout = request->timeout();
     if (timeout < TIMEOUT_MIN) {
         loge("CloseMqttConnection: invalid timeout, must be at least %u second\n", TIMEOUT_MIN);
@@ -222,10 +214,7 @@ Status GRPCControlServer::CloseMqttConnection(ServerContext * context, const Mqt
     }
 }
 
-Status GRPCControlServer::PublishMqtt(ServerContext * context, const MqttPublishRequest * request, MqttPublishReply * reply) {
-    (void)context;
-
-
+Status GRPCControlServer::PublishMqtt(ServerContext *, const MqttPublishRequest * request, MqttPublishReply * reply) {
     if (!request->has_msg()) {
         loge("PublishMqtt: message is missing\n");
         return Status(StatusCode::INVALID_ARGUMENT, "message is missing");
@@ -289,10 +278,7 @@ Status GRPCControlServer::PublishMqtt(ServerContext * context, const MqttPublish
     return Status::OK;
 }
 
-Status GRPCControlServer::SubscribeMqtt(ServerContext * context, const MqttSubscribeRequest * request, MqttSubscribeReply * reply) {
-    (void)context;
-    (void)reply;
-
+Status GRPCControlServer::SubscribeMqtt(ServerContext *, const MqttSubscribeRequest * request, MqttSubscribeReply * reply) {
     int timeout = request->timeout();
     if (timeout < TIMEOUT_MIN) {
         loge("SubscribeMqtt: invalid timeout, must be at least %u second\n", TIMEOUT_MIN);
@@ -393,13 +379,24 @@ Status GRPCControlServer::SubscribeMqtt(ServerContext * context, const MqttSubsc
     }
 }
 
-Status GRPCControlServer::UnsubscribeMqtt(ServerContext * context, const MqttUnsubscribeRequest * request, MqttSubscribeReply * reply) {
-    (void)context;
-    (void)reply;
+Status GRPCControlServer::UnsubscribeMqtt(ServerContext *, const MqttUnsubscribeRequest * request, MqttSubscribeReply * reply) {
+    int timeout = request->timeout();
+    if (timeout < TIMEOUT_MIN) {
+        loge("UnsubscribeMqtt: invalid timeout, must be at least %u second\n", TIMEOUT_MIN);
+        return Status(StatusCode::INVALID_ARGUMENT, "invalid timeout, must be at least 1");
+    }
 
     if (!request->has_connectionid()) {
+        loge("UnsubscribeMqtt: missing connection id\n");
         return Status(StatusCode::INVALID_ARGUMENT, "missing connectionId");
     }
+
+    if (request->filters_size() < 1) {
+        loge("UnsubscribeMqtt: empty filters list\n");
+        return Status(StatusCode::INVALID_ARGUMENT, "empty filters list");
+    }
+
+    // convert filters
 
     const MqttConnectionId & connection_id_obj = request->connectionid();
     int connection_id = connection_id_obj.connectionid();
@@ -407,10 +404,21 @@ Status GRPCControlServer::UnsubscribeMqtt(ServerContext * context, const MqttUns
 
     MqttConnection * connection = m_mqtt->getConnection(connection_id);
     if (!connection) {
+        loge("UnsubscribeMqtt: connection with id %d doesn't found\n", connection_id);
         return Status(StatusCode::NOT_FOUND, "connection for that id doesn't found");
     }
-    // TODO: implement
-    return Status::OK;
+
+    std::list<std::string> filters(request->filters().begin(), request->filters().end());
+    try {
+        std::vector<int> reason_codes = connection->unsubscribe(timeout, filters);
+        for (int reason_code : reason_codes) {
+            reply->add_reasoncodes(reason_code);
+        }
+        return Status::OK;
+    } catch (MqttException & ex) {
+        loge("UnsubscribeMqtt: exception during unsubscribing\n");
+        return Status(StatusCode::INTERNAL, ex.getMessage());
+    }
 }
 
 

--- a/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
@@ -296,7 +296,7 @@ Status GRPCControlServer::SubscribeMqtt(ServerContext *, const MqttSubscribeRequ
         subscription_id_ptr = &subscription_id;
     }
 
-    std::list<std::string> filters;
+    std::vector<std::string> filters;
     int common_qos = 0;
     int common_retain_handling = 0;
     bool common_no_local = false;
@@ -408,7 +408,7 @@ Status GRPCControlServer::UnsubscribeMqtt(ServerContext *, const MqttUnsubscribe
         return Status(StatusCode::NOT_FOUND, "connection for that id doesn't found");
     }
 
-    std::list<std::string> filters(request->filters().begin(), request->filters().end());
+    std::vector<std::string> filters(request->filters().begin(), request->filters().end());
     try {
         std::vector<int> reason_codes = connection->unsubscribe(timeout, filters);
         for (int reason_code : reason_codes) {

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.cpp
@@ -32,16 +32,24 @@ public:
     int rc;                                     // all
     int flags;                                  // connect
     mosquitto_property * props;                 // all
-    int mid;                                    // subscribe
+    int mid;                                    // subscribe / publish / unsubscribe
     std::vector<int> granted_qos;               // subscribe
 
+    // connect / disconnect
     AsyncResult(int rc_, int flags_, const mosquitto_property * props_)
         : rc(rc_), flags(flags_), props(NULL), mid(0) {
         mosquitto_property_copy_all(&props, props_);
     }
 
-    AsyncResult(int rc_, int mid_, int qos_count_, const int * granted_qos_, const mosquitto_property * props_)
-        : rc(rc_), flags(0), props(0), mid(mid_), granted_qos(granted_qos_, granted_qos_ + qos_count_) {
+    // publish / unsubscribe
+    AsyncResult(int mid_, const mosquitto_property * props_)
+        : rc(MOSQ_ERR_SUCCESS), flags(0), props(0), mid(mid_) {
+        mosquitto_property_copy_all(&props, props_);
+    }
+
+    // subscribe
+    AsyncResult(int mid_, int qos_count_, const int * granted_qos_, const mosquitto_property * props_)
+        : rc(MOSQ_ERR_SUCCESS), flags(0), props(0), mid(mid_), granted_qos(granted_qos_, granted_qos_ + qos_count_) {
         mosquitto_property_copy_all(&props, props_);
     }
     AsyncResult(const AsyncResult &) = delete;
@@ -91,10 +99,6 @@ private:
     bool m_valid;
 };
 
-
-static void on_unsubscribe(struct mosquitto *, void *, int, const mosquitto_property *) {
-    logd("on_unsubscribe\n");
-}
 
 MqttConnection::MqttConnection(GRPCDiscoveryClient & grpc_client, const std::string & client_id, const std::string & host, unsigned short port, unsigned short keepalive, bool clean_session, const char * ca, const char * cert, const char * key, bool v5)
     : m_mutex(), m_grpc_client(grpc_client), m_client_id(client_id), m_host(host), m_port(port), m_keepalive(keepalive), m_clean_session(clean_session), m_v5(v5), m_connection_id(0), m_mosq(0), m_requests() {
@@ -280,15 +284,15 @@ std::vector<int> MqttConnection::subscribe(unsigned timeout, const int * subscri
     PendingRequest * request = 0;
     mosquitto_property * properties = NULL;
     int message_id = 0;
+    std::unique_ptr<char*> filters_array(new char*[filters.size()]);
+
     {
         std::lock_guard<std::mutex> lk(m_mutex);
         stateCheck();
 
-        const int count = filters.size();
-        char ** array = new char*[count];
         int i = 0;
         for (auto it = filters.begin(); it != filters.end(); ++it, i++) {
-            array[i] = const_cast<char*>(it->c_str());
+            filters_array.get()[i] = const_cast<char*>(it->c_str());
         }
 
         int options = 0;
@@ -318,7 +322,7 @@ std::vector<int> MqttConnection::subscribe(unsigned timeout, const int * subscri
         }
 
         // TODO: pass also user properties
-        rc = mosquitto_subscribe_multiple(m_mosq, &message_id, count, array, qos, options, properties);
+        rc = mosquitto_subscribe_multiple(m_mosq, &message_id, i, filters_array.get(), qos, options, properties);
         if (rc != MOSQ_ERR_SUCCESS) {
             loge("mosquitto_subscribe_multiple failed with code %d: %s\n", rc, mosquitto_strerror(rc));
             mosquitto_property_free_all(&properties);
@@ -339,9 +343,11 @@ std::vector<int> MqttConnection::subscribe(unsigned timeout, const int * subscri
         throw MqttException("couldn't subscribe", rc);
     }
 
-    std::ostringstream imploded;
-    std::copy(filters.begin(), filters.end(), std::ostream_iterator<std::string>(imploded, " "));
-    logd("Subscribed on '%s' filters QoS %d message id %d\n", imploded.str().c_str(), qos, message_id);
+    {
+        std::ostringstream imploded;
+        std::copy(filters.begin(), filters.end(), std::ostream_iterator<std::string>(imploded, " "));
+        logd("Subscribed on '%s' filters QoS %d message id %d\n", imploded.str().c_str(), qos, message_id);
+    }
 
     mosquitto_property_free_all(&properties);
 
@@ -359,7 +365,68 @@ void MqttConnection::onSubscribe(int mid, int qos_count, const int * granted_qos
 
     PendingRequest * request = getValidPendingRequestLocked(mid);
     if (request) {
-        std::shared_ptr<AsyncResult> result(new AsyncResult(MOSQ_ERR_SUCCESS, mid, qos_count, granted_qos, props));
+        std::shared_ptr<AsyncResult> result(new AsyncResult(mid, qos_count, granted_qos, props));
+        request->submitResult(result);
+    }
+}
+
+
+std::vector<int> MqttConnection::unsubscribe(unsigned timeout, const std::list<std::string> & filters) {
+    PendingRequest * request = 0;
+    int message_id = 0;
+    std::unique_ptr<char*> filters_array(new char*[filters.size()]);
+
+    {
+        std::lock_guard<std::mutex> lk(m_mutex);
+        stateCheck();
+
+        int i = 0;
+        for (auto it = filters.begin(); it != filters.end(); ++it, i++) {
+            filters_array.get()[i] = const_cast<char*>(it->c_str());
+        }
+
+        // TODO: pass also user properties
+        int rc = mosquitto_unsubscribe_multiple(m_mosq, &message_id, i, filters_array.get(), NULL);
+        if (rc != MOSQ_ERR_SUCCESS) {
+            loge("mosquitto_unsubscribe_multiple failed with code %d: %s\n", rc, mosquitto_strerror(rc));
+            throw MqttException("couldn't unsubscribe", rc);
+        }
+
+        request = createPendingRequestLocked(message_id);
+    }
+
+    std::shared_ptr<AsyncResult> result = request->waitForResult(timeout);
+    removePendingRequestUnlocked(message_id);
+
+    int rc = result->rc;
+    if (rc != MOSQ_ERR_SUCCESS) {
+        loge("unsubscribe callback failed with code %d: %s\n", rc, mosquitto_strerror(rc));
+        destroyUnlocked();
+        throw MqttException("couldn't unsubscribe", rc);
+    }
+
+    {
+        std::ostringstream imploded;
+        std::copy(filters.begin(), filters.end(), std::ostream_iterator<std::string>(imploded, " "));
+        logd("Unsubscribed from '%s' filters message id %d\n", imploded.str().c_str(), message_id);
+    }
+
+    // NOTE: mosquitto does not provides result code(s) from unsubscribe; produce vector of successes
+    return std::vector<int> (filters.size(), 0);
+}
+
+void MqttConnection::on_unsubscribe(struct mosquitto *, void * obj, int mid, const mosquitto_property * props) {
+    ((MqttConnection*)obj)->onUnsubscribe(mid, props);
+}
+
+void MqttConnection::onUnsubscribe(int mid, const mosquitto_property * props) {
+    logd("onUnsubscribe mid %d props %p\n", mid, props);
+
+    std::lock_guard<std::mutex> lk(m_mutex);
+
+    PendingRequest * request = getValidPendingRequestLocked(mid);
+    if (request) {
+        std::shared_ptr<AsyncResult> result(new AsyncResult(mid, props));
         request->submitResult(result);
     }
 }
@@ -400,11 +467,10 @@ void MqttConnection::onPublish(int mid, int rc, const mosquitto_property * props
 
     PendingRequest * request = getValidPendingRequestLocked(mid);
     if (request) {
-        std::shared_ptr<AsyncResult> result(new AsyncResult(rc, 0, props));
+        std::shared_ptr<AsyncResult> result(new AsyncResult(mid, props));
         request->submitResult(result);
     }
 }
-
 
 void MqttConnection::on_message(struct mosquitto *, void * obj, const struct mosquitto_message * message, const mosquitto_property * props) {
     ((MqttConnection*)obj)->onMessage(message, props);

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.cpp
@@ -279,7 +279,7 @@ void MqttConnection::onDisconnect(int rc, const mosquitto_property * props) {
     }
 }
 
-std::vector<int> MqttConnection::subscribe(unsigned timeout, const int * subscription_id, const std::list<std::string> & filters, int qos, int retain_handling, bool no_local, bool retain_as_published) {
+std::vector<int> MqttConnection::subscribe(unsigned timeout, const int * subscription_id, const std::vector<std::string> & filters, int qos, int retain_handling, bool no_local, bool retain_as_published) {
 
     PendingRequest * request = 0;
     mosquitto_property * properties = NULL;
@@ -371,7 +371,7 @@ void MqttConnection::onSubscribe(int mid, int qos_count, const int * granted_qos
 }
 
 
-std::vector<int> MqttConnection::unsubscribe(unsigned timeout, const std::list<std::string> & filters) {
+std::vector<int> MqttConnection::unsubscribe(unsigned timeout, const std::vector<std::string> & filters) {
     PendingRequest * request = 0;
     int message_id = 0;
     std::unique_ptr<char*> filters_array(new char*[filters.size()]);

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
@@ -6,7 +6,6 @@
 #ifndef MOSQUITTO_TEST_CLIENT_MQTTCONNECTION_H
 #define MOSQUITTO_TEST_CLIENT_MQTTCONNECTION_H
 
-#include <list>
 #include <vector>
 #include <unordered_map>
 #include <mutex>
@@ -76,7 +75,7 @@ public:
      * @return the vector of reason codes for each filter
      * @throw MqttException on errors
      */
-    std::vector<int> subscribe(unsigned timeout, const int * subscription_id, const std::list<std::string> & filters, int qos, int retain_handling, bool no_local, bool retain_as_published);
+    std::vector<int> subscribe(unsigned timeout, const int * subscription_id, const std::vector<std::string> & filters, int qos, int retain_handling, bool no_local, bool retain_as_published);
 
 
     /**
@@ -87,7 +86,7 @@ public:
      * @return the vector of reason codes for each filter
      * @throw MqttException on errors
      */
-    std::vector<int> unsubscribe(unsigned timeout, const std::list<std::string> & filters);
+    std::vector<int> unsubscribe(unsigned timeout, const std::vector<std::string> & filters);
 
     /**
      * Publishes MQTT message.

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
@@ -80,6 +80,16 @@ public:
 
 
     /**
+     * Unsubscribes from filters.
+     *
+     * @param timeout the timeout in seconds to subscribe
+     * @param filters the filters of topics subscribe to
+     * @return the vector of reason codes for each filter
+     * @throw MqttException on errors
+     */
+    std::vector<int> unsubscribe(unsigned timeout, const std::list<std::string> & filters);
+
+    /**
      * Publishes MQTT message.
      *
      * @param timeout the timeout in seconds to publish
@@ -127,6 +137,8 @@ private:
     void onMessage(const struct mosquitto_message * message, const mosquitto_property * props);
     ClientControl::Mqtt5Message * convertToMqtt5Message(const struct mosquitto_message * message, const mosquitto_property * props);
 
+    static void on_unsubscribe(struct mosquitto *, void * obj, int mid, const mosquitto_property * props);
+    void onUnsubscribe(int mid, const mosquitto_property * props);
 
     static void on_log(struct mosquitto *, void *, int level, const char * str);
 

--- a/uat/custom-components/client-mosquitto-c/src/logger.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/logger.cpp
@@ -23,7 +23,7 @@ void logd(const char *fmt, ...) {
 void logw(const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
-    logall("WARN", stdout, fmt, args);
+    logall("WARN ", stdout, fmt, args);
     va_end(args);
 }
 
@@ -37,13 +37,13 @@ void loge(const char *fmt, ...) {
 void logn(const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
-    logall("NOTICE", stdout, fmt, args);
+    logall("NOTIC", stdout, fmt, args);
     va_end(args);
 }
 
 void logi(const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
-    logall("INFO", stdout, fmt, args);
+    logall("INFO ", stdout, fmt, args);
     va_end(args);
 }


### PR DESCRIPTION
**Issue #, if available:**
Implement unsubscribe in the Mosquitto-based client

**Description of changes:**
- Implement unsubscribe feature
- Fix bug in AsyncResult creation and provide 3'th constructor
- Fix bug in char** leak by usage of std::vector
- Remove names of unused arguments
- Update limitations section in README
- Tune logging output

**Why is this change necessary:**
Test client requires unsubscribe MQTT feature

**How was this change tested:**
At the moment manually, later client will be used in the scenarios.

**Test logs**:

Control:
```
[INFO ] 2023-05-10 18:52:46.904 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId agent_mosquitto
[INFO ] 2023-05-10 18:52:46.916 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId agent_mosquitto address 127.0.0.1 port 40199
[INFO ] 2023-05-10 18:52:46.922 [grpc-default-executor-0] EngineControlImpl - Created new agent control for agent_mosquitto on 127.0.0.1:40199
[INFO ] 2023-05-10 18:52:46.968 [grpc-default-executor-0] ExampleControl - Agent agent_mosquitto is connected
[INFO ] 2023-05-10 18:52:46.971 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id agent_mosquitto
[INFO ] 2023-05-10 18:52:50.318 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
reasonCode: 0
receiveMaximum: 100
maximumQoS: 1
retainAvailable: true
maximumPacketSize: 149504
wildcardSubscriptionsAvailable: true
subscriptionIdentifiersAvailable: false
sharedSubscriptionsAvailable: true
serverKeepAlive: 60
topicAliasMaximum: 8
'
[INFO ] 2023-05-10 18:52:50.318 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-05-10 18:52:50.318 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-05-10 18:52:55.322 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-05-10 18:52:55.416 [pool-2-thread-1] AgentTestScenario - Subscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-05-10 18:53:00.433 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic test/topic
[INFO ] 2023-05-10 18:53:00.473 [pool-2-thread-1] AgentTestScenario - Published connectionId 1 reason code 0 reason string ''
[INFO ] 2023-05-10 18:53:00.473 [grpc-default-executor-0] GRPCDiscoveryServer - OnReceiveMessage: agentId agent_mosquitto connectionId 1 topic test/topic QoS 0
[INFO ] 2023-05-10 18:53:00.475 [grpc-default-executor-0] AgentTestScenario - Message received on agentId agent_mosquitto connectionId 1 topic test/topic QoS 0 content <ByteString@3972c1b9 size=12 contents="Hello World!">
[INFO ] 2023-05-10 18:53:05.481 [pool-2-thread-1] AgentControlImpl - UnsubscribeMqtt: unsubscribe on connectionId 1
[INFO ] 2023-05-10 18:53:05.540 [pool-2-thread-1] AgentTestScenario - Unsubscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-05-10 18:53:20.574 [grpc-default-executor-0] GRPCDiscoveryServer - OnMqttDisconnect: agentId agent_mosquitto connectionId 1 disconnect 'reasonCode: 0
' error ''
[INFO ] 2023-05-10 18:53:20.575 [grpc-default-executor-0] AgentTestScenario - MQTT disconnected on agentId agent_mosquitto connectionId 1 disconnect 'reasonCode: 0
' error ''
[INFO ] 2023-05-10 18:53:20.582 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-05-10 18:53:20.603 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-05-10 18:53:20.619 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId agent_mosquitto reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-05-10 18:53:20.633 [grpc-default-executor-0] ExampleControl - Agent agent_mosquitto is disconnected
```

Client:
```
[DEBUG]: Initialize gRPC library
[DEBUG]: Making gPRC link with 127.0.0.1:47619 as agent_id 'agent_mosquitto'
[DEBUG]: Sending RegisterAgent request with agent_id agent_mosquitto
[DEBUG]: Local address is 127.0.0.1
[DEBUG]: GRPCControlServer created and listed on 127.0.0.1:40199
[DEBUG]: Sending DiscoveryAgent request agent_id 'agent_mosquitto' host:port 127.0.0.1:40199
[DEBUG]: gPRC link established with 127.0.0.1:47619 as agent_id 'agent_mosquitto'
[DEBUG]: Initialize Mosquitto MQTT library
[DEBUG]: Mosquitto library version 2.0.15
[DEBUG]: Handle gRPC requests
[DEBUG]: CreateMqttConnection client_id 'GGMQ-test-device2' broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[DEBUG]: Creating Mosquitto MQTT connection for a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[DEBUG]: Establishing Mosquitto MQTT connection to a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883 in 10 seconds
[DEBUG]: Use provided TLS credentials
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending CONNECT
[DEBUG]: mosquitto: Client GGMQ-test-device2 received CONNACK (0)
[DEBUG]: onConnect rc 0 flags 0 props 0x7f9cf0010780
[DEBUG]: Establishing MQTT connection to a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883 completed with reason code 0
[DEBUG]: Connection registered with id 1
[DEBUG]: Subscription: filter test/topic QoS 0 noLocal 0 retainAsPublished 0 retainHandling 2
[DEBUG]: SubscribeMqtt connection_id 1
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending SUBSCRIBE (Mid: 1, Topic: test/topic, QoS: 0, Options: 0x20)
[DEBUG]: mosquitto: Client GGMQ-test-device2 received SUBACK
[DEBUG]: onSubscribe mid 1 qos_count 1 granted_qos 0x7f9cf0013dd0 props (nil)
[DEBUG]: Subscribed on 'test/topic ' filters QoS 0 message id 1
[DEBUG]: PublishMqtt connection_id 1 topic test/topic retain 0
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending PUBLISH (d0, q1, r0, m2, 'test/topic', ... (12 bytes))
[DEBUG]: mosquitto: Client GGMQ-test-device2 received PUBACK (Mid: 2, RC:0)
[DEBUG]: onPublish mid 2 rc 0 props (nil)
[DEBUG]: mosquitto: Client GGMQ-test-device2 received PUBLISH (d0, q0, r0, m0, 'test/topic', ... (12 bytes))
[DEBUG]: onMessage message 0x7f9cf0015908 props (nil)
[DEBUG]: Sending OnReceiveMessage request agent_id 'agent_mosquitto' connection_id 1
[DEBUG]: Published to 'test/topic' QoS 1  id 2
[DEBUG]: UnsubscribeMqtt connection_id 1
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending UNSUBSCRIBE (Mid: 3, Topic: test/topic)
[DEBUG]: mosquitto: Client GGMQ-test-device2 received UNSUBACK
[DEBUG]: onUnsubscribe mid 3 props (nil)
[DEBUG]: Unsubscribed from 'test/topic ' filters message id 3
[DEBUG]: CloseMqttConnection connection_id 1 reason 4
[DEBUG]: Disconnect Mosquitto MQTT connection with reason code 4
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending DISCONNECT
[DEBUG]: onDisconnect rc 0 props (nil)
[DEBUG]: Sending OnMqttDisconnect request agent_id 'agent_mosquitto' connection_id 1 error '(null)'
[DEBUG]: Destroy Mosquitto MQTT connection
[DEBUG]: ShutdownAgent with reason 'That's it.'
[DEBUG]: Shutdown gPRC link
[DEBUG]: Sending UnregisterAgent request agent_id 'agent_mosquitto' reason 'Agent shutdown by OTF request 'That's it.''
[DEBUG]: Shutdown MQTT library
[DEBUG]: Shutdown gRPC library
[DEBUG]: Execution done
```


**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
