### PR TITLE
feat(uat): t1 was extended with t2, t6 and t19

### DIFF
--- a/uat/README.md
+++ b/uat/README.md
@@ -75,6 +75,9 @@ java -Dggc.archive=./greengrass-nucleus-latest.zip -Dtest.log.path=./logs -Dtags
 
 Command arguments:
 
-Dggc.archive - path to the nucleus zip that was downloaded
-Dtest.log.path - path where you would like the test results to be stored
-
+Dggc.archive - path to the nucleus zip that was downloaded<br />
+Dtest.log.path - path where you would like the test results to be stored<br />
+Dtags can be extended, if you would like to test exact scenario, you can do as follows:<br />
+```bash
+java -Dggc.archive=./greengrass-nucleus-latest.zip -Dtest.log.path=./logs -Dtags="@GGMQ and @GGMQ-1-T1 and @sdk-java and @mqtt3" -jar uat/testing-features/target/client-devices-auth-testing-features.jar
+```

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -7,6 +7,7 @@ Feature: GGMQ-1
     Given my device is registered as a Thing
     And my device is running Greengrass
 
+  @GGMQ-1-T1
   Scenario Outline: GGMQ-1-T1-<mqtt-v>-<name>: As a customer, I can connect, subscribe, publish and receive using client application to MQTT topic
     When I create a Greengrass deployment with components
       | aws.greengrass.clientdevices.Auth        | LATEST                                            |
