### PR TITLE
fix(uat): switch to OTF version 1.2.0-SNAPSHOT

### DIFF
--- a/uat/pom.xml
+++ b/uat/pom.xml
@@ -70,7 +70,7 @@
         <junit.version>5.9.2</junit.version>
         <mockito.version>3.2.0</mockito.version>
         <auto.service.version>1.0.1</auto.service.version>
-        <greengrass.testing.version>1.1.0-SNAPSHOT</greengrass.testing.version>
+        <greengrass.testing.version>1.2.0-SNAPSHOT</greengrass.testing.version>
         <wiremock.version>2.27.2</wiremock.version>
         <jackson.version>2.15.0</jackson.version>
         <!-- Plugin versions -->


### PR DESCRIPTION
**Issue #, if available:**
EMQX container doesn't stop between running different test scenarios

**Description of changes:**
- Switch to OTF version 1.2.0-SNAPSHOT with graceful stopping of Nucleus

**Why is this change necessary:**
Old OTF has a problem with kill -9 nucleus and children which leave docker components abandoned

**How was this change tested:**
Manually we observe problem is fixed

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
