### PR TITLE
fix(uat): resolve issue when control uses outdated address of restart

### DIFF
--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImpl.java
@@ -197,6 +197,17 @@ public class AgentControlImpl implements AgentControl {
     }
 
     /**
+     * Checks is agent receives request on that gRPC server address.
+     *
+     * @param the address address of gRPC server of agent (MQTT client)
+     * @param the port port of gRPC server of agent (MQTT client)
+     * @return true when address is the same
+     */
+    boolean isOnThatAddress(@NonNull String address, int port) {
+        return this.port == port && this.address.equals(address);
+    }
+
+    /**
      * Do MQTT subscription(s).
      *
      * @param subscribeRequest subscribe request

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
@@ -217,10 +217,8 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
 
     private void unregisterAllAgent() {
         agents.forEach((agentId, agentControl) -> {
-            if (agents.remove(agentId, agentControl)) {
-                if (engineEvents != null) {
-                    engineEvents.onAgentDeattached(agentControl);
-                }
+            if (agents.remove(agentId, agentControl) && engineEvents != null) {
+                engineEvents.onAgentDeattached(agentControl);
             }
         });
     }

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
@@ -164,10 +164,21 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
             });
 
         if (isNew[0]) {
+            // completely new agent
             logger.atInfo().log("Created new agent control for {} on {}:{}", agentId, address, port);
             agentControl.startAgent();
             if (engineEvents != null) {
                 engineEvents.onAgentAttached(agentControl);
+            }
+        } else {
+            // check agent is relocated after restart
+            if (agentControl.isOnThatAddress(address, port)) {
+                logger.atInfo().log("Agent {} on {}:{} send duplicated DiscoveryAgent", agentId, address, port);
+            } else {
+                logger.atInfo().log("Agent {} relocated to {}:{}", agentId, address, port);
+                agents.remove(agentId);
+                // recursion
+                onDiscoveryAgent(agentId, address, port);
             }
         }
     }
@@ -207,7 +218,7 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
     private void unregisterAllAgent() {
         agents.forEach((agentId, agentControl) -> {
             if (agents.remove(agentId, agentControl)) {
-                agentControl.stopAgent();
+                // agentControl.stopAgent();
                 if (engineEvents != null) {
                     engineEvents.onAgentDeattached(agentControl);
                 }

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
@@ -218,7 +218,6 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
     private void unregisterAllAgent() {
         agents.forEach((agentId, agentControl) -> {
             if (agents.remove(agentId, agentControl)) {
-                // agentControl.stopAgent();
                 if (engineEvents != null) {
                     engineEvents.onAgentDeattached(agentControl);
                 }

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -333,6 +333,7 @@ Feature: GGMQ-1
       | v3     | SUCCESS          | 0              | SUCCESS               |
       | v5     | NOT_AUTHORIZED   | 16             | GRANTED_QOS_1         |
 
+  @GGMQ-1-T14
   Scenario: GGMQ-1-T14: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic
     When I create a Greengrass deployment with components
       | aws.greengrass.clientdevices.Auth        | LATEST                                                        |


### PR DESCRIPTION
**Issue #, if available:**
resolve issue when control uses outdated address of restart

**Description of changes:**
- Fix bug in control when agent is restarted
- Add more tags in scenarios

**Why is this change necessary:**
'no local' feature should be tests

**How was this change tested:**
By running scenarios

**Test results:**
With sdk-java client
```
$ ./run_test_aws_T100_sdk.sh 
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
[INFO ] 2023-05-19 18:14:58.694 [main] GreengrassContextModule - Extracting greengrass-nucleus-latest.zip into /tmp/gg-testing-15744393887570050675/greengrass
[INFO ] 2023-05-19 18:14:59.371 [main] LoggerSteps - OTF Version is otf-1.1.0-SNAPSHOT
[INFO ] 2023-05-19 18:14:59.371 [main] LoggerSteps - Attaching thread context to scenario: 'GGMQ-1-T100-sdk-java: Local broker supports 'no local' MQTT v5.0 feature'
[WARN ] 2023-05-19 18:14:59.495 [main] ProfileFileReader - Ignoring profile 'sso-session default' on line 7 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:14:59.495 [main] ProfileFileReader - Ignoring profile 'sso-session Developers-219258050757' on line 11 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:14:59.931 [main] ProfileFileReader - Ignoring profile 'sso-session default' on line 7 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:14:59.932 [main] ProfileFileReader - Ignoring profile 'sso-session Developers-219258050757' on line 11 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:14:59.988 [main] ProfileFileReader - Ignoring profile 'sso-session default' on line 7 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:14:59.988 [main] ProfileFileReader - Ignoring profile 'sso-session Developers-219258050757' on line 11 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:15:00.060 [main] ProfileFileReader - Ignoring profile 'sso-session default' on line 7 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:15:00.060 [main] ProfileFileReader - Ignoring profile 'sso-session Developers-219258050757' on line 11 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:15:00.409 [main] ProfileFileReader - Ignoring profile 'sso-session default' on line 7 because it did not start with 'profile ' and it was not 'default'.
[WARN ] 2023-05-19 18:15:00.410 [main] ProfileFileReader - Ignoring profile 'sso-session Developers-219258050757' on line 11 because it did not start with 'profile ' and it was not 'default'.
[INFO ] 2023-05-19 18:15:00.727 [main] AbstractAWSResourceLifecycle - Created IotPolicy in IotLifecycle
[INFO ] 2023-05-19 18:15:01.892 [main] AbstractAWSResourceLifecycle - Created IamPolicy in IamLifecycle
[INFO ] 2023-05-19 18:15:02.457 [main] AbstractAWSResourceLifecycle - Created IamRole in IamLifecycle
[INFO ] 2023-05-19 18:15:02.751 [main] AbstractAWSResourceLifecycle - Created IotRoleAlias in IotLifecycle
[INFO ] 2023-05-19 18:15:02.855 [main] AbstractAWSResourceLifecycle - Created IotPolicy in IotLifecycle
[INFO ] 2023-05-19 18:15:02.965 [main] AbstractAWSResourceLifecycle - Created IotThingGroup in IotLifecycle
[INFO ] 2023-05-19 18:15:03.440 [main] AbstractAWSResourceLifecycle - Created IotCertificate in IotLifecycle
[INFO ] 2023-05-19 18:15:03.527 [main] AbstractAWSResourceLifecycle - Created IotThing in IotLifecycle
[INFO ] 2023-05-19 18:15:03.662 [main] feature - Finished step: 'my device is registered as a Thing' with status PASSED
[INFO ] 2023-05-19 18:15:04.505 [main] DefaultGreengrass - Starting Greengrass on pid 301341
[INFO ] 2023-05-19 18:15:04.505 [main] feature - Finished step: 'my device is running Greengrass' with status PASSED
[INFO ] 2023-05-19 18:15:06.679 [main] AbstractAWSResourceLifecycle - Created S3Bucket in S3Lifecycle
[INFO ] 2023-05-19 18:15:11.794 [main] AbstractAWSResourceLifecycle - Created S3Object in S3Lifecycle
[INFO ] 2023-05-19 18:15:11.795 [main] RecipeComponentPreparationService - Uploaded /tmp/gg-testing-15744393887570050675/0dd49efd50564325f2ed/components/aws.greengrass.client.Mqtt5JavaSdkClient/aws.greengrass.client.Mqtt5JavaSdkClient.jar to s3://gg-0dd49efd50564325f2ed-gg-component-store/greengrass/artifacts/aws.greengrass.client.Mqtt5JavaSdkClient.jar
[INFO ] 2023-05-19 18:15:12.642 [main] AbstractAWSResourceLifecycle - Created GreengrassComponent in GreengrassV2Lifecycle
[INFO ] 2023-05-19 18:15:12.643 [main] RecipeComponentPreparationService - Created component aws.greengrass.client.Mqtt5JavaSdkClient:1.0.0-0dd49efd50564325f2ed from /greengrass/components/recipes/client_java_sdk.yaml
[INFO ] 2023-05-19 18:15:12.644 [main] feature - Finished step: 'I create a Greengrass deployment with components' with status PASSED
[INFO ] 2023-05-19 18:15:12.857 [main] EngineControlImpl - MQTT client control gRPC server started, listening on 39003
[INFO ] 2023-05-19 18:15:12.858 [main] MqttControlSteps - MQTT clients control started gRPC service on port 39003 addresses [172.17.0.1, 172.25.32.127]
[INFO ] 2023-05-19 18:15:12.961 [main] AbstractAWSResourceLifecycle - Created IotPolicy in IotLifecycle
[INFO ] 2023-05-19 18:15:13.264 [main] AbstractAWSResourceLifecycle - Created IotCertificate in IotLifecycle
[INFO ] 2023-05-19 18:15:13.265 [main] AbstractAWSResourceLifecycle - Created IotThing in IotLifecycle
[INFO ] 2023-05-19 18:15:13.266 [main] feature - Finished step: 'I create client device "clientDeviceTest"' with status PASSED
[INFO ] 2023-05-19 18:15:13.361 [main] feature - Finished step: 'I associate "clientDeviceTest" with ggc' with status PASSED
[INFO ] 2023-05-19 18:15:13.378 [main] feature - Finished step: 'I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:' with status PASSED
[INFO ] 2023-05-19 18:15:13.380 [main] feature - Finished step: 'I update my Greengrass deployment configuration, setting the component aws.greengrass.client.Mqtt5JavaSdkClient configuration to:' with status PASSED
[INFO ] 2023-05-19 18:15:13.716 [main] AbstractAWSResourceLifecycle - Created GreengrassDeployment in GreengrassV2Lifecycle
[INFO ] 2023-05-19 18:15:13.716 [main] DeploymentSteps - Created Greengrass deployment: 3abbb31e-109f-4d19-bd8a-833a26ab0b76
[INFO ] 2023-05-19 18:15:13.716 [main] feature - Finished step: 'I deploy the Greengrass deployment configuration' with status PASSED
[INFO ] 2023-05-19 18:15:44.925 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId aws.greengrass.client.Mqtt5JavaSdkClient
[INFO ] 2023-05-19 18:15:45.017 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId aws.greengrass.client.Mqtt5JavaSdkClient address 172.25.32.127 port 46875
[INFO ] 2023-05-19 18:15:45.019 [grpc-default-executor-0] EngineControlImpl - Created new agent control for aws.greengrass.client.Mqtt5JavaSdkClient on 172.25.32.127:46875
[INFO ] 2023-05-19 18:15:45.062 [grpc-default-executor-0] MqttControlSteps - Agent aws.greengrass.client.Mqtt5JavaSdkClient is connected
[INFO ] 2023-05-19 18:15:53.151 [main] feature - Finished step: 'the Greengrass deployment is COMPLETED on the device after 300 seconds' with status PASSED
[INFO ] 2023-05-19 18:15:53.781 [main] MqttControlSteps - Discovered data for broker default_broker: 
[INFO ] 2023-05-19 18:15:53.781 [main] MqttControlSteps - groupId greengrassV2-coreDevice-gg-0dd49efd50564325f2ed-ggc-thing with 1 CA
[INFO ] 2023-05-19 18:15:53.782 [main] MqttControlSteps - Core with thing Arn arn:aws:iot:eu-central-1:285891398846:thing/gg-0dd49efd50564325f2ed-ggc-thing
[INFO ] 2023-05-19 18:15:53.782 [main] MqttControlSteps - Connectivity info: id 172.17.0.1 host 172.17.0.1 port 8883
[INFO ] 2023-05-19 18:15:53.782 [main] MqttControlSteps - Connectivity info: id 172.25.32.127 host 172.25.32.127 port 8883
[INFO ] 2023-05-19 18:15:53.783 [main] feature - Finished step: 'I discover core device broker as "default_broker" from "clientDeviceTest"' with status PASSED
[INFO ] 2023-05-19 18:15:53.784 [main] MqttControlSteps - Creating MQTT connection with broker default_broker to address 172.17.0.1:8883 as Thing gg-0dd49efd50564325f2ed-clientDeviceTest on aws.greengrass.client.Mqtt5JavaSdkClient MQTT v5
[INFO ] 2023-05-19 18:15:54.789 [main] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
reasonCode: 0
retainAvailable: true
maximumPacketSize: 268435455
wildcardSubscriptionsAvailable: true
subscriptionIdentifiersAvailable: true
sharedSubscriptionsAvailable: true
'
[INFO ] 2023-05-19 18:15:54.789 [main] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-05-19 18:15:54.789 [main] MqttControlSteps - Connection with broker default_broker established to address 172.17.0.1:8883 as Thing gg-0dd49efd50564325f2ed-clientDeviceTest on aws.greengrass.client.Mqtt5JavaSdkClient
[INFO ] 2023-05-19 18:15:54.789 [main] feature - Finished step: 'I connect device "clientDeviceTest" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker" using mqtt "v5"' with status PASSED
[INFO ] 2023-05-19 18:15:54.789 [main] feature - Finished step: 'I set MQTT5 'no local' to True' with status PASSED
[INFO ] 2023-05-19 18:15:54.790 [main] MqttControlSteps - Create MQTT subscription for Thing gg-0dd49efd50564325f2ed-clientDeviceTest to topics filter iot_data_0 with QoS 0
[INFO ] 2023-05-19 18:15:54.790 [main] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-05-19 18:15:54.802 [main] MqttControlSteps - MQTT subscription has on topics filter iot_data_0 been created with reason code 0
[INFO ] 2023-05-19 18:15:54.803 [main] feature - Finished step: 'I subscribe "clientDeviceTest" to "iot_data_0" with qos 0' with status PASSED
[INFO ] 2023-05-19 18:15:54.803 [main] MqttControlSteps - Publishing MQTT message Test message as Thing gg-0dd49efd50564325f2ed-clientDeviceTest to topics filter iot_data_0 with QoS 0
[INFO ] 2023-05-19 18:15:54.803 [main] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic iot_data_0
[INFO ] 2023-05-19 18:15:54.814 [main] MqttControlSteps - MQTT message Test message has been succesfully published
[INFO ] 2023-05-19 18:15:54.814 [main] feature - Finished step: 'I publish from "clientDeviceTest" to "iot_data_0" with qos 0 and message "Test message"' with status PASSED
[INFO ] 2023-05-19 18:15:54.815 [main] MqttControlSteps - Awaiting for MQTT message Test message on topic iot_data_0 on Thing gg-0dd49efd50564325f2ed-clientDeviceTest for 10 seconds
[INFO ] 2023-05-19 18:16:04.816 [main] feature - Finished step: 'message "Test message" received on "clientDeviceTest" from "iot_data_0" topic within 10 seconds is false expected' with status PASSED
[INFO ] 2023-05-19 18:16:05.498 [main] DefaultGreengrass - Stopped Greengrass on pid 301341
[INFO ] 2023-05-19 18:16:06.038 [main] AbstractAWSResourceLifecycle - Removed GreengrassDeployment in GreengrassV2Lifecycle
[INFO ] 2023-05-19 18:16:06.235 [main] AbstractAWSResourceLifecycle - Removed GreengrassComponent in GreengrassV2Lifecycle
[INFO ] 2023-05-19 18:16:06.453 [main] AbstractAWSResourceLifecycle - Removed S3Object in S3Lifecycle
[INFO ] 2023-05-19 18:16:06.956 [main] AbstractAWSResourceLifecycle - Removed S3Bucket in S3Lifecycle
[INFO ] 2023-05-19 18:16:08.184 [main] AbstractAWSResourceLifecycle - Removed IamRole in IamLifecycle
[INFO ] 2023-05-19 18:16:08.684 [main] AbstractAWSResourceLifecycle - Removed IamPolicy in IamLifecycle
[INFO ] 2023-05-19 18:16:08.828 [main] AbstractAWSResourceLifecycle - Removed IotThing in IotLifecycle
[INFO ] 2023-05-19 18:16:09.084 [main] AbstractAWSResourceLifecycle - Removed IotCertificate in IotLifecycle
[INFO ] 2023-05-19 18:16:09.208 [main] AbstractAWSResourceLifecycle - Removed IotPolicy in IotLifecycle
[INFO ] 2023-05-19 18:16:09.326 [main] AbstractAWSResourceLifecycle - Removed IotThing in IotLifecycle
[INFO ] 2023-05-19 18:16:09.621 [main] AbstractAWSResourceLifecycle - Removed IotCertificate in IotLifecycle
[INFO ] 2023-05-19 18:16:09.695 [main] AbstractAWSResourceLifecycle - Removed IotThingGroup in IotLifecycle
[INFO ] 2023-05-19 18:16:09.816 [main] AbstractAWSResourceLifecycle - Removed IotPolicy in IotLifecycle
[INFO ] 2023-05-19 18:16:09.887 [main] AbstractAWSResourceLifecycle - Removed IotRoleAlias in IotLifecycle
[INFO ] 2023-05-19 18:16:10.026 [main] AbstractAWSResourceLifecycle - Removed IotPolicy in IotLifecycle
[INFO ] 2023-05-19 18:16:10.027 [main] AWSResourcesSteps - Successfully removed externally created resources
[INFO ] 2023-05-19 18:16:10.028 [main] MqttControlSteps - Agent aws.greengrass.client.Mqtt5JavaSdkClient is disconnected
[INFO ] 2023-05-19 18:16:10.033 [main] EngineControlImpl - gRPC MQTT client control server stopped
[INFO ] 2023-05-19 18:16:10.038 [main] LoggerSteps - Clearing thread context on scenario: 'GGMQ-1-T100-sdk-java: Local broker supports 'no local' MQTT v5.0 feature'
[INFO ] 2023-05-19 18:16:10.045 [main] StepTrackingReporting - Passed: 'GGMQ-1-T100-sdk-java: Local broker supports 'no local' MQTT v5.0 feature'
[INFO ] 2023-05-19 18:16:10.153 [Thread-1] AWSResourcesCleanupModule - Cleaned up com.aws.greengrass.testing.resources.greengrass.GreengrassV2Lifecycle$$EnhancerByGuice$$22480187@676356d2
[INFO ] 2023-05-19 18:16:10.153 [Thread-1] AWSResourcesCleanupModule - Cleaned up com.aws.greengrass.testing.api.device.local.LocalDevice@2fbe26da
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
