### PR TITLE
feat(uat): added publish to java-paho-agent

### DIFF
--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
@@ -5,8 +5,8 @@
 
 package com.aws.greengrass.testing.mqtt311.client.paho;
 
-import com.aws.greengrass.testing.mqtt.client.MqttSubscribeReply;
 import com.aws.greengrass.testing.mqtt.client.MqttPublishReply;
+import com.aws.greengrass.testing.mqtt.client.MqttSubscribeReply;
 import com.aws.greengrass.testing.mqtt5.client.MqttConnection;
 import com.aws.greengrass.testing.mqtt5.client.MqttLib;
 import com.aws.greengrass.testing.mqtt5.client.exceptions.MqttException;

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.testing.mqtt311.client.paho;
 
 import com.aws.greengrass.testing.mqtt.client.MqttSubscribeReply;
+import com.aws.greengrass.testing.mqtt.client.MqttPublishReply;
 import com.aws.greengrass.testing.mqtt5.client.MqttConnection;
 import com.aws.greengrass.testing.mqtt5.client.MqttLib;
 import com.aws.greengrass.testing.mqtt5.client.exceptions.MqttException;
@@ -17,6 +18,7 @@ import org.eclipse.paho.client.mqttv3.IMqttClient;
 import org.eclipse.paho.client.mqttv3.IMqttToken;
 import org.eclipse.paho.client.mqttv3.MqttClient;
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -97,6 +99,26 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
                 throw new MqttException("Could not disconnect", e);
             }
         }
+    }
+
+    @Override
+    public MqttPublishReply publish(long timeout, @NonNull Message message) {
+        MqttMessage mqttMessage = new MqttMessage();
+        mqttMessage.setQos(message.getQos());
+        mqttMessage.setPayload(message.getPayload());
+        mqttMessage.setRetained(message.isRetain());
+        MqttPublishReply.Builder builder = MqttPublishReply.newBuilder();
+        try {
+            mqttClient.publish(message.getTopic(), mqttMessage);
+            builder.setReasonCode(0);
+        } catch (org.eclipse.paho.client.mqttv3.MqttException ex) {
+            logger.atError().withThrowable(ex)
+                    .log("Failed during publishing message with reasonCode {} and reasonString {}",
+                            ex.getReasonCode(), ex.getMessage());
+            builder.setReasonCode(ex.getReasonCode());
+            builder.setReasonString(ex.getMessage());
+        }
+        return builder.build();
     }
 
     /**

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -5,8 +5,8 @@
 
 package com.aws.greengrass.testing.mqtt5.client;
 
-import com.aws.greengrass.testing.mqtt.client.MqttSubscribeReply;
 import com.aws.greengrass.testing.mqtt.client.MqttPublishReply;
+import com.aws.greengrass.testing.mqtt.client.MqttSubscribeReply;
 import com.aws.greengrass.testing.mqtt5.client.exceptions.MqttException;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.testing.mqtt5.client;
 
 import com.aws.greengrass.testing.mqtt.client.MqttSubscribeReply;
+import com.aws.greengrass.testing.mqtt.client.MqttPublishReply;
 import com.aws.greengrass.testing.mqtt5.client.exceptions.MqttException;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -127,20 +128,6 @@ public interface MqttConnection {
     }
 
     /**
-     * Useful information from PUBACK packet.
-     */
-    @Getter
-    @AllArgsConstructor
-    class PubAckInfo {
-        /** MQTT v5.0 Reason code of PUBACK packet. */
-        private Integer reasonCode;
-
-        /** MQTT v5.0 Reason string of PUBACK packet. */
-        private String reasonString;
-        // TODO: add user's properties
-    }
-
-    /**
      * Useful information from UNSUBACK packet.
      * Actually is the same as SubAckInfo.
      */
@@ -178,4 +165,13 @@ public interface MqttConnection {
      * @exception MqttException on errors
      */
     void disconnect(long timeout, int reasonCode) throws MqttException;
+
+    /**
+     * Publishes MQTT message.
+     *
+     * @param timeout publish operation timeout in seconds
+     * @param message message to publish
+     * @return useful information from PUBACK packet or null of no PUBACK has been received (as for QoS 0)
+     */
+    MqttPublishReply publish(long timeout, @NonNull Message message);
 }

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -15,10 +15,10 @@ import com.aws.greengrass.testing.mqtt.client.MqttConnectReply;
 import com.aws.greengrass.testing.mqtt.client.MqttConnectRequest;
 import com.aws.greengrass.testing.mqtt.client.MqttConnectionId;
 import com.aws.greengrass.testing.mqtt.client.MqttProtoVersion;
-import com.aws.greengrass.testing.mqtt.client.MqttSubscribeReply;
-import com.aws.greengrass.testing.mqtt.client.MqttSubscribeRequest;
 import com.aws.greengrass.testing.mqtt.client.MqttPublishReply;
 import com.aws.greengrass.testing.mqtt.client.MqttPublishRequest;
