### PR TITLE
fix(uat): fix random errors during running test scenarios

### DIFF
--- a/.license/style.xml
+++ b/.license/style.xml
@@ -27,7 +27,7 @@
         <padLines>false</padLines>
     </batch>
     <shell>
-        <firstLine># </firstLine>
+        <firstLine>#</firstLine>
         <beforeEachLine># </beforeEachLine>
         <endLine>#</endLine>
         <firstLineDetectionPattern>#(\\s|\\t)*.*$</firstLineDetectionPattern>

--- a/uat/custom-components/client-mosquitto-c/pom.xml
+++ b/uat/custom-components/client-mosquitto-c/pom.xml
@@ -61,6 +61,40 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>${license.plugin.version}</version>
+                <configuration>
+                    <licenseSets>
+                        <licenseSet>
+                            <header>../../../.license/header.txt</header>
+                            <headerDefinitions>
+                                <headerDefinition>../../../.license/style.xml</headerDefinition>
+                            </headerDefinitions>
+                            <useDefaultExcludes>true</useDefaultExcludes>
+                            <excludes>
+                                <exclude>*</exclude>
+                            </excludes>
+                        </licenseSet>
+                    </licenseSets>
+                    <mapping>
+                        <cpp>JAVA_STYLE</cpp>
+                        <h>JAVA_STYLE</h>
+                        <bat>BATCH</bat>
+                        <proto>JAVA_STYLE</proto>
+                        <txt>SHELL</txt>
+                    </mapping>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>${exec.plugin.version}</version>

--- a/uat/custom-components/client-mosquitto-c/scripts/export_docker_runner.sh
+++ b/uat/custom-components/client-mosquitto-c/scripts/export_docker_runner.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 
 docker save client-mosquitto-c:runner-amd64 | gzip > mosquitto-test-client.amd64.tar.gz

--- a/uat/custom-components/client-mosquitto-c/scripts/produce_docker_container.sh
+++ b/uat/custom-components/client-mosquitto-c/scripts/produce_docker_container.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 
 set -e
 

--- a/uat/custom-components/client-mosquitto-c/scripts/rebuild_docker.sh
+++ b/uat/custom-components/client-mosquitto-c/scripts/rebuild_docker.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 
 rm -rf proto && cp -a ../../proto proto
 

--- a/uat/custom-components/client-mosquitto-c/scripts/rebuild_linux_debug.sh
+++ b/uat/custom-components/client-mosquitto-c/scripts/rebuild_linux_debug.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 
 rm -rf build && mkdir -p build
 

--- a/uat/custom-components/client-mosquitto-c/scripts/rebuild_linux_prod.sh
+++ b/uat/custom-components/client-mosquitto-c/scripts/rebuild_linux_prod.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 
 rm -rf build && mkdir -p build
 

--- a/uat/custom-components/client-mosquitto-c/scripts/rebuild_windows.bat
+++ b/uat/custom-components/client-mosquitto-c/scripts/rebuild_windows.bat
@@ -1,3 +1,8 @@
+@REM -------------------------------
+@REM Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+@REM SPDX-License-Identifier: Apache-2.0
+@REM -------------------------------
+
 @rem TODO: add commands to build mosquitto-based agent on Windows
 
 exit 0

--- a/uat/custom-components/client-mosquitto-c/scripts/run_docker.sh
+++ b/uat/custom-components/client-mosquitto-c/scripts/run_docker.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 
 docker build -f Dockerfile --target runner -t client-mosquitto-c:runner-amd64 .
 

--- a/uat/custom-components/client-mosquitto-c/src/CMakeLists.txt
+++ b/uat/custom-components/client-mosquitto-c/src/CMakeLists.txt
@@ -1,3 +1,8 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
 function(GRPC_GENERATE PROTO_SRCS GRPC_SRCS DEST)
     foreach(FIL ${ARGN})
         get_filename_component(ABS_FIL ${FIL} ABSOLUTE)

--- a/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
@@ -177,7 +177,7 @@ Status GRPCControlServer::CreateMqttConnection(ServerContext *, const MqttConnec
 
         return Status::OK;
     } catch (MqttException & ex) {
-        loge("CreateMqttConnection: exception during connecting\n");
+        loge("CreateMqttConnection: exception during connecting: %s\n", ex.getMessage().c_str());
         return Status(StatusCode::INTERNAL, ex.getMessage());
     }
 }

