### PR TITLE
feat(uat): added userProperties for connect, publish and receive

### DIFF
--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.testing.mqtt311.client.paho;
 
+import com.aws.greengrass.testing.mqtt.client.Mqtt5Properties;
 import com.aws.greengrass.testing.mqtt.client.MqttPublishReply;
 import com.aws.greengrass.testing.mqtt.client.MqttSubscribeReply;
 import com.aws.greengrass.testing.mqtt5.client.GRPCClient;
@@ -25,7 +26,6 @@ import org.eclipse.paho.client.mqttv3.MqttMessage;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -39,9 +39,6 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
     private static final Logger logger = LogManager.getLogger(Mqtt311ConnectionImpl.class);
     private static final String EXCEPTION_WHEN_CONNECTING = "Exception occurred during connect";
     private static final String EXCEPTION_WHEN_CONFIGURE_SSL_CA = "Exception occurred during SSL configuration";
-
-    // MQTT 3.1.1 doesn't support user properties
-    private static final Map<String, String> USER_PROPERTIES = null;
 
     private final AtomicBoolean isClosing = new AtomicBoolean();
     private final IMqttClient mqttClient;
@@ -84,7 +81,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
 
     @Override
     public MqttSubscribeReply subscribe(long timeout, @NonNull List<Subscription> subscriptions,
-                                        Map<String, String> userProperties) {
+                                        List<Mqtt5Properties> userProperties) {
         String[] filters = new String[subscriptions.size()];
         int[] qos = new int[subscriptions.size()];
         MqttMessageListener[] messageListeners = new MqttMessageListener[subscriptions.size()];
@@ -176,7 +173,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
         @Override
         public void messageArrived(String topic, MqttMessage mqttMessage) throws Exception {
             GRPCClient.MqttReceivedMessage message = new GRPCClient.MqttReceivedMessage(
-                    mqttMessage.getQos(), mqttMessage.isRetained(), topic, mqttMessage.getPayload(), USER_PROPERTIES);
+                    mqttMessage.getQos(), mqttMessage.isRetained(), topic, mqttMessage.getPayload(), null);
             executorService.submit(() -> {
                 grpcClient.onReceiveMqttMessage(connectionId, message);
                 logger.atInfo().log("Received MQTT message: connectionId {} topic {} QoS {} retain {}",

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
@@ -83,7 +83,8 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
     }
 
     @Override
-    public MqttSubscribeReply subscribe(long timeout, @NonNull List<Subscription> subscriptions) {
+    public MqttSubscribeReply subscribe(long timeout, @NonNull List<Subscription> subscriptions,
+                                        Map<String, String> userProperties) {
         String[] filters = new String[subscriptions.size()];
         int[] qos = new int[subscriptions.size()];
         MqttMessageListener[] messageListeners = new MqttMessageListener[subscriptions.size()];

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
@@ -25,6 +25,7 @@ import org.eclipse.paho.client.mqttv3.MqttMessage;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -38,6 +39,9 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
     private static final Logger logger = LogManager.getLogger(Mqtt311ConnectionImpl.class);
     private static final String EXCEPTION_WHEN_CONNECTING = "Exception occurred during connect";
     private static final String EXCEPTION_WHEN_CONFIGURE_SSL_CA = "Exception occurred during SSL configuration";
+
+    // MQTT 3.1.1 doesn't support user properties
+    private static final Map<String, String> USER_PROPERTIES = null;
 
     private final AtomicBoolean isClosing = new AtomicBoolean();
     private final IMqttClient mqttClient;
@@ -171,7 +175,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
         @Override
         public void messageArrived(String topic, MqttMessage mqttMessage) throws Exception {
             GRPCClient.MqttReceivedMessage message = new GRPCClient.MqttReceivedMessage(
-                    mqttMessage.getQos(), mqttMessage.isRetained(), topic, mqttMessage.getPayload());
+                    mqttMessage.getQos(), mqttMessage.isRetained(), topic, mqttMessage.getPayload(), USER_PROPERTIES);
             executorService.submit(() -> {
                 grpcClient.onReceiveMqttMessage(connectionId, message);
                 logger.atInfo().log("Received MQTT message: connectionId {} topic {} QoS {} retain {}",

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCClient.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCClient.java
@@ -5,10 +5,11 @@
 
 package com.aws.greengrass.testing.mqtt5.client;
 
+import com.aws.greengrass.testing.mqtt.client.Mqtt5Properties;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.util.Map;
+import java.util.List;
 
 /**
  * Interface to gRPC client.
@@ -33,7 +34,7 @@ public interface GRPCClient {
         private byte[] payload;
 
         /** User properties. */
-        private Map<String, String> userProperties;
+        private List<Mqtt5Properties> userProperties;
     }
 
 
@@ -55,7 +56,8 @@ public interface GRPCClient {
         /** Server reference. */
         String serverReference;
 
-        // TODO: add user's properties
+        /** User properties. */
+        private List<Mqtt5Properties> userProperties;
     }
 
     /**

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCClient.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCClient.java
@@ -8,6 +8,8 @@ package com.aws.greengrass.testing.mqtt5.client;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.Map;
+
 /**
  * Interface to gRPC client.
  */
@@ -30,7 +32,8 @@ public interface GRPCClient {
         /** Payload of message. */
         private byte[] payload;
 
-        // TODO: add user's properties and so one
+        /** User properties. */
+        private Map<String, String> userProperties;
     }
 
 

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -5,6 +5,7 @@
 
 package com.aws.greengrass.testing.mqtt5.client;
 
+import com.aws.greengrass.testing.mqtt.client.Mqtt5Properties;
 import com.aws.greengrass.testing.mqtt.client.MqttPublishReply;
 import com.aws.greengrass.testing.mqtt.client.MqttSubscribeReply;
 import com.aws.greengrass.testing.mqtt5.client.exceptions.MqttException;
@@ -14,7 +15,6 @@ import lombok.Getter;
 import lombok.NonNull;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Interface of MQTT5 connection.
@@ -46,7 +46,7 @@ public interface MqttConnection {
         private Integer serverKeepAlive;
         private String responseInformation;
         private String serverReference;
-        private Map<String, String> userProperties;
+        private List<Mqtt5Properties>  userProperties;
 
         // TODO: int topicAliasMaximum;          // miss for AWS IoT device SDK MQTT5 client ?
         // TODO: Authentication Method
@@ -104,7 +104,9 @@ public interface MqttConnection {
         private List<Integer> reasonCodes;
 
         private String reasonString;
-        // TODO: add user's properties
+
+        /** User properties. */
+        private List<Mqtt5Properties>  userProperties;
     }
 
     /**
@@ -126,7 +128,7 @@ public interface MqttConnection {
         private byte[] payload;
 
         /** User properties. */
-        private Map<String, String> userProperties;
+        private List<Mqtt5Properties>  userProperties;
 
         // TODO: add user's properties and so one
     }
@@ -136,8 +138,8 @@ public interface MqttConnection {
      * Actually is the same as SubAckInfo.
      */
     class UnsubAckInfo extends SubAckInfo {
-        public UnsubAckInfo(List<Integer> reasonCodes, String reasonString) {
-            super(reasonCodes, reasonString);
+        public UnsubAckInfo(List<Integer> reasonCodes, String reasonString, List<Mqtt5Properties>  userProperties) {
+            super(reasonCodes, reasonString, userProperties);
         }
     }
 
@@ -161,7 +163,7 @@ public interface MqttConnection {
      * @return useful information from SUBACK packet
      */
     MqttSubscribeReply subscribe(long timeout, @NonNull List<Subscription> subscriptions,
-                                 Map<String, String> userProperties);
+                                 List<Mqtt5Properties> userProperties);
 
     /**
      * Closes MQTT connection.

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -14,6 +14,7 @@ import lombok.Getter;
 import lombok.NonNull;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Interface of MQTT5 connection.
@@ -123,6 +124,9 @@ public interface MqttConnection {
 
         /** Payload of message. */
         private byte[] payload;
+
+        /** User properties. */
+        private Map<String, String> userProperties;
 
         // TODO: add user's properties and so one
     }

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -46,11 +46,11 @@ public interface MqttConnection {
         private Integer serverKeepAlive;
         private String responseInformation;
         private String serverReference;
+        private Map<String, String> userProperties;
 
         // TODO: int topicAliasMaximum;          // miss for AWS IoT device SDK MQTT5 client ?
         // TODO: Authentication Method
         // TODO: Authentication Data
-        // TODO: user's Properties
 
         /**
          * Creates ConnAckInfo for result of MQTT 3.1.1 connect.
@@ -157,9 +157,11 @@ public interface MqttConnection {
      *
      * @param timeout subscribe operation timeout in seconds
      * @param subscriptions list of subscriptions
+     * @param userProperties  Map of user's properties MQTT v5.0
      * @return useful information from SUBACK packet
      */
-    MqttSubscribeReply subscribe(long timeout, @NonNull List<Subscription> subscriptions);
+    MqttSubscribeReply subscribe(long timeout, @NonNull List<Subscription> subscriptions,
+                                 Map<String, String> userProperties);
 
     /**
      * Closes MQTT connection.

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
@@ -5,12 +5,13 @@
 
 package com.aws.greengrass.testing.mqtt5.client;
 
+import com.aws.greengrass.testing.mqtt.client.Mqtt5Properties;
 import com.aws.greengrass.testing.mqtt5.client.exceptions.MqttException;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NonNull;
 
-import java.util.Map;
+import java.util.List;
 
 /**
  * Interface of MQTT5 library.
@@ -54,7 +55,7 @@ public interface MqttLib extends AutoCloseable {
         private int connectionTimeout;
 
         /** User properties. */
-        private Map<String, String> userProperties;
+        private List<Mqtt5Properties> userProperties;
     }
 
     /**

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttLib.java
@@ -10,6 +10,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NonNull;
 
+import java.util.Map;
+
 /**
  * Interface of MQTT5 library.
  */
@@ -50,6 +52,9 @@ public interface MqttLib extends AutoCloseable {
 
         /** The true MQTT v5.0 connection is requested. */
         private int connectionTimeout;
+
+        /** User properties. */
+        private Map<String, String> userProperties;
     }
 
     /**

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -171,7 +171,8 @@ class GRPCControlServer {
                     .keepalive(keepalive)
                     .cleanSession(request.getCleanSession())
                     .mqtt50(version == MqttProtoVersion.MQTT_PROTOCOL_V_50)
-                    .connectionTimeout(timeout);
+                    .connectionTimeout(timeout)
+                    .userProperties(request.getProperties().getUserPropertiesMap());
 
             // check TLS optional settings
             if (request.hasTls()) {
@@ -279,6 +280,7 @@ class GRPCControlServer {
                     .retain(isRetain)
                     .topic(topic)
                     .payload(message.getPayload().toByteArray())
+                    .userProperties(message.getProperties().getUserPropertiesMap())
                     .build();
             MqttPublishReply publishReply = connection.publish(timeout, internalMessage);
                 if (publishReply != null) {

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -174,7 +174,7 @@ class GRPCControlServer {
                     .mqtt50(version == MqttProtoVersion.MQTT_PROTOCOL_V_50)
                     .connectionTimeout(timeout);
 
-            if (!request.getPropertiesList().isEmpty()) {
+            if (request.getPropertiesList() != null && !request.getPropertiesList().isEmpty()) {
                 connectionParamsBuilder.userProperties(request.getPropertiesList());
             }
 
@@ -284,7 +284,7 @@ class GRPCControlServer {
                     .retain(isRetain)
                     .topic(topic)
                     .payload(message.getPayload().toByteArray());
-            if (!message.getPropertiesList().isEmpty()) {
+            if (message.getPropertiesList() != null && !message.getPropertiesList().isEmpty()) {
                 internalMessage.userProperties(message.getPropertiesList());
             }
 

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
@@ -8,7 +8,6 @@ package com.aws.greengrass.testing.mqtt5.client.grpc;
 import com.aws.greengrass.testing.mqtt.client.DiscoveryRequest;
 import com.aws.greengrass.testing.mqtt.client.Mqtt5Disconnect;
 import com.aws.greengrass.testing.mqtt.client.Mqtt5Message;
-import com.aws.greengrass.testing.mqtt.client.Mqtt5Properties;
 import com.aws.greengrass.testing.mqtt.client.MqttAgentDiscoveryGrpc;
 import com.aws.greengrass.testing.mqtt.client.MqttConnectionId;
 import com.aws.greengrass.testing.mqtt.client.MqttQoS;
@@ -123,8 +122,7 @@ class GRPCDiscoveryClient implements GRPCClient {
                                         .setQos(MqttQoS.forNumber(message.getQos()))
                                         .setRetain(message.isRetain());
         if (message.getUserProperties() != null) {
-            msgBuilder.setProperties(Mqtt5Properties.newBuilder()
-                    .putAllUserProperties(message.getUserProperties()).build());
+            msgBuilder.addAllProperties(message.getUserProperties());
         }
 
         OnReceiveMessageRequest request = OnReceiveMessageRequest.newBuilder()

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.testing.mqtt5.client.grpc;
 import com.aws.greengrass.testing.mqtt.client.DiscoveryRequest;
 import com.aws.greengrass.testing.mqtt.client.Mqtt5Disconnect;
 import com.aws.greengrass.testing.mqtt.client.Mqtt5Message;
+import com.aws.greengrass.testing.mqtt.client.Mqtt5Properties;
 import com.aws.greengrass.testing.mqtt.client.MqttAgentDiscoveryGrpc;
 import com.aws.greengrass.testing.mqtt.client.MqttConnectionId;
 import com.aws.greengrass.testing.mqtt.client.MqttQoS;
@@ -17,7 +18,6 @@ import com.aws.greengrass.testing.mqtt.client.RegisterReply;
 import com.aws.greengrass.testing.mqtt.client.RegisterRequest;
 import com.aws.greengrass.testing.mqtt.client.UnregisterRequest;
 import com.aws.greengrass.testing.mqtt5.client.GRPCClient;
-import com.aws.greengrass.testing.mqtt5.client.GRPCClient.MqttReceivedMessage;
 import com.aws.greengrass.testing.mqtt5.client.exceptions.GRPCException;
 import com.google.protobuf.ByteString;
 import io.grpc.Grpc;
@@ -122,6 +122,9 @@ class GRPCDiscoveryClient implements GRPCClient {
                                         .setPayload(ByteString.copyFrom(message.getPayload()))
                                         .setQos(MqttQoS.forNumber(message.getQos()))
                                         .setRetain(message.isRetain())
+                                        .setProperties(
+                                                Mqtt5Properties.newBuilder()
+                                                .putAllUserProperties(message.getUserProperties()).build())
                                         .build();
 
         OnReceiveMessageRequest request = OnReceiveMessageRequest.newBuilder()

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
@@ -117,20 +117,20 @@ class GRPCDiscoveryClient implements GRPCClient {
 
     @Override
     public void onReceiveMqttMessage(int connectionId, MqttReceivedMessage message) {
-        Mqtt5Message msg = Mqtt5Message.newBuilder()
+        Mqtt5Message.Builder msgBuilder = Mqtt5Message.newBuilder()
                                         .setTopic(message.getTopic())
                                         .setPayload(ByteString.copyFrom(message.getPayload()))
                                         .setQos(MqttQoS.forNumber(message.getQos()))
-                                        .setRetain(message.isRetain())
-                                        .setProperties(
-                                                Mqtt5Properties.newBuilder()
-                                                .putAllUserProperties(message.getUserProperties()).build())
-                                        .build();
+                                        .setRetain(message.isRetain());
+        if (message.getUserProperties() != null) {
+            msgBuilder.setProperties(Mqtt5Properties.newBuilder()
+                    .putAllUserProperties(message.getUserProperties()).build());
+        }
 
         OnReceiveMessageRequest request = OnReceiveMessageRequest.newBuilder()
                         .setAgentId(agentId)
                         .setConnectionId(MqttConnectionId.newBuilder().setConnectionId(connectionId).build())
-                        .setMsg(msg)
+                        .setMsg(msgBuilder.build())
                         .build();
         try {
             blockingStub.onReceiveMessage(request);

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
@@ -32,6 +32,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Class with hardcoded scenario to do manual tests of client and control.
@@ -179,7 +181,7 @@ class AgentTestScenario implements Runnable {
                     .setKeepalive(KEEP_ALIVE)
                     .setCleanSession(CLEAN_SESSION)
                     .setTimeout(CONNECT_TIMEOUT)
-                    .setProperties(createMqtt5Properties())
+                    .addAllProperties(createMqtt5Properties())
                     .setProtocolVersion(mqtt50  ? MqttProtoVersion.MQTT_PROTOCOL_V_50
                                                 : MqttProtoVersion.MQTT_PROTOCOL_V_311);
 
@@ -229,15 +231,15 @@ class AgentTestScenario implements Runnable {
                             .setPayload(ByteString.copyFrom(data))
                             .setQos(qos)
                             .setRetain(retain)
-                            .setProperties(createMqtt5Properties())
+                            .addAllProperties(createMqtt5Properties())
                             .build();
     }
 
-    private Mqtt5Properties createMqtt5Properties() {
-        return Mqtt5Properties.newBuilder()
-                .putUserProperties("region", "US")
-                .putUserProperties("type", "JSON")
-                .build();
+    private List<Mqtt5Properties> createMqtt5Properties() {
+        List<Mqtt5Properties> properties = new ArrayList<>();
+        properties.add(Mqtt5Properties.newBuilder().setKey("region").setValue("US").build());
+        properties.add(Mqtt5Properties.newBuilder().setKey("type").setValue("JSON").build());
+        return properties;
     }
 
     private void testUnsubscribe(ConnectionControl connectionControl) {

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.testing.mqtt.client.control;
 
 import com.aws.greengrass.testing.mqtt.client.Mqtt5Disconnect;
 import com.aws.greengrass.testing.mqtt.client.Mqtt5Message;
+import com.aws.greengrass.testing.mqtt.client.Mqtt5Properties;
 import com.aws.greengrass.testing.mqtt.client.Mqtt5RetainHandling;
 import com.aws.greengrass.testing.mqtt.client.Mqtt5Subscription;
 import com.aws.greengrass.testing.mqtt.client.MqttConnectRequest;
@@ -178,6 +179,7 @@ class AgentTestScenario implements Runnable {
                     .setKeepalive(KEEP_ALIVE)
                     .setCleanSession(CLEAN_SESSION)
                     .setTimeout(CONNECT_TIMEOUT)
+                    .setProperties(createMqtt5Properties())
                     .setProtocolVersion(mqtt50  ? MqttProtoVersion.MQTT_PROTOCOL_V_50
                                                 : MqttProtoVersion.MQTT_PROTOCOL_V_311);
 
@@ -226,7 +228,15 @@ class AgentTestScenario implements Runnable {
                             .setPayload(ByteString.copyFrom(data))
                             .setQos(qos)
                             .setRetain(retain)
+                            .setProperties(createMqtt5Properties())
                             .build();
+    }
+
+    private Mqtt5Properties createMqtt5Properties() {
+        return Mqtt5Properties.newBuilder()
+                .putUserProperties("region", "US")
+                .putUserProperties("type", "JSON")
+                .build();
     }
 
     private void testUnsubscribe(ConnectionControl connectionControl) {

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
@@ -196,7 +196,8 @@ class AgentTestScenario implements Runnable {
         Mqtt5Subscription subscription = createSubscription(SUBSCRIBE_FILTER, SUBSCRIBE_QOS, SUBSCRIBE_NO_LOCAL,
                                                             SUBSCRIBE_RETAIN_AS_PUBLISHED, SUBSCRIBE_RETAIN_HANDLING);
 
-        MqttSubscribeReply reply = connectionControl.subscribeMqtt(SUBSCRIPTION_ID, subscription);
+        MqttSubscribeReply reply = connectionControl.subscribeMqtt(SUBSCRIPTION_ID, createMqtt5Properties(),
+                subscription);
         logger.atInfo().log("Subscribe response: connectionId {} reason codes {} reason string '{}'",
                                 connectionControl.getConnectionId(),
                                 reply.getReasonCodesList(),

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/ConnectionControl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/ConnectionControl.java
@@ -13,6 +13,8 @@ import com.aws.greengrass.testing.mqtt.client.MqttPublishReply;
 import com.aws.greengrass.testing.mqtt.client.MqttSubscribeReply;
 import lombok.NonNull;
 
+import java.util.List;
+
 /**
  * Control of single MQTT connection.
  */
@@ -75,7 +77,7 @@ public interface ConnectionControl {
      * @return reply to subscribe
      * @throws StatusRuntimeException on errors
      */
-    MqttSubscribeReply subscribeMqtt(Integer subscriptionId, Mqtt5Properties mqtt5Properties,
+    MqttSubscribeReply subscribeMqtt(Integer subscriptionId, List<Mqtt5Properties> mqtt5Properties,
                                      @NonNull Mqtt5Subscription... subscriptions);
 
     /**

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/ConnectionControl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/ConnectionControl.java
@@ -7,6 +7,7 @@ package com.aws.greengrass.testing.mqtt.client.control.api;
 
 import com.aws.greengrass.testing.mqtt.client.Mqtt5ConnAck;
 import com.aws.greengrass.testing.mqtt.client.Mqtt5Message;
+import com.aws.greengrass.testing.mqtt.client.Mqtt5Properties;
 import com.aws.greengrass.testing.mqtt.client.Mqtt5Subscription;
 import com.aws.greengrass.testing.mqtt.client.MqttPublishReply;
 import com.aws.greengrass.testing.mqtt.client.MqttSubscribeReply;
@@ -70,10 +71,12 @@ public interface ConnectionControl {
      *
      * @param subscriptionId optional subscription id
      * @param subscriptions MQTT v5.0 subscriptions
+     * @param mqtt5Properties MQTT v5.0 properties
      * @return reply to subscribe
      * @throws StatusRuntimeException on errors
      */
-    MqttSubscribeReply subscribeMqtt(Integer subscriptionId, @NonNull Mqtt5Subscription... subscriptions);
+    MqttSubscribeReply subscribeMqtt(Integer subscriptionId, Mqtt5Properties mqtt5Properties,
+                                     @NonNull Mqtt5Subscription... subscriptions);
 
     /**
      * Publish MQTT message.

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/ConnectionControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/ConnectionControlImpl.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.testing.mqtt.client.control.implementation;
 import com.aws.greengrass.testing.mqtt.client.Mqtt5ConnAck;
 import com.aws.greengrass.testing.mqtt.client.Mqtt5Disconnect;
 import com.aws.greengrass.testing.mqtt.client.Mqtt5Message;
+import com.aws.greengrass.testing.mqtt.client.Mqtt5Properties;
 import com.aws.greengrass.testing.mqtt.client.Mqtt5Subscription;
 import com.aws.greengrass.testing.mqtt.client.MqttCloseRequest;
 import com.aws.greengrass.testing.mqtt.client.MqttConnectReply;
@@ -99,7 +100,8 @@ public class ConnectionControlImpl implements ConnectionControl {
     }
 
     @Override
-    public MqttSubscribeReply subscribeMqtt(Integer subscriptionId, @NonNull Mqtt5Subscription... subscriptions) {
+    public MqttSubscribeReply subscribeMqtt(Integer subscriptionId, Mqtt5Properties mqtt5Properties,
+                                            @NonNull Mqtt5Subscription... subscriptions) {
         MqttSubscribeRequest.Builder builder = MqttSubscribeRequest.newBuilder()
                 .setConnectionId(MqttConnectionId.newBuilder().setConnectionId(connectionId).build())
                 .setTimeout(timeout)
@@ -107,6 +109,9 @@ public class ConnectionControlImpl implements ConnectionControl {
 
         if (subscriptionId != null) {
             builder.setSubscriptionId(subscriptionId);
+        }
+        if (mqtt5Properties != null) {
+            builder.putAllUserProperties(mqtt5Properties.getUserPropertiesMap());
         }
 
         return agentControl.subscribeMqtt(builder.build());

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/ConnectionControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/ConnectionControlImpl.java
@@ -23,6 +23,7 @@ import com.aws.greengrass.testing.mqtt.client.control.api.ConnectionControl;
 import lombok.NonNull;
 
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Implementation of ConnectionControl.
@@ -100,7 +101,7 @@ public class ConnectionControlImpl implements ConnectionControl {
     }
 
     @Override
-    public MqttSubscribeReply subscribeMqtt(Integer subscriptionId, Mqtt5Properties mqtt5Properties,
+    public MqttSubscribeReply subscribeMqtt(Integer subscriptionId, List<Mqtt5Properties> mqtt5Properties,
                                             @NonNull Mqtt5Subscription... subscriptions) {
         MqttSubscribeRequest.Builder builder = MqttSubscribeRequest.newBuilder()
                 .setConnectionId(MqttConnectionId.newBuilder().setConnectionId(connectionId).build())
@@ -111,7 +112,7 @@ public class ConnectionControlImpl implements ConnectionControl {
             builder.setSubscriptionId(subscriptionId);
         }
         if (mqtt5Properties != null) {
-            builder.putAllUserProperties(mqtt5Properties.getUserPropertiesMap());
+            builder.addAllProperties(mqtt5Properties);
         }
 
         return agentControl.subscribeMqtt(builder.build());

--- a/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/ConnectionControlImplTest.java
+++ b/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/ConnectionControlImplTest.java
@@ -123,7 +123,7 @@ class ConnectionControlImplTest {
         when(agent.subscribeMqtt(any(MqttSubscribeRequest.class))).thenReturn(reply);
 
         // WHEN
-        final MqttSubscribeReply actual = connectionControl.subscribeMqtt(subscriptionId, subscription);
+        final MqttSubscribeReply actual = connectionControl.subscribeMqtt(subscriptionId, null, subscription);
 
         // THEN
         assertSame(reply, actual);

--- a/uat/proto/mqtt_client_control.proto
+++ b/uat/proto/mqtt_client_control.proto
@@ -26,6 +26,7 @@ message MqttConnectionId {
 message Mqtt5Properties {
     // TODO:
     int32 stub = 1;
+    map<string, string> userProperties = 2;
 };
 
 // The MQTT v5.0 message

--- a/uat/proto/mqtt_client_control.proto
+++ b/uat/proto/mqtt_client_control.proto
@@ -24,8 +24,7 @@ message MqttConnectionId {
 
 // MQTT 5.0 user's properties used in most of packets
 message Mqtt5Properties {
-    int32 stub = 1;
-    map<string, string> userProperties = 2;
+    map<string, string> userProperties = 1;
 };
 
 // The MQTT v5.0 message

--- a/uat/proto/mqtt_client_control.proto
+++ b/uat/proto/mqtt_client_control.proto
@@ -24,7 +24,8 @@ message MqttConnectionId {
 
 // MQTT 5.0 user's properties used in most of packets
 message Mqtt5Properties {
-    map<string, string> userProperties = 1;
+    string key = 1;
+    string value = 2;
 };
 
 // The MQTT v5.0 message
@@ -33,7 +34,7 @@ message Mqtt5Message {
     bytes payload = 2;
     MqttQoS qos = 3;
     bool retain = 4;
-    optional Mqtt5Properties properties = 5;
+    repeated Mqtt5Properties properties = 5;
 };
 
 // End of common part
@@ -104,7 +105,7 @@ message Mqtt5Disconnect {
     optional int32 sessionExpiryInterval = 2;
     optional string reasonString = 3;
     optional string serverReference = 4;
-    optional Mqtt5Properties properties = 5;
+    repeated Mqtt5Properties properties = 5;
 }
 
 // End of discovery part
@@ -174,7 +175,7 @@ message Mqtt5ConnAck {
     optional string responseInformation = 14;
     optional string serverReference = 15;
     optional int32 topicAliasMaximum = 16;
-    map<string, string> userProperties = 17;
+    repeated Mqtt5Properties properties = 17;
 
     // TODO: Authentication Method
     // TODO: Authentication Data
@@ -212,7 +213,7 @@ message MqttConnectRequest {
     bool cleanSession = 5;                              // clean sesions (clean start) flag
     MqttProtoVersion protocolVersion = 6;               // version of MQTT protocol to use, currently only 5 is supported
     int32 timeout = 7;                                  // connect timeout in seconds
-    optional Mqtt5Properties properties = 8;            // CONNECT packet MQTT 5 properties
+    repeated Mqtt5Properties properties = 8;            // CONNECT packet MQTT 5 properties
     optional TLSSettings tls = 9;                       // TLS settings for secured connection
     optional Mqtt5Message willMessage = 10;             // will message to set
 }
@@ -230,7 +231,7 @@ message MqttCloseRequest {
     MqttConnectionId connectionId = 1;                  // id of connection to disconnect
     int32 timeout = 2;                                  // disconnect timeout in seconds
     int32 reason = 3;                                   // MQTT disconnect reason
-    optional Mqtt5Properties properties = 4;            // DISCONNECT packet MQTT v5.0 properties
+    repeated Mqtt5Properties properties = 4;            // DISCONNECT packet MQTT v5.0 properties
 }
 
 // Request to subscribe to MQTT topic(s)
@@ -239,14 +240,14 @@ message MqttSubscribeRequest {
     int32 timeout = 2;                                  // subscribe timeout in seconds
     optional int32 subscriptionId = 3;                  // optional subscription id
     repeated Mqtt5Subscription subscriptions = 4;       // list of filter with options
-    map<string, string> userProperties = 5;             // MQTT v5.0 user's properties
+    repeated Mqtt5Properties properties = 5;             // MQTT v5.0 user's properties
 }
 
 // Response to subscribe request
 message MqttSubscribeReply {
     repeated int32 reasonCodes = 1;                     // MQTT v5.0 SUBACK reason codes
     optional string reasonString = 2;                   // MQTT v5.0 SUBACK  reason string
-    optional Mqtt5Properties properties = 3;            // MQTT v5.0 SUBACK user's properties
+    repeated Mqtt5Properties properties = 3;            // MQTT v5.0 SUBACK user's properties
 }
 
 // Request to unsubscribe from MQTT topic(s)
@@ -254,7 +255,7 @@ message MqttUnsubscribeRequest {
     MqttConnectionId connectionId = 1;                  // id of connection to unsubscribe
     int32 timeout = 2;                                  // unsubscribe timeout in seconds
     repeated string filters = 3;                        // list of filter to unsubscribe
-    // TODO: add user properties
+    repeated Mqtt5Properties properties = 4;            // MQTT v5.0 PUBACK user's properties
 }
 
 // Request to publish MQTT message
@@ -268,7 +269,7 @@ message MqttPublishRequest {
 message MqttPublishReply {
     optional int32 reasonCode = 1;                      // MQTT v5.0 PUBACK reason code
     optional string reasonString = 2;                   // MQTT v5.0 PUBACK reason string
-    optional Mqtt5Properties properties = 3;            // MQTT v5.0 PUBACK user's properties
+    repeated Mqtt5Properties properties = 3;            // MQTT v5.0 PUBACK user's properties
 }
 
 // end of MQTT client contol part

--- a/uat/proto/mqtt_client_control.proto
+++ b/uat/proto/mqtt_client_control.proto
@@ -24,7 +24,6 @@ message MqttConnectionId {
 
 // MQTT 5.0 user's properties used in most of packets
 message Mqtt5Properties {
-    // TODO:
     int32 stub = 1;
     map<string, string> userProperties = 2;
 };
@@ -35,7 +34,7 @@ message Mqtt5Message {
     bytes payload = 2;
     MqttQoS qos = 3;
     bool retain = 4;
-    Mqtt5Properties properties = 5;
+    optional Mqtt5Properties properties = 5;
 };
 
 // End of common part
@@ -176,10 +175,10 @@ message Mqtt5ConnAck {
     optional string responseInformation = 14;
     optional string serverReference = 15;
     optional int32 topicAliasMaximum = 16;
+    map<string, string> userProperties = 17;
 
     // TODO: Authentication Method
     // TODO: Authentication Data
-    // TODO: user's Properties
 };
 
 
@@ -225,7 +224,6 @@ message MqttConnectReply {
     MqttConnectionId connectionId = 2;                  // id of establisted connection
     optional Mqtt5ConnAck connAck = 3;                  // information from CONNACK packet
     optional string error = 4;                          // error string if available, has sense on connected = false
-    // TODO: add user properties
 }
 
 // Request to close MQTT connection
@@ -242,7 +240,7 @@ message MqttSubscribeRequest {
     int32 timeout = 2;                                  // subscribe timeout in seconds
     optional int32 subscriptionId = 3;                  // optional subscription id
     repeated Mqtt5Subscription subscriptions = 4;       // list of filter with options
-    // TODO: add user properties
+    map<string, string> userProperties = 5;             // MQTT v5.0 user's properties
 }
 
 // Response to subscribe request

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -365,7 +365,8 @@ public class MqttControlSteps {
                                                                         SUBSCRIBE_NO_LOCAL,
                                                                         SUBSCRIBE_RETAIN_AS_PUBLISHED,
                                                                         mqtt5RetainHandling);
-        MqttSubscribeReply mqttSubscribeReply = connectionControl.subscribeMqtt(SUBSCRIPTION_ID, mqtt5Subscription);
+        MqttSubscribeReply mqttSubscribeReply = connectionControl.subscribeMqtt(SUBSCRIPTION_ID, null,
+                mqtt5Subscription);
         if (mqttSubscribeReply == null) {
             throw new RuntimeException("Do not receive reply to MQTT subscribe request");
         }
@@ -421,7 +422,8 @@ public class MqttControlSteps {
                 SUBSCRIBE_NO_LOCAL,
                 SUBSCRIBE_RETAIN_AS_PUBLISHED,
                 DEFAULT_SUBSCRIBE_RETAIN_HANDLING);
-        MqttSubscribeReply mqttSubscribeReply = connectionControl.subscribeMqtt(SUBSCRIPTION_ID, mqtt5Subscription);
+        MqttSubscribeReply mqttSubscribeReply = connectionControl.subscribeMqtt(SUBSCRIPTION_ID, null,
+                mqtt5Subscription);
         if (mqttSubscribeReply == null) {
             throw new RuntimeException("Do not receive reply to MQTT subscribe request");
         }


### PR DESCRIPTION
**Issue #, if available:**
added userProperties for connect, publish and receive

**Description of changes:**
- added userProperties for connect, publish and receive Mqtt V5.0

**Why is this change necessary:**
- required step for several test features

**How was this change tested:**
run command **mvn exec:java** in paho-agent module 

**Test results:**
Control's log:
```
INFO ] 2023-06-07 14:50:06.228 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] EngineControlImpl - MQTT client control gRPC server started, listening on 47619
[INFO ] 2023-06-07 14:50:12.555 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId paho-java-agent
[INFO ] 2023-06-07 14:50:12.590 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId paho-java-agent address 127.0.0.1 port 40475
[INFO ] 2023-06-07 14:50:12.592 [grpc-default-executor-0] EngineControlImpl - Created new agent control for paho-java-agent on 127.0.0.1:40475
[INFO ] 2023-06-07 14:50:12.615 [grpc-default-executor-0] ExampleControl - Agent paho-java-agent is connected
[INFO ] 2023-06-07 14:50:12.617 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id paho-java-agent
[INFO ] 2023-06-07 14:50:17.928 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
receiveMaximum: 100
maximumQoS: 1
retainAvailable: true
maximumPacketSize: 149504
serverKeepAlive: 60
'
[INFO ] 2023-06-07 14:50:17.928 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-06-07 14:50:17.928 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-06-07 14:50:22.935 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-06-07 14:50:23.099 [pool-2-thread-1] AgentTestScenario - Subscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-06-07 14:50:28.106 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic test/topic
[INFO ] 2023-06-07 14:50:28.127 [pool-2-thread-1] AgentTestScenario - Published connectionId 1 reason code 0 reason string ''
[INFO ] 2023-06-07 14:50:28.320 [grpc-default-executor-0] GRPCDiscoveryServer - OnReceiveMessage: agentId paho-java-agent connectionId 1 topic test/topic QoS 0
[INFO ] 2023-06-07 14:50:28.321 [grpc-default-executor-0] AgentTestScenario - Message received on agentId paho-java-agent connectionId 1 topic test/topic QoS 0 content <ByteString@76d97d21 size=12 contents="Hello World!">
[INFO ] 2023-06-07 14:50:33.132 [pool-2-thread-1] AgentControlImpl - UnsubscribeMqtt: unsubscribe on connectionId 1
[ERROR] 2023-06-07 14:50:33.141 [pool-2-thread-1] AgentTestScenario - gRPC error code UNIMPLEMENTED: description: Method ClientControl.MqttClientControl/UnsubscribeMqtt is unimplemented
io.grpc.StatusRuntimeException: UNIMPLEMENTED: Method ClientControl.MqttClientControl/UnsubscribeMqtt is unimplemented
```

Client's log:
```
[INFO ] 2023-06-07 14:50:12.206 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Making gPRC client connection with 127.0.0.1:47619 as paho-java-agent...
[INFO ] 2023-06-07 14:50:12.568 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Client connection with Control is established, local address is 127.0.0.1
[INFO ] 2023-06-07 14:50:12.587 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - GRPCControlServer created and listed on 127.0.0.1:40475
[INFO ] 2023-06-07 14:50:12.629 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Handle gRPC requests
[INFO ] 2023-06-07 14:50:12.629 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - Server awaitTermination
[INFO ] 2023-06-07 14:50:15.786 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId best-thing-akezhan broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.eclipse.paho.mqttv5.client.internal.FileLock (file:/home/akezhanuarbekov/.m2/repository/org/eclipse/paho/org.eclipse.paho.mqttv5.client/1.2.5/org.eclipse.paho.mqttv5.client-1.2.5.jar) to method sun.nio.ch.FileLockImpl.release()
WARNING: Please consider reporting this to the maintainers of org.eclipse.paho.mqttv5.client.internal.FileLock
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
[INFO ] 2023-06-07 14:50:22.943 [grpc-default-executor-0] GRPCControlServer - Subscription: filter test/topic QoS 0 noLocal false retainAsPublished false retainHandling 2
[INFO ] 2023-06-07 14:50:22.943 [grpc-default-executor-0] GRPCControlServer - Subscribe: connectionId 1 for 1 filters
[INFO ] 2023-06-07 14:50:23.093 [grpc-default-executor-0] GRPCControlServer - Subscribe response: connectionId 1 reason codes [0] reason string 
[INFO ] 2023-06-07 14:50:28.114 [grpc-default-executor-0] GRPCControlServer - Publish: connectionId 1 topic test/topic QoS 1 retain false
[INFO ] 2023-06-07 14:50:28.124 [grpc-default-executor-0] GRPCControlServer - Publish response: connectionId 1 reason code 0 reason string 
[INFO ] 2023-06-07 14:50:28.305 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT userProperties: region, US
[INFO ] 2023-06-07 14:50:28.306 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT userProperties: type, JSON
[INFO ] 2023-06-07 14:50:28.325 [pool-3-thread-1] MqttConnectionImpl - Received MQTT message: connectionId 1 topic test/topic QoS 0 retain false
[INFO ] 2023-06-07 14:50:33.148 [grpc-default-executor-0] GRPCControlServer - closeMqttConnection: connectionId 1 reason 4
[INFO ] 2023-06-07 14:50:33.266 [grpc-default-executor-0] GRPCControlServer - shutdownAgent: reason That's it.
[INFO ] 2023-06-07 14:50:33.275 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - Server awaitTermination done
[INFO ] 2023-06-07 14:50:33.275 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Shutdown gPRC link
[INFO ] 2023-06-07 14:50:33.285 [com.aws.greengrass.testing.mqtt5.client.Main.main()] Main - Execution done successfully
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