@@ -29,15 +30,24 @@ Feature: GGMQ-1
          },
          "policies":{
             "MyPermissivePolicy":{
-               "AllowAll":{
-                  "statementDescription":"Allow client devices to perform all actions.",
-                  "operations":[
-                     "*"
+               "AllowConnect": {
+                "statementDescription": "Allow client devices to connect.",
+                  "operations": [
+                    "mqtt:connect"
                   ],
-                  "resources":[
-                     "*"
+                  "resources": [
+                    "*"
                   ]
-               }
+                },
+                "AllowSubscribe": {
+                  "statementDescription": "Allow client devices to subscribe to iot_data_1.",
+                  "operations": [
+                      "mqtt:subscribe"
+                   ],
+                    "resources": [
+                    "*"
+                    ]
+                  }
             }
          }
       }
@@ -57,29 +67,83 @@ Feature: GGMQ-1
     Then the Greengrass deployment is COMPLETED on the device after 300 seconds
     And I discover core device broker as "default_broker" from "clientDeviceTest"
     And I connect device "clientDeviceTest" on <agent> to "default_broker" using mqtt "<mqtt-v>"
-    When I subscribe "clientDeviceTest" to "iot_data_0" with qos 0
-    When I publish from "clientDeviceTest" to "iot_data_0" with qos 0 and message "Test message"
-    And message "Test message" received on "clientDeviceTest" from "iot_data_0" topic within 5 seconds
+    When I subscribe "clientDeviceTest" to "iot_data_0" with qos 0 and expect status "<subscribe-status-q0>"
+    When I subscribe "clientDeviceTest" to "iot_data _1" with qos 1 and expect status "<subscribe-status-q1>"
+    When I publish from "clientDeviceTest" to "iot_data_0" with qos 0 and message "Hello world"
+    When I publish from "clientDeviceTest" to "iot_data_1" with qos 1 and message "Hello world" and expect status <publish-statusq1>
+    Then message "Hello world" received on "clientDeviceTest" from "iot_data_1" topic within 10 seconds is false expected
+    And I disconnect device "clientDeviceTest" with reason code 0
+    When I create a Greengrass deployment with components
+      | aws.greengrass.clientdevices.Auth        | LATEST |
+      | aws.greengrass.clientdevices.mqtt.EMQX   | LATEST |
+      | aws.greengrass.clientdevices.IPDetector  | LATEST |
+      | <agent>                                  | LATEST |
+    And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:
+    """
+{
+   "MERGE":{
+      "deviceGroups":{
+         "formatVersion":"2021-03-05",
+         "definitions":{
+            "PublisherDeviceGroup":{
+               "selectionRule": "thingName: ${clientDeviceTest}",
+               "policyName":"MyPermissivePublishPolicy"
+            }
+         },
+         "policies":{
+            "MyPermissivePublishPolicy":{
+                "AllowPublish": {
+                  "statementDescription": "Allow client devices to publish on test/topic.",
+                  "operations": [
+                  "mqtt:publish"
+                   ],
+                   "resources": [
+                      "mqtt:topic:iot_data_1"
+                   ]
+                  }
+            }
+         }
+      }
+   }
+}
+    """
+    And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.IPDetector configuration to:
+    """
+{
+   "MERGE":{
+      "includeIPv4LoopbackAddrs":"true"
+   }
+}
+    """
+    And I deploy the Greengrass deployment configuration
+    Then the Greengrass deployment is COMPLETED on the device after 120 seconds
+    And I connect device "clientDeviceTest" on <agent> to "default_broker" using mqtt "<mqtt-v>"
+    When I subscribe "clientDeviceTest" to "iot_data_0" with qos 0 and expect status "<subscribe-status-q0>"
+    When I subscribe "clientDeviceTest" to "iot_data_1" with qos 1 and expect status "<subscribe-status-q1>"
+    When I publish from "clientDeviceTest" to "iot_data_0" with qos 0 and message "Hello world" and expect status <publish-statusq10>
+    When I publish from "clientDeviceTest" to "iot_data_1" with qos 1 and message "Hello world"
+    Then message "Hello world" received on "clientDeviceTest" from "iot_data_0" topic within 10 seconds is false expected
+    Then message "Hello world" received on "clientDeviceTest" from "iot_data_1" topic within 10 seconds
 
     @mqtt3 @sdk-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
+      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q0 | subscribe-status-q1| publish-statusq1 | publish-statusq10 |
+      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    | SUCCESS             | SUCCESS            | 0                | 0                 |
 
     @mqtt3 @mosquitto-c
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
+      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q0 | subscribe-status-q1| publish-statusq1 | publish-statusq10 |
+      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | SUCCESS             | SUCCESS            | 0                | 0                 |
 
     @mqtt5 @sdk-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
+      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q0 | subscribe-status-q1| publish-statusq1 | publish-statusq10 |
+      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    | SUCCESS             | GRANTED_QOS_1      | 135              | 0                 |
 
     @mqtt5 @mosquitto-c
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
+      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q0 | subscribe-status-q1| publish-statusq1 | publish-statusq10 |
+      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | SUCCESS             | SUCCESS            | 0                | 0                 |
 
   Scenario Outline: GGMQ-1-T8-<mqtt-v>-<name>: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic
     When I start an assertion server


### PR DESCRIPTION
**Issue #, if available:**
Test scenario T1 was extended with T2, T6 and T19

**Description of changes:**
- T1 was extended with T2, T6 and T19

**Why is this change necessary:**
- required step for several test features

**How was this change tested:**
run command **mvn exec:java** in paho-agent module 

**Test results:**
```
    <testcase classname="GGMQ-1" name="GGMQ-1-T1-v3-sdk-java: As a customer, I can connect, subscribe, publish and receive using client application to MQTT topic" time="108.319">
        <system-out>
            <![CDATA[Given my device is registered as a Thing....................................passed
And my device is running Greengrass.........................................passed
When I create a Greengrass deployment with components.......................passed
And I create client device "clientDeviceTest"...............................passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:.passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.client.Mqtt5JavaSdkClient configuration to:.passed
When I associate "clientDeviceTest" with ggc................................passed
And I deploy the Greengrass deployment configuration........................passed
Then the Greengrass deployment is COMPLETED on the device after 300 seconds.passed
And I discover core device broker as "default_broker" from "clientDeviceTest".passed
And I connect device "clientDeviceTest" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker" using mqtt "v3".passed
When I subscribe "clientDeviceTest" to "iot_data_0" with qos 0 and expect status "SUCCESS".passed
When I subscribe "clientDeviceTest" to "iot_data _1" with qos 1 and expect status "SUCCESS".passed
When I publish from "clientDeviceTest" to "iot_data_0" with qos 0 and message "Hello world".passed
When I publish from "clientDeviceTest" to "iot_data_1" with qos 1 and message "Hello world" and expect status 0.passed
Then message "Hello world" received on "clientDeviceTest" from "iot_data_1" topic within 10 seconds is false expected.passed
And I disconnect device "clientDeviceTest" with reason code 0...............passed
When I create a Greengrass deployment with components.......................passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:.passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.IPDetector configuration to:.passed
And I deploy the Greengrass deployment configuration........................passed
Then the Greengrass deployment is COMPLETED on the device after 120 seconds.passed
And I connect device "clientDeviceTest" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker" using mqtt "v3".passed
When I subscribe "clientDeviceTest" to "iot_data_0" with qos 0 and expect status "SUCCESS".passed
When I subscribe "clientDeviceTest" to "iot_data_1" with qos 1 and expect status "SUCCESS".passed
When I publish from "clientDeviceTest" to "iot_data_0" with qos 0 and message "Hello world" and expect status 0.passed
When I publish from "clientDeviceTest" to "iot_data_1" with qos 1 and message "Hello world".passed
Then message "Hello world" received on "clientDeviceTest" from "iot_data_0" topic within 10 seconds is false expected.passed
Then message "Hello world" received on "clientDeviceTest" from "iot_data_1" topic within 10 seconds.passed
]]>

    <testcase classname="GGMQ-1" name="GGMQ-1-T1-v5-sdk-java: As a customer, I can connect, subscribe, publish and receive using client application to MQTT topic" time="144.821">
        <system-out>
            <![CDATA[Given my device is registered as a Thing....................................passed
And my device is running Greengrass.........................................passed
When I create a Greengrass deployment with components.......................passed
And I create client device "clientDeviceTest"...............................passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:.passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.client.Mqtt5JavaSdkClient configuration to:.passed
When I associate "clientDeviceTest" with ggc................................passed
And I deploy the Greengrass deployment configuration........................passed
Then the Greengrass deployment is COMPLETED on the device after 300 seconds.passed
And I discover core device broker as "default_broker" from "clientDeviceTest".passed
And I connect device "clientDeviceTest" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker" using mqtt "v5".passed
When I subscribe "clientDeviceTest" to "iot_data_0" with qos 0 and expect status "SUCCESS".passed
When I subscribe "clientDeviceTest" to "iot_data _1" with qos 1 and expect status "GRANTED_QOS_1".passed
When I publish from "clientDeviceTest" to "iot_data_0" with qos 0 and message "Hello world".passed
When I publish from "clientDeviceTest" to "iot_data_1" with qos 1 and message "Hello world" and expect status 135.passed
Then message "Hello world" received on "clientDeviceTest" from "iot_data_1" topic within 10 seconds is false expected.passed
And I disconnect device "clientDeviceTest" with reason code 0...............passed
When I create a Greengrass deployment with components.......................passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:.passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.IPDetector configuration to:.passed
And I deploy the Greengrass deployment configuration........................passed
Then the Greengrass deployment is COMPLETED on the device after 120 seconds.passed
And I connect device "clientDeviceTest" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker" using mqtt "v5".passed
When I subscribe "clientDeviceTest" to "iot_data_0" with qos 0 and expect status "SUCCESS".passed
When I subscribe "clientDeviceTest" to "iot_data_1" with qos 1 and expect status "GRANTED_QOS_1".passed
When I publish from "clientDeviceTest" to "iot_data_0" with qos 0 and message "Hello world" and expect status 0.passed
When I publish from "clientDeviceTest" to "iot_data_1" with qos 1 and message "Hello world".passed
Then message "Hello world" received on "clientDeviceTest" from "iot_data_0" topic within 10 seconds is false expected.passed
Then message "Hello world" received on "clientDeviceTest" from "iot_data_1" topic within 10 seconds.passed
]]>
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
