### PR TITLE
feat(uat): add scenarios to test 'no local' feature for local broker

### DIFF
--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
@@ -215,6 +215,7 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
     }
 
 
+    @SuppressWarnings("PMD.CollapsibleIfStatements")
     private void unregisterAllAgent() {
         agents.forEach((agentId, agentControl) -> {
             if (agents.remove(agentId, agentControl)) {

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -99,7 +99,7 @@ public class MqttControlSteps {
     private static final int DEFAULT_MQTT_KEEP_ALIVE = 60;
 
     // connect default properties
-    private static final boolean DEFAULT_CONNECT_CLEAR_SESSION = true;
+    private static final boolean DEFAULT_CONNECT_CLEAR_SESSION = true;  // TODO: use also variable and step to set it
     private static final int IOT_CORE_MQTT_PORT = 8883;
 
     // publish default properties

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1468,19 +1468,53 @@ Feature: GGMQ-1
     And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
     And I connect device "subscriber" on <agent> to "localMqttBroker2" using mqtt "<mqtt-v>"
 
-    # 1. payload format indicator set to 0
-    When I subscribe "subscriber" to "iot_data_0" with qos 0
+    # 7. test case when both tx/rx payload format indicators are set to 0
+    And I clear message storage
     And I set MQTT publish 'payload format indicator' flag to false
-    When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world1"
     And I set the 'payload format indicator' flag in expected received messages to false
-    And message "Hello world1" received on "subscriber" from "iot_data_0" topic within 5 seconds
+    When I subscribe "subscriber" to "payload_format_indicator_false_false" with qos 0
+    When I publish from "publisher" to "payload_format_indicator_false_false" with qos 0 and message "Payload format indicators false/false"
+    And message "Payload format indicators false/false" received on "subscriber" from "payload_format_indicator_false_false" topic within 5 seconds
 
-    # 2. payload format indicator set to 1
-    When I subscribe "subscriber" to "iot_data_1" with qos 0
+    # 8. test case when both tx/rx payload format indicators set to 1
+    And I clear message storage
     And I set MQTT publish 'payload format indicator' flag to true
-    When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world2"
     And I set the 'payload format indicator' flag in expected received messages to true
-    And message "Hello world2" received on "subscriber" from "iot_data_1" topic within 5 seconds
+    When I subscribe "subscriber" to "payload_format_indicator_true_true" with qos 0
+    When I publish from "publisher" to "payload_format_indicator_true_true" with qos 0 and message "Payload format indicators true/true"
+    And message "Payload format indicators true/true" received on "subscriber" from "payload_format_indicator_true_true" topic within 5 seconds
+
+    # 10. test case when tx payload format indicator set to 1 and rx to 0
+    And I clear message storage
+    And I set MQTT publish 'payload format indicator' flag to true
+    And I set the 'payload format indicator' flag in expected received messages to false
+    When I subscribe "subscriber" to "payload_format_indicator_true_false" with qos 0
+    When I publish from "publisher" to "payload_format_indicator_true_false" with qos 0 and message "Payload format indicators true/false"
+    And message "Payload format indicators true/false" is not received on "subscriber" from "payload_format_indicator_true_false" topic within 5 seconds
+
+    # 11. test case when tx payload format indicator set to 0 and rx to 1
+    And I clear message storage
+    And I set MQTT publish 'payload format indicator' flag to false
+    And I set the 'payload format indicator' flag in expected received messages to true
+    When I subscribe "subscriber" to "payload_format_indicator_false_true" with qos 0
+    When I publish from "publisher" to "payload_format_indicator_false_true" with qos 0 and message "Payload format indicators false/true"
+    And message "Payload format indicators false/true" is not received on "subscriber" from "payload_format_indicator_false_true" topic within 5 seconds
+
+    # 12. test case when tx payload format indicator set to 1 and rx is unset
+    And I clear message storage
+    And I set MQTT publish 'payload format indicator' flag to true
+    And I set the 'payload format indicator' flag in expected received messages to null
+    When I subscribe "subscriber" to "payload_format_indicator_true_null" with qos 0
+    When I publish from "publisher" to "payload_format_indicator_true_null" with qos 0 and message "Payload format indicators true/null"
+    And message "Payload format indicators true/null" received on "subscriber" from "payload_format_indicator_true_null" topic within 5 seconds
+
+    # 13. test case when tx payload format indicator set to 0 and rx is unset
+    And I clear message storage
+    And I set MQTT publish 'payload format indicator' flag to false
+    And I set the 'payload format indicator' flag in expected received messages to null
+    When I subscribe "subscriber" to "payload_format_indicator_false_null" with qos 0
+    When I publish from "publisher" to "payload_format_indicator_false_null" with qos 0 and message "Payload format indicators false/null"
+    And message "Payload format indicators false/null" received on "subscriber" from "payload_format_indicator_false_null" topic within 5 seconds
 
     And I disconnect device "subscriber" with reason code 0
     And I disconnect device "publisher" with reason code 0

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1396,11 +1396,8 @@ Feature: GGMQ-1
     And I set MQTT subscribe 'no local' flag to true
     When I subscribe "subscriber" to "no_local_test" with qos 0
 
-    When I publish from "subscriber" to "no_local_false" with qos 0 and message "First message no local true test"
-    Then message "First message no local true test" is not received on "subscriber" from "no_local_false" topic within 5 seconds
-
-    When I publish from "publisher" to "no_local_false" with qos 0 and message "Second message no local true test"
-    Then message "Second message no local true test" received on "subscriber" from "no_local_false" topic within 5 seconds
+    When I publish from "subscriber" to "no_local_true" with qos 0 and message "First message no local true test"
+    Then message "First message no local true test" is not received on "subscriber" from "no_local_true" topic within 5 seconds
 
     And I clear message storage
 

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1408,6 +1408,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
 
+  # TODO: when paho-java is ready to handle payload format indicator join all T1xx scenarios together
   @GGMQ-1-T104
   Scenario Outline: GGMQ-1-T104-<mqtt-v>-<name>: As a customer, I can send and receive MQTT v5.0 messages with 'payload format indicator'
     When I create a Greengrass deployment with components
@@ -1484,7 +1485,11 @@ Feature: GGMQ-1
     And I disconnect device "subscriber" with reason code 0
     And I disconnect device "publisher" with reason code 0
 
-    # TODO: add more agents here when 'payload format indicator' feature will be added to it
+    @mqtt5 @sdk-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
+
     @mqtt5 @mosquitto-c
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |


### PR DESCRIPTION
**Issue #, if available:**
Set/unset non local publishing

**Description of changes:**
- Add step @And("I set MQTT5 'no local' to {booleanValue}")
- Join subscribe steps to single implementation
- Add GGMQ-1-T100 scenarios to test 'no local' feature
- Change SUCCESS to GRANTED_QOS_0 in SubscribeReasonCode
- Fix bug in control when agent is restarted
- Add more tags in scenarios

**Why is this change necessary:**
'no local' feature should be tests

**How was this change tested:**
By running scenarios

**Test results:**
With sdk-java client
```
$ ./run_test_aws_T100_sdk.sh 
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
[INFO ] 2023-05-19 18:14:58.694 [main] GreengrassContextModule - Extracting greengrass-nucleus-latest.zip into /tmp/gg-testing-15744393887570050675/greengrass
[INFO ] 2023-05-19 18:14:59.371 [main] LoggerSteps - OTF Version is otf-1.1.0-SNAPSHOT
[INFO ] 2023-05-19 18:14:59.371 [main] LoggerSteps - Attaching thread context to scenario: 'GGMQ-1-T100-sdk-java: Local broker supports 'no local' MQTT v5.0 feature'
[WARN ] 2023-05-19 18:14:59.495 [main] ProfileFileReader - Ignoring profile 'sso-session default' on line 7 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:14:59.495 [main] ProfileFileReader - Ignoring profile 'sso-session Developers-219258050757' on line 11 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:14:59.931 [main] ProfileFileReader - Ignoring profile 'sso-session default' on line 7 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:14:59.932 [main] ProfileFileReader - Ignoring profile 'sso-session Developers-219258050757' on line 11 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:14:59.988 [main] ProfileFileReader - Ignoring profile 'sso-session default' on line 7 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:14:59.988 [main] ProfileFileReader - Ignoring profile 'sso-session Developers-219258050757' on line 11 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:15:00.060 [main] ProfileFileReader - Ignoring profile 'sso-session default' on line 7 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:15:00.060 [main] ProfileFileReader - Ignoring profile 'sso-session Developers-219258050757' on line 11 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:15:00.409 [main] ProfileFileReader - Ignoring profile 'sso-session default' on line 7 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:15:00.410 [main] ProfileFileReader - Ignoring profile 'sso-session Developers-219258050757' on line 11 because it did not start with 'profile ' and it was not 'default'.
[INFO ] 2023-05-19 18:15:00.727 [main] AbstractAWSResourceLifecycle - Created IotPolicy in IotLifecycle
[INFO ] 2023-05-19 18:15:01.892 [main] AbstractAWSResourceLifecycle - Created IamPolicy in IamLifecycle
[INFO ] 2023-05-19 18:15:02.457 [main] AbstractAWSResourceLifecycle - Created IamRole in IamLifecycle
[INFO ] 2023-05-19 18:15:02.751 [main] AbstractAWSResourceLifecycle - Created IotRoleAlias in IotLifecycle
[INFO ] 2023-05-19 18:15:02.855 [main] AbstractAWSResourceLifecycle - Created IotPolicy in IotLifecycle
[INFO ] 2023-05-19 18:15:02.965 [main] AbstractAWSResourceLifecycle - Created IotThingGroup in IotLifecycle
[INFO ] 2023-05-19 18:15:03.440 [main] AbstractAWSResourceLifecycle - Created IotCertificate in IotLifecycle
[INFO ] 2023-05-19 18:15:03.527 [main] AbstractAWSResourceLifecycle - Created IotThing in IotLifecycle
[INFO ] 2023-05-19 18:15:03.662 [main] feature - Finished step: 'my device is registered as a Thing' with status PASSED
[INFO ] 2023-05-19 18:15:04.505 [main] DefaultGreengrass - Starting Greengrass on pid 301341
[INFO ] 2023-05-19 18:15:04.505 [main] feature - Finished step: 'my device is running Greengrass' with status PASSED
[INFO ] 2023-05-19 18:15:06.679 [main] AbstractAWSResourceLifecycle - Created S3Bucket in S3Lifecycle
[INFO ] 2023-05-19 18:15:11.794 [main] AbstractAWSResourceLifecycle - Created S3Object in S3Lifecycle
[INFO ] 2023-05-19 18:15:11.795 [main] RecipeComponentPreparationService - Uploaded /tmp/gg-testing-15744393887570050675/0dd49efd50564325f2ed/components/aws.greengrass.client.Mqtt5JavaSdkClient/aws.greengrass.client.Mqtt5JavaSdkClient.jar to s3://gg-0dd49efd50564325f2ed-gg-component-store/greengrass/artifacts/aws.greengrass.client.Mqtt5JavaSdkClient.jar
[INFO ] 2023-05-19 18:15:12.642 [main] AbstractAWSResourceLifecycle - Created GreengrassComponent in GreengrassV2Lifecycle
[INFO ] 2023-05-19 18:15:12.643 [main] RecipeComponentPreparationService - Created component aws.greengrass.client.Mqtt5JavaSdkClient:1.0.0-0dd49efd50564325f2ed from /greengrass/components/recipes/client_java_sdk.yaml
[INFO ] 2023-05-19 18:15:12.644 [main] feature - Finished step: 'I create a Greengrass deployment with components' with status PASSED
[INFO ] 2023-05-19 18:15:12.857 [main] EngineControlImpl - MQTT client control gRPC server started, listening on 39003
[INFO ] 2023-05-19 18:15:12.858 [main] MqttControlSteps - MQTT clients control started gRPC service on port 39003 addresses [172.17.0.1, 172.25.32.127]
[INFO ] 2023-05-19 18:15:12.961 [main] AbstractAWSResourceLifecycle - Created IotPolicy in IotLifecycle
[INFO ] 2023-05-19 18:15:13.264 [main] AbstractAWSResourceLifecycle - Created IotCertificate in IotLifecycle
[INFO ] 2023-05-19 18:15:13.265 [main] AbstractAWSResourceLifecycle - Created IotThing in IotLifecycle
[INFO ] 2023-05-19 18:15:13.266 [main] feature - Finished step: 'I create client device "clientDeviceTest"' with status PASSED
[INFO ] 2023-05-19 18:15:13.361 [main] feature - Finished step: 'I associate "clientDeviceTest" with ggc' with status PASSED
[INFO ] 2023-05-19 18:15:13.378 [main] feature - Finished step: 'I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:' with status PASSED
[INFO ] 2023-05-19 18:15:13.380 [main] feature - Finished step: 'I update my Greengrass deployment configuration, setting the component aws.greengrass.client.Mqtt5JavaSdkClient configuration to:' with status PASSED
[INFO ] 2023-05-19 18:15:13.716 [main] AbstractAWSResourceLifecycle - Created GreengrassDeployment in GreengrassV2Lifecycle
[INFO ] 2023-05-19 18:15:13.716 [main] DeploymentSteps - Created Greengrass deployment: 3abbb31e-109f-4d19-bd8a-833a26ab0b76
[INFO ] 2023-05-19 18:15:13.716 [main] feature - Finished step: 'I deploy the Greengrass deployment configuration' with status PASSED
[INFO ] 2023-05-19 18:15:44.925 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId aws.greengrass.client.Mqtt5JavaSdkClient
[INFO ] 2023-05-19 18:15:45.017 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId aws.greengrass.client.Mqtt5JavaSdkClient address 172.25.32.127 port 46875
[INFO ] 2023-05-19 18:15:45.019 [grpc-default-executor-0] EngineControlImpl - Created new agent control for aws.greengrass.client.Mqtt5JavaSdkClient on 172.25.32.127:46875
[INFO ] 2023-05-19 18:15:45.062 [grpc-default-executor-0] MqttControlSteps - Agent aws.greengrass.client.Mqtt5JavaSdkClient is connected
[INFO ] 2023-05-19 18:15:53.151 [main] feature - Finished step: 'the Greengrass deployment is COMPLETED on the device after 300 seconds' with status PASSED
[INFO ] 2023-05-19 18:15:53.781 [main] MqttControlSteps - Discovered data for broker default_broker: 
[INFO ] 2023-05-19 18:15:53.781 [main] MqttControlSteps - groupId greengrassV2-coreDevice-gg-0dd49efd50564325f2ed-ggc-thing with 1 CA
[INFO ] 2023-05-19 18:15:53.782 [main] MqttControlSteps - Core with thing Arn arn:aws:iot:eu-central-1:285891398846:thing/gg-0dd49efd50564325f2ed-ggc-thing
[INFO ] 2023-05-19 18:15:53.782 [main] MqttControlSteps - Connectivity info: id 172.17.0.1 host 172.17.0.1 port 8883
[INFO ] 2023-05-19 18:15:53.782 [main] MqttControlSteps - Connectivity info: id 172.25.32.127 host 172.25.32.127 port 8883
[INFO ] 2023-05-19 18:15:53.783 [main] feature - Finished step: 'I discover core device broker as "default_broker" from "clientDeviceTest"' with status PASSED
[INFO ] 2023-05-19 18:15:53.784 [main] MqttControlSteps - Creating MQTT connection with broker default_broker to address 172.17.0.1:8883 as Thing gg-0dd49efd50564325f2ed-clientDeviceTest on aws.greengrass.client.Mqtt5JavaSdkClient MQTT v5
[INFO ] 2023-05-19 18:15:54.789 [main] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
reasonCode: 0
retainAvailable: true
maximumPacketSize: 268435455
wildcardSubscriptionsAvailable: true
subscriptionIdentifiersAvailable: true
sharedSubscriptionsAvailable: true
'
[INFO ] 2023-05-19 18:15:54.789 [main] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-05-19 18:15:54.789 [main] MqttControlSteps - Connection with broker default_broker established to address 172.17.0.1:8883 as Thing gg-0dd49efd50564325f2ed-clientDeviceTest on aws.greengrass.client.Mqtt5JavaSdkClient
[INFO ] 2023-05-19 18:15:54.789 [main] feature - Finished step: 'I connect device "clientDeviceTest" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker" using mqtt "v5"' with status PASSED
[INFO ] 2023-05-19 18:15:54.789 [main] feature - Finished step: 'I set MQTT5 'no local' to True' with status PASSED
[INFO ] 2023-05-19 18:15:54.790 [main] MqttControlSteps - Create MQTT subscription for Thing gg-0dd49efd50564325f2ed-clientDeviceTest to topics filter iot_data_0 with QoS 0
[INFO ] 2023-05-19 18:15:54.790 [main] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-05-19 18:15:54.802 [main] MqttControlSteps - MQTT subscription has on topics filter iot_data_0 been created with reason code 0
[INFO ] 2023-05-19 18:15:54.803 [main] feature - Finished step: 'I subscribe "clientDeviceTest" to "iot_data_0" with qos 0' with status PASSED
[INFO ] 2023-05-19 18:15:54.803 [main] MqttControlSteps - Publishing MQTT message Test message as Thing gg-0dd49efd50564325f2ed-clientDeviceTest to topics filter iot_data_0 with QoS 0
[INFO ] 2023-05-19 18:15:54.803 [main] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic iot_data_0
[INFO ] 2023-05-19 18:15:54.814 [main] MqttControlSteps - MQTT message Test message has been succesfully published
[INFO ] 2023-05-19 18:15:54.814 [main] feature - Finished step: 'I publish from "clientDeviceTest" to "iot_data_0" with qos 0 and message "Test message"' with status PASSED
[INFO ] 2023-05-19 18:15:54.815 [main] MqttControlSteps - Awaiting for MQTT message Test message on topic iot_data_0 on Thing gg-0dd49efd50564325f2ed-clientDeviceTest for 10 seconds
[INFO ] 2023-05-19 18:16:04.816 [main] feature - Finished step: 'message "Test message" received on "clientDeviceTest" from "iot_data_0" topic within 10 seconds is false expected' with status PASSED
[INFO ] 2023-05-19 18:16:05.498 [main] DefaultGreengrass - Stopped Greengrass on pid 301341
[INFO ] 2023-05-19 18:16:06.038 [main] AbstractAWSResourceLifecycle - Removed GreengrassDeployment in GreengrassV2Lifecycle
[INFO ] 2023-05-19 18:16:06.235 [main] AbstractAWSResourceLifecycle - Removed GreengrassComponent in GreengrassV2Lifecycle
[INFO ] 2023-05-19 18:16:06.453 [main] AbstractAWSResourceLifecycle - Removed S3Object in S3Lifecycle
[INFO ] 2023-05-19 18:16:06.956 [main] AbstractAWSResourceLifecycle - Removed S3Bucket in S3Lifecycle
[INFO ] 2023-05-19 18:16:08.184 [main] AbstractAWSResourceLifecycle - Removed IamRole in IamLifecycle
[INFO ] 2023-05-19 18:16:08.684 [main] AbstractAWSResourceLifecycle - Removed IamPolicy in IamLifecycle
[INFO ] 2023-05-19 18:16:08.828 [main] AbstractAWSResourceLifecycle - Removed IotThing in IotLifecycle
[INFO ] 2023-05-19 18:16:09.084 [main] AbstractAWSResourceLifecycle - Removed IotCertificate in IotLifecycle
[INFO ] 2023-05-19 18:16:09.208 [main] AbstractAWSResourceLifecycle - Removed IotPolicy in IotLifecycle
[INFO ] 2023-05-19 18:16:09.326 [main] AbstractAWSResourceLifecycle - Removed IotThing in IotLifecycle
[INFO ] 2023-05-19 18:16:09.621 [main] AbstractAWSResourceLifecycle - Removed IotCertificate in IotLifecycle
[INFO ] 2023-05-19 18:16:09.695 [main] AbstractAWSResourceLifecycle - Removed IotThingGroup in IotLifecycle
[INFO ] 2023-05-19 18:16:09.816 [main] AbstractAWSResourceLifecycle - Removed IotPolicy in IotLifecycle
[INFO ] 2023-05-19 18:16:09.887 [main] AbstractAWSResourceLifecycle - Removed IotRoleAlias in IotLifecycle
[INFO ] 2023-05-19 18:16:10.026 [main] AbstractAWSResourceLifecycle - Removed IotPolicy in IotLifecycle
[INFO ] 2023-05-19 18:16:10.027 [main] AWSResourcesSteps - Successfully removed externally created resources
[INFO ] 2023-05-19 18:16:10.028 [main] MqttControlSteps - Agent aws.greengrass.client.Mqtt5JavaSdkClient is disconnected
[INFO ] 2023-05-19 18:16:10.033 [main] EngineControlImpl - gRPC MQTT client control server stopped
[INFO ] 2023-05-19 18:16:10.038 [main] LoggerSteps - Clearing thread context on scenario: 'GGMQ-1-T100-sdk-java: Local broker supports 'no local' MQTT v5.0 feature'
[INFO ] 2023-05-19 18:16:10.045 [main] StepTrackingReporting - Passed: 'GGMQ-1-T100-sdk-java: Local broker supports 'no local' MQTT v5.0 feature'
[INFO ] 2023-05-19 18:16:10.153 [Thread-1] AWSResourcesCleanupModule - Cleaned up com.aws.greengrass.testing.resources.greengrass.GreengrassV2Lifecycle$$EnhancerByGuice$$22480187@676356d2
[INFO ] 2023-05-19 18:16:10.153 [Thread-1] AWSResourcesCleanupModule - Cleaned up com.aws.greengrass.testing.api.device.local.LocalDevice@2fbe26da
```

With mosquitto-c client:
```
$ ./run_test_aws_T100_sdk.sh 
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
[INFO ] 2023-05-19 18:14:58.694 [main] GreengrassContextModule - Extracting greengrass-nucleus-latest.zip into /tmp/gg-testing-15744393887570050675/greengrass
[INFO ] 2023-05-19 18:14:59.371 [main] LoggerSteps - OTF Version is otf-1.1.0-SNAPSHOT
[INFO ] 2023-05-19 18:14:59.371 [main] LoggerSteps - Attaching thread context to scenario: 'GGMQ-1-T100-sdk-java: Local broker supports 'no local' MQTT v5.0 feature'
[WARN ] 2023-05-19 18:14:59.495 [main] ProfileFileReader - Ignoring profile 'sso-session default' on line 7 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:14:59.495 [main] ProfileFileReader - Ignoring profile 'sso-session Developers-219258050757' on line 11 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:14:59.931 [main] ProfileFileReader - Ignoring profile 'sso-session default' on line 7 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:14:59.932 [main] ProfileFileReader - Ignoring profile 'sso-session Developers-219258050757' on line 11 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:14:59.988 [main] ProfileFileReader - Ignoring profile 'sso-session default' on line 7 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:14:59.988 [main] ProfileFileReader - Ignoring profile 'sso-session Developers-219258050757' on line 11 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:15:00.060 [main] ProfileFileReader - Ignoring profile 'sso-session default' on line 7 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:15:00.060 [main] ProfileFileReader - Ignoring profile 'sso-session Developers-219258050757' on line 11 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:15:00.409 [main] ProfileFileReader - Ignoring profile 'sso-session default' on line 7 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:15:00.410 [main] ProfileFileReader - Ignoring profile 'sso-session Developers-219258050757' on line 11 because it did not start with 'profile ' and it was not 'default'.
[INFO ] 2023-05-19 18:15:00.727 [main] AbstractAWSResourceLifecycle - Created IotPolicy in IotLifecycle
[INFO ] 2023-05-19 18:15:01.892 [main] AbstractAWSResourceLifecycle - Created IamPolicy in IamLifecycle
[INFO ] 2023-05-19 18:15:02.457 [main] AbstractAWSResourceLifecycle - Created IamRole in IamLifecycle
[INFO ] 2023-05-19 18:15:02.751 [main] AbstractAWSResourceLifecycle - Created IotRoleAlias in IotLifecycle
[INFO ] 2023-05-19 18:15:02.855 [main] AbstractAWSResourceLifecycle - Created IotPolicy in IotLifecycle
[INFO ] 2023-05-19 18:15:02.965 [main] AbstractAWSResourceLifecycle - Created IotThingGroup in IotLifecycle
[INFO ] 2023-05-19 18:15:03.440 [main] AbstractAWSResourceLifecycle - Created IotCertificate in IotLifecycle
[INFO ] 2023-05-19 18:15:03.527 [main] AbstractAWSResourceLifecycle - Created IotThing in IotLifecycle
[INFO ] 2023-05-19 18:15:03.662 [main] feature - Finished step: 'my device is registered as a Thing' with status PASSED
[INFO ] 2023-05-19 18:15:04.505 [main] DefaultGreengrass - Starting Greengrass on pid 301341
[INFO ] 2023-05-19 18:15:04.505 [main] feature - Finished step: 'my device is running Greengrass' with status PASSED
[INFO ] 2023-05-19 18:15:06.679 [main] AbstractAWSResourceLifecycle - Created S3Bucket in S3Lifecycle
[INFO ] 2023-05-19 18:15:11.794 [main] AbstractAWSResourceLifecycle - Created S3Object in S3Lifecycle
[INFO ] 2023-05-19 18:15:11.795 [main] RecipeComponentPreparationService - Uploaded /tmp/gg-testing-15744393887570050675/0dd49efd50564325f2ed/components/aws.greengrass.client.Mqtt5JavaSdkClient/aws.greengrass.client.Mqtt5JavaSdkClient.jar to s3://gg-0dd49efd50564325f2ed-gg-component-store/greengrass/artifacts/aws.greengrass.client.Mqtt5JavaSdkClient.jar
[INFO ] 2023-05-19 18:15:12.642 [main] AbstractAWSResourceLifecycle - Created GreengrassComponent in GreengrassV2Lifecycle
[INFO ] 2023-05-19 18:15:12.643 [main] RecipeComponentPreparationService - Created component aws.greengrass.client.Mqtt5JavaSdkClient:1.0.0-0dd49efd50564325f2ed from /greengrass/components/recipes/client_java_sdk.yaml
[INFO ] 2023-05-19 18:15:12.644 [main] feature - Finished step: 'I create a Greengrass deployment with components' with status PASSED
[INFO ] 2023-05-19 18:15:12.857 [main] EngineControlImpl - MQTT client control gRPC server started, listening on 39003
[INFO ] 2023-05-19 18:15:12.858 [main] MqttControlSteps - MQTT clients control started gRPC service on port 39003 addresses [172.17.0.1, 172.25.32.127]
[INFO ] 2023-05-19 18:15:12.961 [main] AbstractAWSResourceLifecycle - Created IotPolicy in IotLifecycle
[INFO ] 2023-05-19 18:15:13.264 [main] AbstractAWSResourceLifecycle - Created IotCertificate in IotLifecycle
[INFO ] 2023-05-19 18:15:13.265 [main] AbstractAWSResourceLifecycle - Created IotThing in IotLifecycle
[INFO ] 2023-05-19 18:15:13.266 [main] feature - Finished step: 'I create client device "clientDeviceTest"' with status PASSED
[INFO ] 2023-05-19 18:15:13.361 [main] feature - Finished step: 'I associate "clientDeviceTest" with ggc' with status PASSED
[INFO ] 2023-05-19 18:15:13.378 [main] feature - Finished step: 'I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:' with status PASSED
[INFO ] 2023-05-19 18:15:13.380 [main] feature - Finished step: 'I update my Greengrass deployment configuration, setting the component aws.greengrass.client.Mqtt5JavaSdkClient configuration to:' with status PASSED
[INFO ] 2023-05-19 18:15:13.716 [main] AbstractAWSResourceLifecycle - Created GreengrassDeployment in GreengrassV2Lifecycle
[INFO ] 2023-05-19 18:15:13.716 [main] DeploymentSteps - Created Greengrass deployment: 3abbb31e-109f-4d19-bd8a-833a26ab0b76
[INFO ] 2023-05-19 18:15:13.716 [main] feature - Finished step: 'I deploy the Greengrass deployment configuration' with status PASSED
[INFO ] 2023-05-19 18:15:44.925 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId aws.greengrass.client.Mqtt5JavaSdkClient
[INFO ] 2023-05-19 18:15:45.017 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId aws.greengrass.client.Mqtt5JavaSdkClient address 172.25.32.127 port 46875
[INFO ] 2023-05-19 18:15:45.019 [grpc-default-executor-0] EngineControlImpl - Created new agent control for aws.greengrass.client.Mqtt5JavaSdkClient on 172.25.32.127:46875
[INFO ] 2023-05-19 18:15:45.062 [grpc-default-executor-0] MqttControlSteps - Agent aws.greengrass.client.Mqtt5JavaSdkClient is connected
[INFO ] 2023-05-19 18:15:53.151 [main] feature - Finished step: 'the Greengrass deployment is COMPLETED on the device after 300 seconds' with status PASSED
[INFO ] 2023-05-19 18:15:53.781 [main] MqttControlSteps - Discovered data for broker default_broker: 
[INFO ] 2023-05-19 18:15:53.781 [main] MqttControlSteps - groupId greengrassV2-coreDevice-gg-0dd49efd50564325f2ed-ggc-thing with 1 CA
[INFO ] 2023-05-19 18:15:53.782 [main] MqttControlSteps - Core with thing Arn arn:aws:iot:eu-central-1:285891398846:thing/gg-0dd49efd50564325f2ed-ggc-thing
[INFO ] 2023-05-19 18:15:53.782 [main] MqttControlSteps - Connectivity info: id 172.17.0.1 host 172.17.0.1 port 8883
[INFO ] 2023-05-19 18:15:53.782 [main] MqttControlSteps - Connectivity info: id 172.25.32.127 host 172.25.32.127 port 8883
[INFO ] 2023-05-19 18:15:53.783 [main] feature - Finished step: 'I discover core device broker as "default_broker" from "clientDeviceTest"' with status PASSED
[INFO ] 2023-05-19 18:15:53.784 [main] MqttControlSteps - Creating MQTT connection with broker default_broker to address 172.17.0.1:8883 as Thing gg-0dd49efd50564325f2ed-clientDeviceTest on aws.greengrass.client.Mqtt5JavaSdkClient MQTT v5
[INFO ] 2023-05-19 18:15:54.789 [main] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
reasonCode: 0
retainAvailable: true
maximumPacketSize: 268435455
wildcardSubscriptionsAvailable: true
subscriptionIdentifiersAvailable: true
sharedSubscriptionsAvailable: true
'
[INFO ] 2023-05-19 18:15:54.789 [main] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-05-19 18:15:54.789 [main] MqttControlSteps - Connection with broker default_broker established to address 172.17.0.1:8883 as Thing gg-0dd49efd50564325f2ed-clientDeviceTest on aws.greengrass.client.Mqtt5JavaSdkClient
[INFO ] 2023-05-19 18:15:54.789 [main] feature - Finished step: 'I connect device "clientDeviceTest" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker" using mqtt "v5"' with status PASSED
[INFO ] 2023-05-19 18:15:54.789 [main] feature - Finished step: 'I set MQTT5 'no local' to True' with status PASSED
[INFO ] 2023-05-19 18:15:54.790 [main] MqttControlSteps - Create MQTT subscription for Thing gg-0dd49efd50564325f2ed-clientDeviceTest to topics filter iot_data_0 with QoS 0
[INFO ] 2023-05-19 18:15:54.790 [main] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-05-19 18:15:54.802 [main] MqttControlSteps - MQTT subscription has on topics filter iot_data_0 been created with reason code 0
[INFO ] 2023-05-19 18:15:54.803 [main] feature - Finished step: 'I subscribe "clientDeviceTest" to "iot_data_0" with qos 0' with status PASSED
[INFO ] 2023-05-19 18:15:54.803 [main] MqttControlSteps - Publishing MQTT message Test message as Thing gg-0dd49efd50564325f2ed-clientDeviceTest to topics filter iot_data_0 with QoS 0
[INFO ] 2023-05-19 18:15:54.803 [main] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic iot_data_0
[INFO ] 2023-05-19 18:15:54.814 [main] MqttControlSteps - MQTT message Test message has been succesfully published
[INFO ] 2023-05-19 18:15:54.814 [main] feature - Finished step: 'I publish from "clientDeviceTest" to "iot_data_0" with qos 0 and message "Test message"' with status PASSED
[INFO ] 2023-05-19 18:15:54.815 [main] MqttControlSteps - Awaiting for MQTT message Test message on topic iot_data_0 on Thing gg-0dd49efd50564325f2ed-clientDeviceTest for 10 seconds
[INFO ] 2023-05-19 18:16:04.816 [main] feature - Finished step: 'message "Test message" received on "clientDeviceTest" from "iot_data_0" topic within 10 seconds is false expected' with status PASSED
[INFO ] 2023-05-19 18:16:05.498 [main] DefaultGreengrass - Stopped Greengrass on pid 301341
[INFO ] 2023-05-19 18:16:06.038 [main] AbstractAWSResourceLifecycle - Removed GreengrassDeployment in GreengrassV2Lifecycle
[INFO ] 2023-05-19 18:16:06.235 [main] AbstractAWSResourceLifecycle - Removed GreengrassComponent in GreengrassV2Lifecycle
[INFO ] 2023-05-19 18:16:06.453 [main] AbstractAWSResourceLifecycle - Removed S3Object in S3Lifecycle
[INFO ] 2023-05-19 18:16:06.956 [main] AbstractAWSResourceLifecycle - Removed S3Bucket in S3Lifecycle
[INFO ] 2023-05-19 18:16:08.184 [main] AbstractAWSResourceLifecycle - Removed IamRole in IamLifecycle
[INFO ] 2023-05-19 18:16:08.684 [main] AbstractAWSResourceLifecycle - Removed IamPolicy in IamLifecycle
[INFO ] 2023-05-19 18:16:08.828 [main] AbstractAWSResourceLifecycle - Removed IotThing in IotLifecycle
[INFO ] 2023-05-19 18:16:09.084 [main] AbstractAWSResourceLifecycle - Removed IotCertificate in IotLifecycle
[INFO ] 2023-05-19 18:16:09.208 [main] AbstractAWSResourceLifecycle - Removed IotPolicy in IotLifecycle
[INFO ] 2023-05-19 18:16:09.326 [main] AbstractAWSResourceLifecycle - Removed IotThing in IotLifecycle
[INFO ] 2023-05-19 18:16:09.621 [main] AbstractAWSResourceLifecycle - Removed IotCertificate in IotLifecycle
[INFO ] 2023-05-19 18:16:09.695 [main] AbstractAWSResourceLifecycle - Removed IotThingGroup in IotLifecycle
[INFO ] 2023-05-19 18:16:09.816 [main] AbstractAWSResourceLifecycle - Removed IotPolicy in IotLifecycle
[INFO ] 2023-05-19 18:16:09.887 [main] AbstractAWSResourceLifecycle - Removed IotRoleAlias in IotLifecycle
[INFO ] 2023-05-19 18:16:10.026 [main] AbstractAWSResourceLifecycle - Removed IotPolicy in IotLifecycle
[INFO ] 2023-05-19 18:16:10.027 [main] AWSResourcesSteps - Successfully removed externally created resources
[INFO ] 2023-05-19 18:16:10.028 [main] MqttControlSteps - Agent aws.greengrass.client.Mqtt5JavaSdkClient is disconnected
[INFO ] 2023-05-19 18:16:10.033 [main] EngineControlImpl - gRPC MQTT client control server stopped
[INFO ] 2023-05-19 18:16:10.038 [main] LoggerSteps - Clearing thread context on scenario: 'GGMQ-1-T100-sdk-java: Local broker supports 'no local' MQTT v5.0 feature'
[INFO ] 2023-05-19 18:16:10.045 [main] StepTrackingReporting - Passed: 'GGMQ-1-T100-sdk-java: Local broker supports 'no local' MQTT v5.0 feature'
[INFO ] 2023-05-19 18:16:10.153 [Thread-1] AWSResourcesCleanupModule - Cleaned up com.aws.greengrass.testing.resources.greengrass.GreengrassV2Lifecycle$$EnhancerByGuice$$22480187@676356d2
[INFO ] 2023-05-19 18:16:10.153 [Thread-1] AWSResourcesCleanupModule - Cleaned up com.aws.greengrass.testing.api.device.local.LocalDevice@2fbe26da
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