--- a/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
@@ -427,11 +427,8 @@ std::string GRPCControlServer::getJoinedCA(const TLSSettings & tls_settings) {
     const RepeatedPtrField<std::string> & ca_list = tls_settings.calist();
 
     std::string result;
-    logd("Has %d items in calist\n", ca_list.size());
 
     for (const std::string & ca : ca_list) {
-        logd("CA has length %d\n", ca.length());
-
         if (!result.empty()) {
             result.append("\n");
         }
@@ -439,8 +436,6 @@ std::string GRPCControlServer::getJoinedCA(const TLSSettings & tls_settings) {
         result.append(ca);
 
     }
-
-    logd("Joined CAs length %d\n", result.length());
 
     return result;
 }

--- a/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
@@ -370,6 +370,7 @@ Status GRPCControlServer::SubscribeMqtt(ServerContext *, const MqttSubscribeRequ
     try {
         std::vector<int> reason_codes = connection->subscribe(timeout, subscription_id_ptr, filters, common_qos, common_retain_handling, common_no_local, common_retain_as_published);
         for (int reason_code : reason_codes) {
+            logd("subscribe reason code %d\n", reason_code);
             reply->add_reasoncodes(reason_code);
         }
 

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.cpp
@@ -170,6 +170,8 @@ ClientControl::Mqtt5ConnAck * MqttConnection::start(unsigned timeout) {
             // TODO: select TLS version with mosquitto_tls_opts_set();
             // NOTE: enable for tests only
             // mosquitto_tls_insecure_set(m_mosq, true);
+        } else {
+            logd("TLS credentials does not provided, continue without encryption\n");
         }
 
         // TODO
@@ -531,7 +533,7 @@ void MqttConnection::removeFile(std::string & file) {
 
 // FIXME: place credentials to temporary files is dangerous
 std::string MqttConnection::saveToTempFile(const std::string & content) {
-    char buffer[1024];
+    char buffer[L_tmpnam + 1];
     char * filename = tmpnam(buffer);                                   // TODO: replace unsafe tmpnam()
     if (filename) {
         FILE* fp = fopen(filename, "w");

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.cpp
@@ -52,6 +52,7 @@ public:
         : rc(MOSQ_ERR_SUCCESS), flags(0), props(0), mid(mid_), granted_qos(granted_qos_, granted_qos_ + qos_count_) {
         mosquitto_property_copy_all(&props, props_);
     }
+
     AsyncResult(const AsyncResult &) = delete;
     AsyncResult & operator=(const AsyncResult &) = delete;
 

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.cpp
@@ -347,7 +347,7 @@ std::vector<int> MqttConnection::subscribe(unsigned timeout, const int * subscri
     {
         std::ostringstream imploded;
         std::copy(filters.begin(), filters.end(), std::ostream_iterator<std::string>(imploded, " "));
-        logd("Subscribed on '%s' filters QoS %d message id %d\n", imploded.str().c_str(), qos, message_id);
+        logd("Subscribed on filters '%s' QoS %d no local %d retain as published %d retain handing %d with message id %d\n", imploded.str().c_str(), qos, no_local, retain_as_published, retain_handling, message_id);
     }
 
     mosquitto_property_free_all(&properties);
@@ -409,7 +409,7 @@ std::vector<int> MqttConnection::unsubscribe(unsigned timeout, const std::vector
     {
         std::ostringstream imploded;
         std::copy(filters.begin(), filters.end(), std::ostream_iterator<std::string>(imploded, " "));
-        logd("Unsubscribed from '%s' filters message id %d\n", imploded.str().c_str(), message_id);
+        logd("Unsubscribed from filters '%s' with message id %d\n", imploded.str().c_str(), message_id);
     }
 
     // NOTE: mosquitto does not provides result code(s) from unsubscribe; produce vector of successes
@@ -453,7 +453,7 @@ ClientControl::MqttPublishReply * MqttConnection::publish(unsigned timeout, int 
     std::shared_ptr<AsyncResult> result = request->waitForResult(timeout);
     removePendingRequestUnlocked(message_id);
 
-    logd("Published to '%s' QoS %d  id %d\n", topic.c_str(), qos, message_id);
+    logd("Published on topic '%s' QoS %d retain %d with message id %d\n", topic.c_str(), qos, is_retain, message_id);
     return convertToPublishReply(result->rc, result->props);
 }
 

--- a/uat/mqtt-client-control/pom.xml
+++ b/uat/mqtt-client-control/pom.xml
@@ -155,6 +155,7 @@
                     <arguments>
                         <argument>47619</argument>
                         <argument>true</argument>
+                        <argument>true</argument>
                     </arguments>
                 </configuration>
             </plugin>

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/AgentControl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/AgentControl.java
@@ -56,8 +56,10 @@ public interface AgentControl {
 
     /**
      * Stops the agent control.
+     *
+     * @param sendShutdown when set shutdown request will be sent to agent and all MQTT connection are closed
      */
-    void stopAgent();
+    void stopAgent(boolean sendShutdown);
 
     /**
      * Gets id of the agent.

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/addon/EventFilter.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/addon/EventFilter.java
@@ -26,6 +26,7 @@ public final class EventFilter {
     private final String topic;
     private final String topicFilter;
     private final byte[] content;
+    private final Boolean retain;
 
     EventFilter(Builder builder) {
         super();
@@ -39,6 +40,7 @@ public final class EventFilter {
         this.topic = builder.topic;
         this.topicFilter = builder.topicFilter;
         this.content = builder.content;
+        this.retain = builder.retain;
     }
 
     /**
@@ -55,6 +57,7 @@ public final class EventFilter {
         private String topic;
         private String topicFilter;
         private byte[] content;
+        private Boolean retain;
 
         /**
          * Sets type of event.
@@ -176,10 +179,21 @@ public final class EventFilter {
          * Applicable only for MQTT message events
          * Both withContent() set the same field
          *
-         * @param content the byte arrat content of MQTT message
+         * @param content the byte array content of MQTT message
          */
         public Builder withContent(@NonNull byte[] content) {
             this.content = content;
+            return this;
+        }
+
+        /**
+         * Sets retain flag.
+         * Applicable only for MQTT message events
+         *
+         * @param retain the retain flag of the message
+         */
+        public Builder withRetain(boolean retain) {
+            this.retain = retain;
             return this;
         }
 

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImpl.java
@@ -138,9 +138,11 @@ public class AgentControlImpl implements AgentControl {
     }
 
     @Override
-    public void stopAgent() {
-        closeAllMqttConnections();
-        disconnect();
+    public void stopAgent(boolean sendShutdown) {
+        if (sendShutdown) {
+            closeAllMqttConnections();
+        }
+        disconnect(sendShutdown);
     }
 
     @Override
@@ -311,14 +313,14 @@ public class AgentControlImpl implements AgentControl {
         });
     }
 
-    private void disconnect() {
+    private void disconnect(boolean sendShutdown) {
         if (!isDisconnected.getAndSet(true)) {
-            if (!isShutdownSent.getAndSet(true)) {
+            if (sendShutdown && !isShutdownSent.getAndSet(true)) {
                 shutdownAgent("none");
             }
             channel.shutdown();
             try {
-                channel.awaitTermination(1, TimeUnit.SECONDS);
+                channel.awaitTermination(10, TimeUnit.SECONDS);
             } catch (InterruptedException ex) {
                 Thread.currentThread().interrupt();
             }

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
@@ -187,10 +187,10 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
     public void onUnregisterAgent(@NonNull String agentId) {
         AgentControlImpl agentControl = agents.remove(agentId);
         if (agentControl != null) {
-            agentControl.stopAgent();
             if (engineEvents != null) {
                 engineEvents.onAgentDeattached(agentControl);
             }
+            agentControl.stopAgent();
         }
     }
 
@@ -217,8 +217,11 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
 
     private void unregisterAllAgent() {
         agents.forEach((agentId, agentControl) -> {
-            if (agents.remove(agentId, agentControl) && engineEvents != null) {
-                engineEvents.onAgentDeattached(agentControl);
+            if (agents.remove(agentId, agentControl)) {
+                agentControl.stopAgent();
+                if (engineEvents != null) {
+                    engineEvents.onAgentDeattached(agentControl);
+                }
             }
         });
     }

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
@@ -187,7 +187,7 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
     public void onUnregisterAgent(@NonNull String agentId) {
         AgentControlImpl agentControl = agents.remove(agentId);
         if (agentControl != null) {
-            agentControl.stopAgent();
+            agentControl.stopAgent(false);
             if (engineEvents != null) {
                 engineEvents.onAgentDeattached(agentControl);
             }
@@ -218,7 +218,7 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
     private void unregisterAllAgent() {
         agents.forEach((agentId, agentControl) -> {
             if (agents.remove(agentId, agentControl)) {
-                agentControl.stopAgent();
+                agentControl.stopAgent(true);
                 if (engineEvents != null) {
                     engineEvents.onAgentDeattached(agentControl);
                 }

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
@@ -187,10 +187,10 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
     public void onUnregisterAgent(@NonNull String agentId) {
         AgentControlImpl agentControl = agents.remove(agentId);
         if (agentControl != null) {
+            agentControl.stopAgent();
             if (engineEvents != null) {
                 engineEvents.onAgentDeattached(agentControl);
             }
-            agentControl.stopAgent();
         }
     }
 

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/SubscribeReasonCode.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/SubscribeReasonCode.java
@@ -16,7 +16,7 @@ public enum SubscribeReasonCode {
      * the maximum QoS sent will be QoS 0.
      * This might be a lower QoS than was requested.
      */
-    SUCCESS(0),
+    GRANTED_QOS_0(0),
 
     /**
      * Returned when the subscription is accepted and
@@ -24,6 +24,13 @@ public enum SubscribeReasonCode {
      * This might be a lower QoS than was requested.
      */
     GRANTED_QOS_1(1),
+
+    /**
+     * Returned when the subscription is accepted and
+     * the maximum QoS sent will be QoS 2.
+     * This might be a lower QoS than was requested.
+     */
+    GRANTED_QOS_2(2),
 
     /**
      * Returned when the subscription is not accepted and the Server either does not wish to reveal the reason

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/addon/MqttMessageEvent.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/addon/MqttMessageEvent.java
@@ -70,6 +70,11 @@ public class MqttMessageEvent extends EventImpl {
             }
         }
 
+        matched = isRetainMatched(filter.getRetain());
+        if (!matched) {
+            return false;
+        }
+
         // TODO: check QoS ?
 
         // check content
@@ -107,6 +112,10 @@ public class MqttMessageEvent extends EventImpl {
         } else {
             return Arrays.equals(expected, byteStringPayload.toByteArray());
         }
+    }
+
+    private boolean isRetainMatched(Boolean retain) {
+        return retain == null || retain == message.getRetain();
     }
 
     private static boolean isTopicMatched(@NonNull String topic, @NonNull String topicFilter) {

--- a/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImplTest.java
+++ b/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImplTest.java
@@ -65,7 +65,7 @@ class AgentControlImplTest {
 
     @AfterEach
     void teardown() {
-        agentControl.stopAgent();
+        agentControl.stopAgent(false);
     }
 
     @Test

--- a/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImplTest.java
+++ b/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImplTest.java
@@ -267,7 +267,7 @@ class EngineControlImplTest {
 
         // THEN
         assertNull(engineControl.getAgent(agentId));
-        verify(agentControl, times(1)).stopAgent();
+        verify(agentControl, times(1)).stopAgent(false);
         verify(engineEvents).onAgentDeattached(eq(agentControl));
     }
 

--- a/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/addon/MqttMessageEventTest.java
+++ b/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/addon/MqttMessageEventTest.java
@@ -236,4 +236,100 @@ class MqttMessageEventTest {
         verify(message).getTopic();
         verify(message).getPayload();
     }
+
+    @Test
+    void GIVEN_retain_and_matched_filter_WHEN_is_matched_THEN_is() {
+        // GIVEN
+        final long testRunTimestamp = System.currentTimeMillis();
+        final boolean retain = true;
+
+        lenient().when(message.getRetain()).thenReturn(retain);
+
+        EventFilter eventFilter = new EventFilter.Builder()
+                                        .withType(Event.Type.EVENT_TYPE_MQTT_MESSAGE)
+                                        .withToTimestamp(testRunTimestamp)
+                                        .withConnectionControl(connectionControl)
+                                        .withRetain(retain)
+                                        .build();
+
+
+        // WHEN
+        boolean result = mqttMessageEvent.isMatched(eventFilter);
+
+        // THEN
+        assertTrue(result);
+        verify(message).getRetain();
+    }
+
+    @Test
+    void GIVEN_not_retain_and_matched_filter_WHEN_is_matched_THEN_is() {
+        // GIVEN
+        final long testRunTimestamp = System.currentTimeMillis();
+        final boolean retain = false;
+
+        lenient().when(message.getRetain()).thenReturn(retain);
+
+        EventFilter eventFilter = new EventFilter.Builder()
+                                        .withType(Event.Type.EVENT_TYPE_MQTT_MESSAGE)
+                                        .withToTimestamp(testRunTimestamp)
+                                        .withConnectionControl(connectionControl)
+                                        .withRetain(retain)
+                                        .build();
+
+
+        // WHEN
+        boolean result = mqttMessageEvent.isMatched(eventFilter);
+
+        // THEN
+        assertTrue(result);
+        verify(message).getRetain();
+    }
+
+    @Test
+    void GIVEN_retain_and_not_matched_filter_WHEN_is_matched_THEN_is_not() {
+        // GIVEN
+        final long testRunTimestamp = System.currentTimeMillis();
+        final boolean retain = true;
+
+        lenient().when(message.getRetain()).thenReturn(retain);
+
+        EventFilter eventFilter = new EventFilter.Builder()
+                                        .withType(Event.Type.EVENT_TYPE_MQTT_MESSAGE)
+                                        .withToTimestamp(testRunTimestamp)
+                                        .withConnectionControl(connectionControl)
+                                        .withRetain(!retain)
+                                        .build();
+
+
+        // WHEN
+        boolean result = mqttMessageEvent.isMatched(eventFilter);
+
+        // THEN
+        assertFalse(result);
+        verify(message).getRetain();
+    }
+
+    @Test
+    void GIVEN_not_retain_and_not_matched_filter_WHEN_is_matched_THEN_is_not() {
+        // GIVEN
+        final long testRunTimestamp = System.currentTimeMillis();
+        final boolean retain = false;
+
+        lenient().when(message.getRetain()).thenReturn(retain);
+
+        EventFilter eventFilter = new EventFilter.Builder()
+                                        .withType(Event.Type.EVENT_TYPE_MQTT_MESSAGE)
+                                        .withToTimestamp(testRunTimestamp)
+                                        .withConnectionControl(connectionControl)
+                                        .withRetain(!retain)
+                                        .build();
+
+
+        // WHEN
+        boolean result = mqttMessageEvent.isMatched(eventFilter);
+
+        // THEN
+        assertFalse(result);
+        verify(message).getRetain();
+    }
 }

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -438,7 +438,7 @@ public class MqttControlSteps {
         final String filter = scenarioContext.applyInline(topicFilterString);
 
         // do subscription
-        log.info("Create MQTT subscription for Thing {} to topics filter {} with QoS {} subscribeNoLocal {} "
+        log.info("Create MQTT subscription for Thing {} to topics filter {} with QoS {} no local {} "
                     + "retain handling {} ", clientDeviceThingName, filter, qos, subscribeNoLocal,
                     subscribeRetainHandling);
 

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -91,7 +91,6 @@ public class MqttControlSteps {
     private static final int DEFAULT_CONTROL_GRPC_PORT = 0;
     private static final String MQTT_CONTROL_PORT_KEY = "mqttControlPort";
 
-
     private static final int MIN_QOS = 0;
     private static final int MAX_QOS = 2;
 
@@ -288,7 +287,7 @@ public class MqttControlSteps {
             final List<String> caList = broker.getCaList();
             final String host = broker.getHost();
             final Integer port = broker.getPort();
-            log.info("Creating MQTT connection with broker {} to address {}:{} as Thing {} on {} MQTT {}",
+            log.info("Creating MQTT connection with broker {} to address {}:{} as Thing {} on {} using MQTT {}",
                      brokerId, host, port, clientDeviceThingName, componentId, mqttVersion);
             MqttConnectRequest request = buildMqttConnectRequest(
                     clientDeviceThingName, caList, host, port, version);
@@ -359,10 +358,9 @@ public class MqttControlSteps {
      * @param subscribeRetainAsPublished the new values of 'retain as published' flag.
      */
     @And("I set MQTT subscribe retain as published flag to {booleanValue}")
-    public void setSubscribeNoLocal(Boolean subscribeRetainAsPublished) {
+    public void setSubscribeRetainAsPublished(Boolean subscribeRetainAsPublished) {
         this.subscribeRetainAsPublished = subscribeRetainAsPublished;
     }
-
 
 
     /**
@@ -603,14 +601,14 @@ public class MqttControlSteps {
     }
 
     /**
-     * Discover IoT core device broker.
+     * Discover IoT core device broker directly in OTF.
      *
      * @param brokerId       broker name in tests
      * @param clientDeviceId user defined client device id
      * @throws ExecutionException   thrown when future completed exceptionally
      * @throws InterruptedException thrown when the current thread was interrupted while waiting
      */
-    @And("I discover core device broker as {string} from {string}")
+    @And("I discover core device broker as {string} from {string} in OTF")
     public void discoverCoreDeviceBroker(String brokerId, String clientDeviceId)
             throws ExecutionException, InterruptedException {
         final String clientDeviceThingName = getClientDeviceThingName(clientDeviceId);
@@ -640,7 +638,7 @@ public class MqttControlSteps {
      *
      * @param brokerId broker name in tests
      */
-    @And("I label IoT core broker as {string}")
+    @And("I label IoT Core broker as {string}")
     public void discoverCoreDeviceBroker(String brokerId) {
         final String endpoint = resources.lifecycle(IotLifecycle.class)
                                          .dataEndpoint();
@@ -648,6 +646,7 @@ public class MqttControlSteps {
         MqttBrokerConnectionInfo broker = new MqttBrokerConnectionInfo(
                 endpoint, IOT_CORE_MQTT_PORT, Collections.singletonList(ca));
         brokers.put(brokerId, Collections.singletonList(broker));
+        log.info("Added IoT Core broker as {} with endpoint {}:{}", brokerId, endpoint, IOT_CORE_MQTT_PORT);
     }
 
     /**

--- a/uat/testing-features/src/main/resources/greengrass/components/recipes/client_mosquitto_c.yaml
+++ b/uat/testing-features/src/main/resources/greengrass/components/recipes/client_mosquitto_c.yaml
@@ -10,11 +10,11 @@ ComponentDescription: MQTT 5.0/3.1.1 client based on Mosquitto C library
 ComponentPublisher: Amazon
 ComponentConfiguration:
   DefaultConfiguration:
+    # agentId should be the same as ComponentName
     agentId: aws.greengrass.client.MqttMosquittoClient
     controlAddresses: 127.0.0.1
     controlPort: 47619
     requiresPrivilege: false
-    startupTimeoutSeconds: 60
 Manifests:
   - Artifacts:
       - URI: classpath:/greengrass/artifacts/mosquitto-test-client.amd64.tar.gz
@@ -25,7 +25,9 @@ Manifests:
       Install:
         RequiresPrivilege: "{configuration:/requiresPrivilege}"
         Script: |
-          docker rmi client-mosquitto-c:runner-amd64
+          docker stop client-mosquitto-c
+          docker rmi --force client-mosquitto-c:runner-amd64
           docker load --input {artifacts:path}/mosquitto-test-client.amd64.tar.gz
       Run:
+        RequiresPrivilege: "{configuration:/requiresPrivilege}"
         Script: docker run --rm --name=client-mosquitto-c client-mosquitto-c:runner-amd64 "{configuration:/agentId}" "{configuration:/controlPort}" {configuration:/controlAddresses}

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -70,7 +70,7 @@ Feature: GGMQ-1
     When I subscribe "clientDeviceTest" to "iot_data_0" with qos 0 and expect status "<subscribe-status-q0>"
     When I subscribe "clientDeviceTest" to "iot_data _1" with qos 1 and expect status "<subscribe-status-q1>"
     When I publish from "clientDeviceTest" to "iot_data_0" with qos 0 and message "Hello world"
-    When I publish from "clientDeviceTest" to "iot_data_1" with qos 1 and message "Hello world" and expect status <publish-statusq1> and retain false
+    When I publish from "clientDeviceTest" to "iot_data_1" with qos 1 and message "Hello world" and expect status <publish-statusq1>
     Then message "Hello world" received on "clientDeviceTest" from "iot_data_1" topic within 10 seconds is false expected
     And I disconnect device "clientDeviceTest" with reason code 0
     When I create a Greengrass deployment with components
@@ -120,7 +120,7 @@ Feature: GGMQ-1
     And I connect device "clientDeviceTest" on <agent> to "default_broker" using mqtt "<mqtt-v>"
     When I subscribe "clientDeviceTest" to "iot_data_0" with qos 0 and expect status "<subscribe-status-q0>"
     When I subscribe "clientDeviceTest" to "iot_data_1" with qos 1 and expect status "<subscribe-status-q1>"
-    When I publish from "clientDeviceTest" to "iot_data_0" with qos 0 and message "Hello world" and expect status <publish-statusq10> and retain false
+    When I publish from "clientDeviceTest" to "iot_data_0" with qos 0 and message "Hello world" and expect status <publish-statusq10>
     When I publish from "clientDeviceTest" to "iot_data_1" with qos 1 and message "Hello world"
     Then message "Hello world" received on "clientDeviceTest" from "iot_data_0" topic within 10 seconds is false expected
     Then message "Hello world" received on "clientDeviceTest" from "iot_data_1" topic within 10 seconds
@@ -347,7 +347,7 @@ Feature: GGMQ-1
     When I subscribe "subscriber" to "iot_data_0" with qos 0 and expect status "<subscribe-status>"
     When I subscribe "subscriber" to "iot_data_1" with qos 1 and expect status "<subscribe-status>"
     When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world"
-    When I publish from "publisher" to "iot_data_1" with qos 1 and message "Hello world" and expect status <publish-status> and retain false
+    When I publish from "publisher" to "iot_data_1" with qos 1 and message "Hello world" and expect status <publish-status>
     Then message "Hello world" received on "subscriber" from "iot_data_1" topic within 10 seconds is false expected
     And I disconnect device "subscriber" with reason code 0
     And I disconnect device "publisher" with reason code 0
@@ -398,9 +398,9 @@ Feature: GGMQ-1
     Then message "Hello world" received on "subscriber" from "iot_data_1" topic within 10 seconds
 
     @mqtt3 @sdk-java
-     Examples:
-       | mqtt-v | subscribe-status | publish-status | subscribe-status-auth |
-       | v3     | SUCCESS          | 0              | SUCCESS               |
+    Examples:
+      | mqtt-v | subscribe-status | publish-status | subscribe-status-auth |
+      | v3     | SUCCESS          | 0              | SUCCESS               |
 
     @mqtt5 @sdk-java
     Examples:
@@ -409,13 +409,13 @@ Feature: GGMQ-1
 
 
   @GGMQ-1-T14
-  Scenario: GGMQ-1-T14: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic
+  Scenario Outline: GGMQ-1-T14-<mqtt-v>-<name>: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic
     When I create a Greengrass deployment with components
-      | aws.greengrass.clientdevices.Auth        | LATEST                                                        |
-      | aws.greengrass.clientdevices.mqtt.EMQX   | LATEST                                                        |
-      | aws.greengrass.clientdevices.IPDetector  | LATEST                                                        |
-      | aws.greengrass.clientdevices.mqtt.Bridge | LATEST                                                        |
-      | aws.greengrass.client.Mqtt5JavaSdkClient | classpath:/greengrass/components/recipes/client_java_sdk.yaml |
+      | aws.greengrass.clientdevices.Auth        | LATEST                                            |
+      | aws.greengrass.clientdevices.mqtt.EMQX   | LATEST                                            |
+      | aws.greengrass.clientdevices.IPDetector  | LATEST                                            |
+      | aws.greengrass.clientdevices.mqtt.Bridge | LATEST                                            |
+      | <agent>                                  | classpath:/greengrass/components/recipes/<recipe> |
     And I create client device "localMqttSubscriber"
     And I create client device "iotCorePublisher"
     When I associate "localMqttSubscriber" with ggc
@@ -448,11 +448,10 @@ Feature: GGMQ-1
    }
 }
     """
-    And I update my Greengrass deployment configuration, setting the component aws.greengrass.client.Mqtt5JavaSdkClient configuration to:
+    And I update my Greengrass deployment configuration, setting the component <agent> configuration to:
     """
 {
    "MERGE":{
-      "agentId":"aws.greengrass.client.Mqtt5JavaSdkClient",
       "controlAddresses":"${mqttControlAddresses}",
       "controlPort":"${mqttControlPort}"
    }
@@ -492,8 +491,8 @@ Feature: GGMQ-1
     Then the Greengrass deployment is COMPLETED on the device after 300 seconds
     When I discover core device broker as "localBroker" from "localMqttSubscriber"
     And I label IoT core broker as "iotCoreBroker"
-    And I connect device "localMqttSubscriber" on aws.greengrass.client.Mqtt5JavaSdkClient to "localBroker"
-    And I connect device "iotCorePublisher" on aws.greengrass.client.Mqtt5JavaSdkClient to "iotCoreBroker"
+    And I connect device "localMqttSubscriber" on <agent> to "localBroker" using mqtt "<mqtt-v>"
+    And I connect device "iotCorePublisher" on <agent> to "iotCoreBroker" using mqtt "<mqtt-v>"
     And I subscribe "localMqttSubscriber" to "${localMqttSubscriber}topic/to/localmqtt" with qos 1
     And I subscribe "localMqttSubscriber" to "${localMqttSubscriber}topic/device2/#" with qos 1
     And I subscribe "localMqttSubscriber" to "${localMqttSubscriber}topic/+/humidity" with qos 1
@@ -506,6 +505,26 @@ Feature: GGMQ-1
     Then message "T=100C" received on "localMqttSubscriber" from "${localMqttSubscriber}topic/device2/temperature" topic within 10 seconds
     When I publish from "iotCorePublisher" to "${localMqttSubscriber}topic/with/prefix" with qos 1 and message "Hello world"
     Then message "Hello world" received on "localMqttSubscriber" from "prefix/${localMqttSubscriber}topic/with/prefix" topic within 10 seconds
+
+    @mqtt3 @sdk-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
+
+    @mqtt3 @mosquitto-c
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
+
+    @mqtt5 @sdk-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
+
+    @mqtt5 @mosquitto-c
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
 
 
   @GGMQ-1-T101
@@ -559,35 +578,49 @@ Feature: GGMQ-1
     """
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 300 seconds
-    Then I discover core device broker as "localMqttBroker" from "publisher"
-    Then I discover core device broker as "localMqttBroker" from "subscriber"
-    And I connect device "publisher" on <agent> to "localMqttBroker" using mqtt "<mqtt-v>"
-    And I connect device "subscriber" on <agent> to "localMqttBroker" using mqtt "<mqtt-v>"
+    Then I discover core device broker as "localMqttBroker1" from "publisher"
+    Then I discover core device broker as "localMqttBroker2" from "subscriber"
+    And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
+    And I connect device "subscriber" on <agent> to "localMqttBroker2" using mqtt "<mqtt-v>"
 
-    When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world" and expect status 0 and retain true
-    When I subscribe "subscriber" to "iot_data_0" with qos 0 with retainHandling 0
+    And I set MQTT publish retain flag to true
+
+    When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world"
+    And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION"
+    When I subscribe "subscriber" to "iot_data_0" with qos 0
     And message "Hello world" received on "subscriber" from "iot_data_0" topic within 5 seconds
-    When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world" and expect status 0 and retain true
-    When I subscribe "subscriber" to "iot_data_1" with qos 0 with retainHandling 1
+
+    When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world"
+    And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_NEW_SUBSCRIPTION"
+    When I subscribe "subscriber" to "iot_data_1" with qos 0
     And message "Hello world" received on "subscriber" from "iot_data_1" topic within 5 seconds
-    When I publish from "publisher" to "iot_data_2" with qos 0 and message "Hello world" and expect status 0 and retain true
-    When I subscribe "subscriber" to "iot_data_2" with qos 0 with retainHandling 2
+
+    When I publish from "publisher" to "iot_data_2" with qos 0 and message "Hello world"
+    And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_DO_NOT_SEND_AT_SUBSCRIPTION"
+    When I subscribe "subscriber" to "iot_data_2" with qos 0
     And message "Hello world" received on "subscriber" from "iot_data_2" topic within 5 seconds is <retainHandling-2> expected
 
-    When I publish from "publisher" to "iot_data_3" with qos 0 and message "Hello world" and expect status 0 and retain false
-    When I subscribe "subscriber" to "iot_data_3" with qos 0 with retainHandling 0
+    And I set MQTT publish retain flag to false
+
+    When I publish from "publisher" to "iot_data_3" with qos 0 and message "Hello world"
+    And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION"
+    When I subscribe "subscriber" to "iot_data_3" with qos 0
     And message "Hello world" received on "subscriber" from "iot_data_3" topic within 5 seconds is false expected
-    When I publish from "publisher" to "iot_data_4" with qos 0 and message "Hello world" and expect status 0 and retain false
-    When I subscribe "subscriber" to "iot_data_4" with qos 0 with retainHandling 1
+
+    When I publish from "publisher" to "iot_data_4" with qos 0 and message "Hello world"
+    And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_NEW_SUBSCRIPTION"
+    When I subscribe "subscriber" to "iot_data_4" with qos 0
     And message "Hello world" received on "subscriber" from "iot_data_4" topic within 5 seconds is false expected
-    When I publish from "publisher" to "iot_data_5" with qos 0 and message "Hello world" and expect status 0 and retain false
-    When I subscribe "subscriber" to "iot_data_5" with qos 0 with retainHandling 2
+
+    When I publish from "publisher" to "iot_data_5" with qos 0 and message "Hello world"
+    And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_DO_NOT_SEND_AT_SUBSCRIPTION"
+    When I subscribe "subscriber" to "iot_data_5" with qos 0
     And message "Hello world" received on "subscriber" from "iot_data_5" topic within 5 seconds is false expected
 
     @mqtt3 @sdk-java
     Examples:
-      | mqtt-v | name     | agent                                    | recipe               | retainHandling-2 |
-      | v3     | sdk-java | aws.greengrass.client.Mqtt5JavaSdkClient | client_java_sdk.yaml | true             |
+      | mqtt-v | name     | agent                                      | recipe               | retainHandling-2  |
+      | v3     | sdk-java | aws.greengrass.client.Mqtt5JavaSdkClient   | client_java_sdk.yaml | true              |
 
     @mqtt3 @paho-java
     Examples:
@@ -596,8 +629,8 @@ Feature: GGMQ-1
 
     @mqtt5 @sdk-java
     Examples:
-      | mqtt-v | name     | agent                                    | recipe               | retainHandling-2 |
-      | v5     | sdk-java | aws.greengrass.client.Mqtt5JavaSdkClient | client_java_sdk.yaml | false            |
+      | mqtt-v | name     | agent                                      | recipe               | retainHandling-2  |
+      | v5     | sdk-java | aws.greengrass.client.Mqtt5JavaSdkClient   | client_java_sdk.yaml | false             |
 
     @mqtt5 @paho-java
     Examples:

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -532,7 +532,7 @@ Feature: GGMQ-1
 
 
   @GGMQ-1-T101
-  Scenario Outline: GGMQ-1-T101-<mqtt-v>-<name>: As a customer, I can configure retain flag and retain handling
+  Scenario Outline: GGMQ-1-T101-<mqtt-v>-<name>: As a customer, I can use publish retain flag and subscribe retain handling as expected
     When I create a Greengrass deployment with components
       | aws.greengrass.clientdevices.Auth       | LATEST                                            |
       | aws.greengrass.clientdevices.mqtt.EMQX  | LATEST                                            |
@@ -623,20 +623,30 @@ Feature: GGMQ-1
 
     @mqtt3 @sdk-java
     Examples:
-      | mqtt-v | name     | agent                                      | recipe               | retainHandling-2  |
-      | v3     | sdk-java | aws.greengrass.client.Mqtt5JavaSdkClient   | client_java_sdk.yaml | true              |
+      | mqtt-v | name        | agent                                     | recipe                  | retainHandling-2 |
+      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    | true             |
 
     @mqtt3 @paho-java
     Examples:
-      | mqtt-v | name      | agent                                     | recipe                | retainHandling-2 |
-      | v3     | paho-java | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml | true             |
+      | mqtt-v | name        | agent                                     | recipe                  | retainHandling-2 |
+      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   | true             |
+
+    @mqtt3 @mosquitto-c
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  | retainHandling-2 |
+      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | true             |
 
     @mqtt5 @sdk-java
     Examples:
-      | mqtt-v | name     | agent                                      | recipe               | retainHandling-2  |
-      | v5     | sdk-java | aws.greengrass.client.Mqtt5JavaSdkClient   | client_java_sdk.yaml | false             |
+      | mqtt-v | name        | agent                                     | recipe                  | retainHandling-2 |
+      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    | false            |
 
     @mqtt5 @paho-java
     Examples:
-      | mqtt-v | name      | agent                                     | recipe                | retainHandling-2 |
-      | v5     | paho-java | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml | false            |
+      | mqtt-v | name        | agent                                     | recipe                  | retainHandling-2 |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   | false            |
+
+    @mqtt5 @mosquitto-c
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  | retainHandling-2 |
+      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | false            |

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -58,7 +58,7 @@ Feature: GGMQ-1
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 300 seconds
 
-    And I discover core device broker as "default_broker" from "clientDeviceTest"
+    And I discover core device broker as "default_broker" from "clientDeviceTest" in OTF
     And I connect device "clientDeviceTest" on <agent> to "default_broker" using mqtt "<mqtt-v>"
 
     When I subscribe "clientDeviceTest" to "iot_data_0" with qos 0 and expect status "GRANTED_QOS_0"
@@ -193,17 +193,25 @@ Feature: GGMQ-1
     """
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 300 seconds
-    Then I discover core device broker as "localMqttBroker" from "publisher" in OTF
-    And I connect device "publisher" on <agent> to "localMqttBroker" using mqtt "<mqtt-v>"
+    Then I discover core device broker as "default_broker" from "publisher" in OTF
+
+    And I connect device "publisher" on <agent> to "default_broker" using mqtt "<mqtt-v>"
     And I wait 5 seconds
+
     When I publish from "publisher" to "topic/to/pubsub" with qos 1 and message "Hello world"
-    When I publish from "publisher" to "topic/device1/humidity" with qos 1 and message "device1 humidity"
-    When I publish from "publisher" to "topic/device2/temperature" with qos 1 and message "device2 temperature"
-    When I publish from "publisher" to "topic/with/prefix" with qos 1 and message "topicPrefix message"
     Then I wait 5 seconds
     And I get 1 assertions with context "ReceivedPubsubMessage" and message "Hello world"
+
+    When I publish from "publisher" to "topic/device1/humidity" with qos 1 and message "device1 humidity"
+    Then I wait 5 seconds
     And I get 1 assertions with context "ReceivedPubsubMessage" and message "device1 humidity"
+
+    When I publish from "publisher" to "topic/device2/temperature" with qos 1 and message "device2 temperature"
+    Then I wait 5 seconds
     And I get 1 assertions with context "ReceivedPubsubMessage" and message "device2 temperature"
+
+    When I publish from "publisher" to "topic/with/prefix" with qos 1 and message "topicPrefix message"
+    Then I wait 5 seconds
     And I get 1 assertions with context "ReceivedPubsubMessage" and message "topicPrefix message"
 
     @mqtt3 @sdk-java

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -128,22 +128,22 @@ Feature: GGMQ-1
     @mqtt3 @sdk-java
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q0 | subscribe-status-q1| publish-statusq1 | publish-statusq10 |
-      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    | SUCCESS             | SUCCESS            | 0                | 0                 |
+      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    | GRANTED_QOS_0       | GRANTED_QOS_0      | 0                | 0                 |
 
     @mqtt3 @mosquitto-c
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q0 | subscribe-status-q1| publish-statusq1 | publish-statusq10 |
-      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | SUCCESS             | SUCCESS            | 0                | 0                 |
+      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | GRANTED_QOS_0       | GRANTED_QOS_0      | 0                | 0                 |
 
     @mqtt5 @sdk-java
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q0 | subscribe-status-q1| publish-statusq1 | publish-statusq10 |
-      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    | SUCCESS             | GRANTED_QOS_1      | 135              | 0                 |
+      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    | GRANTED_QOS_0       | GRANTED_QOS_1      | 135              | 0                 |
 
     @mqtt5 @mosquitto-c
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q0 | subscribe-status-q1| publish-statusq1 | publish-statusq10 |
-      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | SUCCESS             | SUCCESS            | 0                | 0                 |
+      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | GRANTED_QOS_0       | GRANTED_QOS_0      | 0                | 0                 |
 
 
   @GGMQ-1-T8
@@ -400,7 +400,7 @@ Feature: GGMQ-1
     @mqtt3 @sdk-java
     Examples:
       | mqtt-v | subscribe-status | publish-status | subscribe-status-auth |
-      | v3     | SUCCESS          | 0              | SUCCESS               |
+      | v3     | GRANTED_QOS_0    | 0              | GRANTED_QOS_0         |
 
     @mqtt5 @sdk-java
     Examples:

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -65,7 +65,7 @@ Feature: GGMQ-1
     """
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 300 seconds
-    And I discover core device broker as "default_broker" from "clientDeviceTest"
+    And I discover core device broker as "default_broker" from "clientDeviceTest" in OTF
     And I connect device "clientDeviceTest" on <agent> to "default_broker" using mqtt "<mqtt-v>"
     When I subscribe "clientDeviceTest" to "iot_data_0" with qos 0 and expect status "<subscribe-status-q0>"
     When I subscribe "clientDeviceTest" to "iot_data _1" with qos 1 and expect status "<subscribe-status-q1>"
@@ -246,7 +246,7 @@ Feature: GGMQ-1
     """
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 300 seconds
-    Then I discover core device broker as "localMqttBroker" from "publisher"
+    Then I discover core device broker as "localMqttBroker" from "publisher" in OTF
     And I connect device "publisher" on <agent> to "localMqttBroker" using mqtt "<mqtt-v>"
     And I wait 5 seconds
     When I publish from "publisher" to "topic/to/pubsub" with qos 1 and message "Hello world"
@@ -341,7 +341,7 @@ Feature: GGMQ-1
     When I associate "subscriber" with ggc
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 300 seconds
-    And I discover core device broker as "default_broker" from "publisher"
+    And I discover core device broker as "default_broker" from "publisher" in OTF
     And I connect device "publisher" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker" using mqtt "<mqtt-v>"
     And I connect device "subscriber" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker" using mqtt "<mqtt-v>"
     When I subscribe "subscriber" to "iot_data_0" with qos 0 and expect status "<subscribe-status>"
@@ -387,7 +387,7 @@ Feature: GGMQ-1
     """
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 120 seconds
-    And I discover core device broker as "default_broker" from "subscriber"
+    And I discover core device broker as "default_broker" from "subscriber" in OTF
     And I connect device "publisher" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker" using mqtt "<mqtt-v>"
     And I connect device "subscriber" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker" using mqtt "<mqtt-v>"
     When I subscribe "subscriber" to "iot_data_0" with qos 0 and expect status "<subscribe-status>"
@@ -489,22 +489,26 @@ Feature: GGMQ-1
     """
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 300 seconds
-    When I discover core device broker as "localBroker" from "localMqttSubscriber"
-    And I label IoT core broker as "iotCoreBroker"
+    When I discover core device broker as "localBroker" from "localMqttSubscriber" in OTF
+    And I label IoT Core broker as "iotCoreBroker"
     And I connect device "localMqttSubscriber" on <agent> to "localBroker" using mqtt "<mqtt-v>"
     And I connect device "iotCorePublisher" on <agent> to "iotCoreBroker" using mqtt "<mqtt-v>"
     And I subscribe "localMqttSubscriber" to "${localMqttSubscriber}topic/to/localmqtt" with qos 1
     And I subscribe "localMqttSubscriber" to "${localMqttSubscriber}topic/device2/#" with qos 1
     And I subscribe "localMqttSubscriber" to "${localMqttSubscriber}topic/+/humidity" with qos 1
     And I subscribe "localMqttSubscriber" to "prefix/${localMqttSubscriber}topic/with/prefix" with qos 1
-    When I publish from "iotCorePublisher" to "${localMqttSubscriber}topic/to/localmqtt" with qos 1 and message "Hello world"
-    Then message "Hello world" received on "localMqttSubscriber" from "${localMqttSubscriber}topic/to/localmqtt" topic within 10 seconds
+
+    When I publish from "iotCorePublisher" to "${localMqttSubscriber}topic/to/localmqtt" with qos 1 and message "Hello world1"
+    Then message "Hello world1" received on "localMqttSubscriber" from "${localMqttSubscriber}topic/to/localmqtt" topic within 10 seconds
+
     When I publish from "iotCorePublisher" to "${localMqttSubscriber}topic/device1/humidity" with qos 1 and message "H=10%"
     Then message "H=10%" received on "localMqttSubscriber" from "${localMqttSubscriber}topic/device1/humidity" topic within 10 seconds
+
     When I publish from "iotCorePublisher" to "${localMqttSubscriber}topic/device2/temperature" with qos 1 and message "T=100C"
     Then message "T=100C" received on "localMqttSubscriber" from "${localMqttSubscriber}topic/device2/temperature" topic within 10 seconds
-    When I publish from "iotCorePublisher" to "${localMqttSubscriber}topic/with/prefix" with qos 1 and message "Hello world"
-    Then message "Hello world" received on "localMqttSubscriber" from "prefix/${localMqttSubscriber}topic/with/prefix" topic within 10 seconds
+
+    When I publish from "iotCorePublisher" to "${localMqttSubscriber}topic/with/prefix" with qos 1 and message "Hello world2"
+    Then message "Hello world2" received on "localMqttSubscriber" from "prefix/${localMqttSubscriber}topic/with/prefix" topic within 10 seconds
 
     @mqtt3 @sdk-java
     Examples:
@@ -578,44 +582,44 @@ Feature: GGMQ-1
     """
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 300 seconds
-    Then I discover core device broker as "localMqttBroker1" from "publisher"
-    Then I discover core device broker as "localMqttBroker2" from "subscriber"
+    Then I discover core device broker as "localMqttBroker1" from "publisher" in OTF
+    Then I discover core device broker as "localMqttBroker2" from "subscriber" in OTF
     And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
     And I connect device "subscriber" on <agent> to "localMqttBroker2" using mqtt "<mqtt-v>"
 
     And I set MQTT publish retain flag to true
 
-    When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world"
+    When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world0"
     And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION"
     When I subscribe "subscriber" to "iot_data_0" with qos 0
-    And message "Hello world" received on "subscriber" from "iot_data_0" topic within 5 seconds
+    And message "Hello world0" received on "subscriber" from "iot_data_0" topic within 5 seconds
 
-    When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world"
+    When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world1"
     And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_NEW_SUBSCRIPTION"
     When I subscribe "subscriber" to "iot_data_1" with qos 0
-    And message "Hello world" received on "subscriber" from "iot_data_1" topic within 5 seconds
+    And message "Hello world1" received on "subscriber" from "iot_data_1" topic within 5 seconds
 
-    When I publish from "publisher" to "iot_data_2" with qos 0 and message "Hello world"
+    When I publish from "publisher" to "iot_data_2" with qos 0 and message "Hello world2"
     And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_DO_NOT_SEND_AT_SUBSCRIPTION"
     When I subscribe "subscriber" to "iot_data_2" with qos 0
-    And message "Hello world" received on "subscriber" from "iot_data_2" topic within 5 seconds is <retainHandling-2> expected
+    And message "Hello world2" received on "subscriber" from "iot_data_2" topic within 5 seconds is <retainHandling-2> expected
 
     And I set MQTT publish retain flag to false
 
-    When I publish from "publisher" to "iot_data_3" with qos 0 and message "Hello world"
+    When I publish from "publisher" to "iot_data_3" with qos 0 and message "Hello world3"
     And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION"
     When I subscribe "subscriber" to "iot_data_3" with qos 0
-    And message "Hello world" received on "subscriber" from "iot_data_3" topic within 5 seconds is false expected
+    And message "Hello world3" received on "subscriber" from "iot_data_3" topic within 5 seconds is false expected
 
-    When I publish from "publisher" to "iot_data_4" with qos 0 and message "Hello world"
+    When I publish from "publisher" to "iot_data_4" with qos 0 and message "Hello world4"
     And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_NEW_SUBSCRIPTION"
     When I subscribe "subscriber" to "iot_data_4" with qos 0
-    And message "Hello world" received on "subscriber" from "iot_data_4" topic within 5 seconds is false expected
+    And message "Hello world4" received on "subscriber" from "iot_data_4" topic within 5 seconds is false expected
 
-    When I publish from "publisher" to "iot_data_5" with qos 0 and message "Hello world"
+    When I publish from "publisher" to "iot_data_5" with qos 0 and message "Hello world5"
     And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_DO_NOT_SEND_AT_SUBSCRIPTION"
     When I subscribe "subscriber" to "iot_data_5" with qos 0
-    And message "Hello world" received on "subscriber" from "iot_data_5" topic within 5 seconds is false expected
+    And message "Hello world5" received on "subscriber" from "iot_data_5" topic within 5 seconds is false expected
 
     @mqtt3 @sdk-java
     Examples:


### PR DESCRIPTION
**Issue #, if available:**
Setup retained message control (tune)
Investigate random errors during running test scenarios

**Description of changes:**
- Fix bug with pointer to dead std::string ca in mosquitto c client code
- Tune logging in mosquitto c client code
- Add maven license check to mosquitto c client code
- Rework GGMQ-1-T1 to remove invalid part from GGAD-1-T2
- Extend GGMQ-1-T14 to be outline and run for 2 clients and both MQTT versions
- Tune GGMQ-1-T101
- Tune steps names
- Extend control's stopAgent by adding ability to skip sending commands to agent and use it when agent calls unregister
- Add `retain` flag check to message event filter and 4 unit tests
- Change SUCCESS to GRANTED_QOS_0 in Subscribe reason code

**Why is this change necessary:**
At the moment code and scenarios have the bugs

**How was this change tested:**
When run locally 5 scenarios have failed of 20
Looks it contains other errors and written not accurate.

**Test results:**
```
[INFO ] 2023-06-09 18:19:11.085 [main] StepTrackingReporting - Passed: 'GGMQ-1-T1-v3-sdk-java: As a customer, I can connect, subscribe/publish at QoS 0 and 1 and receive using client application to MQTT topic'
[INFO ] 2023-06-09 18:19:11.085 [main] StepTrackingReporting - Passed: 'GGMQ-1-T1-v3-mosquitto-c: As a customer, I can connect, subscribe/publish at QoS 0 and 1 and receive using client application to MQTT topic
'
[INFO ] 2023-06-09 18:19:11.085 [main] StepTrackingReporting - Passed: 'GGMQ-1-T1-v5-sdk-java: As a customer, I can connect, subscribe/publish at QoS 0 and 1 and receive using client application to MQTT topic'
[INFO ] 2023-06-09 18:19:11.085 [main] StepTrackingReporting - Passed: 'GGMQ-1-T1-v5-mosquitto-c: As a customer, I can connect, subscribe/publish at QoS 0 and 1 and receive using client application to MQTT topic
'
[INFO ] 2023-06-09 18:19:11.086 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v3-sdk-java: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'
[INFO ] 2023-06-09 18:19:11.086 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v3-mosquitto-c: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'
[INFO ] 2023-06-09 18:19:11.086 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v5-sdk-java: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'
[ERROR] 2023-06-09 18:19:11.086 [main] StepTrackingReporting - Failed: 'GGMQ-1-T8-v5-mosquitto-c: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic': Failed at 'I get 1 asserti
ons with context "ReceivedPubsubMessage" and message "Hello world"'
[INFO ] 2023-06-09 18:19:11.087 [main] StepTrackingReporting - Passed: 'GGMQ-1-T13-v3: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration'
[ERROR] 2023-06-09 18:19:11.087 [main] StepTrackingReporting - Failed: 'GGMQ-1-T13-v5: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration': Failed at 't
he Greengrass deployment is COMPLETED on the device after 120 seconds'
[ERROR] 2023-06-09 18:19:11.087 [main] StepTrackingReporting - Failed: 'GGMQ-1-T14-v3-sdk-java: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic': Failed at 'message "Hello wo
rld1" received on "localMqttSubscriber" from "${localMqttSubscriber}topic/to/localmqtt" topic within 10 seconds'
[ERROR] 2023-06-09 18:19:11.087 [main] StepTrackingReporting - Failed: 'GGMQ-1-T14-v3-mosquitto-c: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic': Failed at 'message "Hello
 world1" received on "localMqttSubscriber" from "${localMqttSubscriber}topic/to/localmqtt" topic within 10 seconds'
[ERROR] 2023-06-09 18:19:11.087 [main] StepTrackingReporting - Failed: 'GGMQ-1-T14-v5-sdk-java: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic': Failed at 'message "Hello wo
rld1" received on "localMqttSubscriber" from "${localMqttSubscriber}topic/to/localmqtt" topic within 10 seconds'
[INFO ] 2023-06-09 18:19:11.088 [main] StepTrackingReporting - Passed: 'GGMQ-1-T14-v5-mosquitto-c: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic'
[INFO ] 2023-06-09 18:19:11.088 [main] StepTrackingReporting - Passed: 'GGMQ-1-T101-v3-sdk-java: As a customer, I can use publish retain flag and subscribe retain handling as expected'
[INFO ] 2023-06-09 18:19:11.088 [main] StepTrackingReporting - Passed: 'GGMQ-1-T101-v3-paho-java: As a customer, I can use publish retain flag and subscribe retain handling as expected'
[INFO ] 2023-06-09 18:19:11.088 [main] StepTrackingReporting - Passed: 'GGMQ-1-T101-v3-mosquitto-c: As a customer, I can use publish retain flag and subscribe retain handling as expected'
[INFO ] 2023-06-09 18:19:11.088 [main] StepTrackingReporting - Passed: 'GGMQ-1-T101-v5-sdk-java: As a customer, I can use publish retain flag and subscribe retain handling as expected'
[INFO ] 2023-06-09 18:19:11.088 [main] StepTrackingReporting - Passed: 'GGMQ-1-T101-v5-paho-java: As a customer, I can use publish retain flag and subscribe retain handling as expected'
[INFO ] 2023-06-09 18:19:11.088 [main] StepTrackingReporting - Passed: 'GGMQ-1-T101-v5-mosquitto-c: As a customer, I can use publish retain flag and subscribe retain handling as expected'

```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