+import com.aws.greengrass.testing.mqtt.client.MqttSubscribeReply;
+import com.aws.greengrass.testing.mqtt.client.MqttSubscribeRequest;
 import com.aws.greengrass.testing.mqtt.client.ShutdownRequest;
 import com.aws.greengrass.testing.mqtt.client.TLSSettings;
 import com.aws.greengrass.testing.mqtt5.client.GRPCClient;
@@ -45,8 +45,6 @@ import java.util.concurrent.atomic.AtomicReference;
 class GRPCControlServer {
     private static final Logger logger = LogManager.getLogger(GRPCControlServer.class);
 
-    private static final int QOS_MIN = 0;
-    private static final int QOS_MAX = 2;
     private static final String CONNECTION_WITH_DOES_NOT_FOUND = "connection with id {} doesn't found";
     private static final String CONNECTION_DOES_NOT_FOUND = "connection doesn't found";
     private static final int RETAIN_HANDLING_MIN = 0;

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.testing.mqtt5.client.grpc;
 
 import com.aws.greengrass.testing.mqtt.client.Empty;
 import com.aws.greengrass.testing.mqtt.client.Mqtt5ConnAck;
+import com.aws.greengrass.testing.mqtt.client.Mqtt5Message;
 import com.aws.greengrass.testing.mqtt.client.Mqtt5Subscription;
 import com.aws.greengrass.testing.mqtt.client.MqttClientControlGrpc;
 import com.aws.greengrass.testing.mqtt.client.MqttCloseRequest;
@@ -16,6 +17,8 @@ import com.aws.greengrass.testing.mqtt.client.MqttConnectionId;
 import com.aws.greengrass.testing.mqtt.client.MqttProtoVersion;
 import com.aws.greengrass.testing.mqtt.client.MqttSubscribeReply;
 import com.aws.greengrass.testing.mqtt.client.MqttSubscribeRequest;
+import com.aws.greengrass.testing.mqtt.client.MqttPublishReply;
+import com.aws.greengrass.testing.mqtt.client.MqttPublishRequest;
 import com.aws.greengrass.testing.mqtt.client.ShutdownRequest;
 import com.aws.greengrass.testing.mqtt.client.TLSSettings;
 import com.aws.greengrass.testing.mqtt5.client.GRPCClient;
@@ -52,7 +55,8 @@ class GRPCControlServer {
 
     private static final int PORT_MIN = 1;
     private static final int PORT_MAX = 65_535;
-
+    private static final int QOS_MIN = 0;
+    private static final int QOS_MAX = 2;
     private static final int KEEPALIVE_OFF = 0;
     private static final int KEEPALIVE_MIN = 5;
     private static final int KEEPALIVE_MAX = 65_535;
@@ -157,11 +161,7 @@ class GRPCControlServer {
             }
 
             int timeout = request.getTimeout();
-            if (timeout < TIMEOUT_MIN) {
-                logger.atWarn().log("invalid connect timeout {} must be >= {}", timeout, TIMEOUT_MIN);
-                responseObserver.onError(Status.INVALID_ARGUMENT
-                        .withDescription("invalid connect timeout, must be >= 1")
-                        .asRuntimeException());
+            if (!isValidTimeout(timeout, "connect", responseObserver)) {
                 return;
             }
 
@@ -241,6 +241,57 @@ class GRPCControlServer {
         }
 
         /**
+         * Handler of PublishMqtt gRPC call.
+         *
+         * @param request incoming request
+         * @param responseObserver response control
+         */
+        @Override
+        public void publishMqtt(MqttPublishRequest request, StreamObserver<MqttPublishReply> responseObserver) {
+
+            Mqtt5Message message = request.getMsg();
+
+            int qos = message.getQosValue();
+            if (!isValidQos(qos, responseObserver)) {
+                return;
+            }
+
+            String topic = message.getTopic();
+            if (!isValidTopic(topic, responseObserver)) {
+                return;
+            }
+
+            int timeout = request.getTimeout();
+            if (!isValidTimeout(timeout, "publish", responseObserver)) {
+                return;
+            }
+
+            int connectionId = request.getConnectionId().getConnectionId();
+            MqttConnection connection = mqttLib.getConnection(connectionId);
+            if (!isValidConnection(connection, connectionId, responseObserver)) {
+                return;
+            }
+
+            boolean isRetain = message.getRetain();
+            logger.atInfo().log("Publish: connectionId {} topic {} QoS {} retain {}",
+                    connectionId, topic, qos, isRetain);
+
+            MqttConnection.Message internalMessage = MqttConnection.Message.builder()
+                    .qos(qos)
+                    .retain(isRetain)
+                    .topic(topic)
+                    .payload(message.getPayload().toByteArray())
+                    .build();
+            MqttPublishReply publishReply = connection.publish(timeout, internalMessage);
+                if (publishReply != null) {
+                    logger.atInfo().log("Publish response: connectionId {} reason code {} reason string {}",
+                            connectionId, publishReply.getReasonCode(), publishReply.getReasonString());
+                }
+            responseObserver.onNext(publishReply);
+            responseObserver.onCompleted();
+        }
+
+        /**
          * Handler of CloseMqttConnection gRPC call.
          *
          * @param request incoming request
@@ -259,21 +310,13 @@ class GRPCControlServer {
             }
 
             int timeout = request.getTimeout();
-            if (timeout < TIMEOUT_MIN) {
-                logger.atWarn().log("invalid disconnect timeout, must be >= {}", timeout, TIMEOUT_MIN);
-                responseObserver.onError(Status.INVALID_ARGUMENT
-                        .withDescription("invalid disconnect timeout, must be >= 1")
-                        .asRuntimeException());
+            if (!isValidTimeout(timeout, "disconnect", responseObserver)) {
                 return;
             }
 
             int connectionId = request.getConnectionId().getConnectionId();
             MqttConnection connection = mqttLib.unregisterConnection(connectionId);
-            if (connection == null) {
-                logger.atWarn().log(CONNECTION_WITH_DOES_NOT_FOUND, connectionId);
-                responseObserver.onError(Status.NOT_FOUND
-                        .withDescription(CONNECTION_DOES_NOT_FOUND)
-                        .asRuntimeException());
+            if (!isValidConnection(connection, connectionId, responseObserver)) {
                 return;
             }
 
@@ -543,5 +586,49 @@ class GRPCControlServer {
         }
 
         return builder.build();
+    }
+
+    private boolean isValidQos(int qos, StreamObserver<MqttPublishReply> responseObserver) {
+        if (qos < QOS_MIN || qos > QOS_MAX) {
+            logger.atWarn().log("invalid QoS {}, must be in range [{},{}]", qos, QOS_MIN, QOS_MAX);
+            responseObserver.onError(Status.INVALID_ARGUMENT
+                    .withDescription("invalid QoS, must be in range [0,2]")
+                    .asRuntimeException());
+            return false;
+        }
+        return true;
+    }
+
+    private boolean isValidTopic(String topic, StreamObserver<MqttPublishReply> responseObserver) {
+        if (topic == null || topic.isEmpty()) {
+            logger.atWarn().log("empty topic");
+            responseObserver.onError(Status.INVALID_ARGUMENT
+                    .withDescription("empty topic")
+                    .asRuntimeException());
+            return false;
+        }
+        return true;
+    }
+
+    private boolean isValidTimeout(int timeout, String command, StreamObserver responseObserver) {
+        if (timeout < TIMEOUT_MIN) {
+            logger.atWarn().log("invalid {} timeout {}, must be >= {}", command, timeout, TIMEOUT_MIN);
+            responseObserver.onError(Status.INVALID_ARGUMENT
+                    .withDescription("invalid ".concat(command).concat(" timeout, must be >= 1"))
+                    .asRuntimeException());
+            return false;
+        }
+        return true;
+    }
+
+    private boolean isValidConnection(MqttConnection connection, int connectionId, StreamObserver responseObserver) {
+        if (connection == null) {
+            logger.atWarn().log(CONNECTION_WITH_DOES_NOT_FOUND, connectionId);
+            responseObserver.onError(Status.NOT_FOUND
+                    .withDescription(CONNECTION_DOES_NOT_FOUND)
+                    .asRuntimeException());
+            return false;
+        }
+        return true;
     }
 }


### PR DESCRIPTION
**Issue #, if available:**
Added publish to paho client

**Description of changes:**
- added method publish

**Why is this change necessary:**
- required step for several test features

**How was this change tested:**
run command **mvn exec:java** in paho-agent module 

**Test results:**
Control:
```
INFO ] 2023-05-22 19:37:26.276 [grpc-default-executor-1] GRPCDiscoveryServer - RegisterAgent: agentId best-thing-akezhan
[INFO ] 2023-05-22 19:37:26.324 [grpc-default-executor-1] GRPCDiscoveryServer - DiscoveryClient: agentId best-thing-akezhan address 127.0.0.1 port 36869
[INFO ] 2023-05-22 19:37:26.325 [grpc-default-executor-1] EngineControlImpl - Created new agent control for best-thing-akezhan on 127.0.0.1:36869
[INFO ] 2023-05-22 19:37:26.325 [grpc-default-executor-1] ExampleControl - Agent best-thing-akezhan is connected
[INFO ] 2023-05-22 19:37:26.326 [pool-2-thread-2] AgentTestScenario - Playing test scenario for agent id best-thing-akezhan
[INFO ] 2023-05-22 19:37:31.018 [pool-2-thread-2] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: true
'
[INFO ] 2023-05-22 19:37:31.018 [pool-2-thread-2] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-05-22 19:37:31.018 [pool-2-thread-2] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-05-22 19:37:36.019 [pool-2-thread-2] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic test/topic
[INFO ] 2023-05-22 19:37:47.070 [pool-2-thread-2] AgentTestScenario - Published connectionId 1 reason code 0 reason string ''
[INFO ] 2023-05-22 19:37:52.071 [pool-2-thread-2] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[ERROR] 2023-05-22 19:37:52.084 [pool-2-thread-2] AgentTestScenario - gRPC error code UNIMPLEMENTED: description: Method ClientControl.MqttClientControl/SubscribeMqtt is unimplemented
io.grpc.StatusRuntimeException: UNIMPLEMENTED: Method ClientControl.MqttClientControl/SubscribeMqtt is unimplemented
        at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:271) ~[grpc-stub-1.53.0.jar:1.53.0]
        at io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:252) ~[grpc-stub-1.53.0.jar:1.53.0]
        at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:165) ~[grpc-stub-1.53.0.jar:1.53.0]
        at com.aws.greengrass.testing.mqtt.client.MqttClientControlGrpc$MqttClientControlBlockingStub.subscribeMqtt(MqttClientControlGrpc.java:511) ~[classes/:?]
        at com.aws.greengrass.testing.mqtt.client.control.implementation.AgentControlImpl.subscribeMqtt(AgentControlImpl.java:209) ~[classes/:?]
        at com.aws.greengrass.testing.mqtt.client.control.implementation.ConnectionControlImpl.subscribeMqtt(ConnectionControlImpl.java:112) ~[classes/:?]
        at com.aws.greengrass.testing.mqtt.client.control.AgentTestScenario.testSubscribe(AgentTestScenario.java:197) ~[classes/:?]
        at com.aws.greengrass.testing.mqtt.client.control.AgentTestScenario.run(AgentTestScenario.java:150) [classes/:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:829) [?:?]
[INFO ] 2023-05-22 19:37:52.104 [pool-2-thread-2] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-05-22 19:37:52.109 [pool-2-thread-2] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-05-22 19:37:52.117 [grpc-default-executor-1] GRPCDiscoveryServer - UnregisterAgent: agentId best-thing-akezhan reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-05-22 19:37:52.117 [grpc-default-executor-1] ExampleControl - Agent best-thing-akezhan is disconnected
^C[I
```
Client:
```
[INFO ] 2023-05-22 19:37:25.833 [main] GRPCLinkImpl - Making gPRC client connection with 127.0.0.1:47619 as best-thing-akezhan...
[INFO ] 2023-05-22 19:37:26.292 [main] GRPCLinkImpl - Client connection with Control is established, local address is 127.0.0.1
[INFO ] 2023-05-22 19:37:26.321 [main] GRPCControlServer - GRPCControlServer created and listed on 127.0.0.1:36869
[INFO ] 2023-05-22 19:37:26.359 [main] GRPCLinkImpl - Handle gRPC requests
[INFO ] 2023-05-22 19:37:26.359 [main] GRPCControlServer - Server awaitTermination
[INFO ] 2023-05-22 19:37:29.359 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId best-thing-akezhan broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[INFO ] 2023-05-22 19:37:31.009 [grpc-default-executor-0] Mqtt311ConnectionImpl - MQTT 3.1.1 connection 1 is establisted
[INFO ] 2023-05-22 19:37:36.031 [grpc-default-executor-0] GRPCControlServer - Publish: connectionId 1 topic test/topic QoS 1 retain false
[INFO ] 2023-05-22 19:37:46.525 [grpc-default-executor-0] GRPCControlServer - Publish response: connectionId 1 reason code 0 reason string 
[INFO ] 2023-05-22 19:37:52.088 [grpc-default-executor-0] GRPCControlServer - closeMqttConnection: connectionId 1 reason 4
[INFO ] 2023-05-22 19:37:52.101 [grpc-default-executor-0] Mqtt311ConnectionImpl - MQTT 3.1.1 connection 1 has been disconnected
[INFO ] 2023-05-22 19:37:52.106 [grpc-default-executor-0] GRPCControlServer - shutdownAgent: reason That's it.
[INFO ] 2023-05-22 19:37:52.113 [main] GRPCControlServer - Server awaitTermination done
[INFO ] 2023-05-22 19:37:52.113 [main] GRPCLinkImpl - Shutdown gPRC link
[INFO ] 2023-05-22 19:37:52.121 [main] Main - Execution done successfully
Disconnected from the target VM, address: '127.0.0.1:34077', transport: 'socket'
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
