### PR TITLE
fix(uat): resolve issues in mosquitto/publish and in T13 scenarios

### DIFF
--- a/uat/README.md
+++ b/uat/README.md
@@ -4,6 +4,17 @@ execute E2E
 tests which will spin up an instance of Greengrass on your device and execute different sets of tests, by installing
 the `aws.greengrass.clientdevices.Auth` component.
 
+## Install requirements
+TODO
+```bash
+sudo apt-get install -y maven python3-venv docker.io
+```
+
+## Build the project
+```bash
+mvn -ntp -U clean verify
+```
+
 ## Running UATs locally
 
 ### Requirements

--- a/uat/custom-components/client-mosquitto-c/README.md
+++ b/uat/custom-components/client-mosquitto-c/README.md
@@ -2,12 +2,16 @@
 
 MQTT 3.1.1/5.0 client for tests based on C mosquitto library
 
-## Install requirements
+## Install requirements for native build
 ```bash
 sudo apt-get install -y build-essential gcc cmake git autoconf libtool pkg-config libmosquitto-dev
 ```
 Note: required version 2.0 or above of mosquitto
 
+## Install requirements for docker build
+```bash
+sudo apt-get install -y docker.io
+```
 ## Build
 ```bash
 CXXFLAGS="-Wall -Wextra -g -O0" cmake -Bbuild -H.
@@ -46,9 +50,8 @@ Not all calls are asynchronous.
 2. Subscription on multiple filters.
 Mosquitto API mosquitto_subscribe_multiple() have a common QoS and other properties like retain handling, no local and retain as published for all topic filters.
 It violates MQTT v5.0 where topic filters have separate QoS and other properties.
-At same time usage mosquitto_subscribe_v5() in a loop can can break logic of subscription id.
+At the same time usage mosquitto_subscribe_v5() in a loop can break logic of subscription id which is common for all filters of one subscribe request.
 In result we check all values of QoS and properties in gRPC SubscribeMqtt request and if are not the same report an error in that client.
 
-
 3. Unsubscription
-In Mosquitto API call mosquitto_unsubscribe_v5_callback_set() callback does not provides result codes, instead repeated zero code will be returned on success.
+In Mosquitto API mosquitto_unsubscribe_v5_callback_set() callback does not provides result code, instead zero code will be returned on success.

--- a/uat/mqtt-client-control/pom.xml
+++ b/uat/mqtt-client-control/pom.xml
@@ -129,6 +129,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>${jar.plugin.version}</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -751,7 +751,7 @@ public class MqttControlSteps {
             throw new IllegalStateException("Groups are missing in discovery response");
         }
 
-        log.info("Discovered data for broker {}: ", brokerId);
+        log.info("Discovered data for broker {}:", brokerId);
         groups.stream().forEach(group -> {
             log.info("groupId {} with {} CA", group.getGGGroupId(), group.getCAs().size());
             group.getCores().stream().forEach(core -> {

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -56,7 +56,7 @@ Feature: GGMQ-1
     """
 
     And I deploy the Greengrass deployment configuration
-    Then the Greengrass deployment is COMPLETED on the device after 300 seconds
+    Then the Greengrass deployment is COMPLETED on the device after 5 minutes
 
     And I discover core device broker as "default_broker" from "clientDeviceTest" in OTF
     And I connect device "clientDeviceTest" on <agent> to "default_broker" using mqtt "<mqtt-v>"
@@ -199,7 +199,7 @@ Feature: GGMQ-1
 }
     """
     And I deploy the Greengrass deployment configuration
-    Then the Greengrass deployment is COMPLETED on the device after 300 seconds
+    Then the Greengrass deployment is COMPLETED on the device after 5 minutes
     And the greengrass log on the device contains the line "com.aws.greengrass.mqtt.bridge.clients.MQTTClient: Connected to broker" within 60 seconds
 
     Then I discover core device broker as "default_broker" from "publisher" in OTF
@@ -243,15 +243,16 @@ Feature: GGMQ-1
 
 
   @GGMQ-1-T13
-  Scenario Outline: GGMQ-1-T13-<mqtt-v>: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration
+  Scenario Outline: GGMQ-1-T13-<mqtt-v>-<name>: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration
     When I create a Greengrass deployment with components
-      | aws.greengrass.clientdevices.Auth        | LATEST                                              |
-      | aws.greengrass.clientdevices.mqtt.EMQX   | LATEST                                              |
-      | aws.greengrass.clientdevices.IPDetector  | LATEST                                              |
-      | aws.greengrass.client.Mqtt5JavaSdkClient | classpath:/local-store/recipes/client_java_sdk.yaml |
+      | aws.greengrass.clientdevices.Auth        | LATEST                                  |
+      | aws.greengrass.clientdevices.mqtt.EMQX   | LATEST                                  |
+      | aws.greengrass.clientdevices.IPDetector  | LATEST                                  |
+      | <agent>                                  | classpath:/local-store/recipes/<recipe> |
 
     And I create client device "publisher"
     And I create client device "subscriber"
+
     And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:
     """
 {
@@ -261,11 +262,11 @@ Feature: GGMQ-1
             "definitions":{
                 "MyPermissiveDeviceGroup":{
                     "selectionRule":"thingName: ${publisher} OR thingName: ${subscriber}",
-                    "policyName":"MyPermissivePolicy"
+                    "policyName":"Policy1"
                 }
             },
             "policies":{
-                "MyPermissivePolicy":{
+                "Policy1":{
                     "AllowConnect":{
                         "statementDescription":"Allow client devices to connect.",
                         "operations":[
@@ -275,8 +276,8 @@ Feature: GGMQ-1
                             "*"
                         ]
                     },
-                    "AllowPublish":{
-                        "statementDescription":"Allow client devices to publish on test/topic.",
+                    "AllowOnlyPublish":{
+                        "statementDescription":"Allow client devices to only publish to all topics.",
                         "operations":[
                             "mqtt:publish"
                         ],
@@ -290,7 +291,7 @@ Feature: GGMQ-1
     }
 }
     """
-    And I update my Greengrass deployment configuration, setting the component aws.greengrass.client.Mqtt5JavaSdkClient configuration to:
+    And I update my Greengrass deployment configuration, setting the component <agent> configuration to:
     """
 {
     "MERGE":{
@@ -303,20 +304,20 @@ Feature: GGMQ-1
     When I associate "subscriber" with ggc
 
     And I deploy the Greengrass deployment configuration
-    Then the Greengrass deployment is COMPLETED on the device after 300 seconds
+    Then the Greengrass deployment is COMPLETED on the device after 5 minutes
 
     And I discover core device broker as "default_broker" from "publisher" in OTF
-    And I connect device "publisher" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker" using mqtt "<mqtt-v>"
-    And I connect device "subscriber" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker" using mqtt "<mqtt-v>"
+    And I connect device "publisher" on <agent> to "default_broker" using mqtt "<mqtt-v>"
+    And I connect device "subscriber" on <agent> to "default_broker" using mqtt "<mqtt-v>"
 
-    When I subscribe "subscriber" to "iot_data_0" with qos 0 and expect status "<subscribe-status>"
-    When I subscribe "subscriber" to "iot_data_1" with qos 1 and expect status "<subscribe-status>"
+    When I subscribe "subscriber" to "iot_data_0" with qos 0 and expect status "<subscribe-status-na>"
+    When I subscribe "subscriber" to "iot_data_1" with qos 1 and expect status "<subscribe-status-na>"
 
-    When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world0"
-    Then message "Hello world0" received on "subscriber" from "iot_data_0" topic within 10 seconds
+    When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world 0"
+    Then message "Hello world 0" received on "subscriber" from "iot_data_0" topic within 10 seconds is false expected
 
-    When I publish from "publisher" to "iot_data_1" with qos 1 and message "Hello world1" and expect status <publish-status>
-    Then message "Hello world1" received on "subscriber" from "iot_data_1" topic within 10 seconds is false expected
+    When I publish from "publisher" to "iot_data_1" with qos 1 and message "Hello world 1" and expect status <publish-status-nms>
+    Then message "Hello world 1" received on "subscriber" from "iot_data_1" topic within 10 seconds is false expected
 
     And I disconnect device "subscriber" with reason code 0
     And I disconnect device "publisher" with reason code 0
@@ -325,7 +326,8 @@ Feature: GGMQ-1
       | aws.greengrass.clientdevices.Auth        | LATEST |
       | aws.greengrass.clientdevices.mqtt.EMQX   | LATEST |
       | aws.greengrass.clientdevices.IPDetector  | LATEST |
-      | aws.greengrass.client.Mqtt5JavaSdkClient | LATEST |
+      | <agent>                                  | LATEST |
+
     And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:
     """
 {
@@ -334,13 +336,31 @@ Feature: GGMQ-1
             "formatVersion":"2021-03-05",
             "definitions":{
                 "SubscriberDeviceGroup":{
-                    "selectionRule":"thingName: ${subscriber}",
-                    "policyName":"MyPermissiveSubscribePolicy"
+                    "selectionRule":"thingName: ${publisher} OR thingName: ${subscriber}",
+                    "policyName":"Policy2"
                 }
             },
             "policies":{
-                "MyPermissiveSubscribePolicy":{
-                    "AllowSubscribe":{
+                "Policy2":{
+                    "AllowConnect":{
+                        "statementDescription":"Allow client devices to connect.",
+                        "operations":[
+                            "mqtt:connect"
+                        ],
+                        "resources":[
+                            "*"
+                        ]
+                    },
+                    "AllowOnlyPublish":{
+                        "statementDescription":"Allow client devices to only publish to all topics.",
+                        "operations":[
+                            "mqtt:publish"
+                        ],
+                        "resources":[
+                            "*"
+                        ]
+                    },
+                    "AllowOneSubscribe":{
                         "statementDescription":"Allow client devices to subscribe to iot_data_1.",
                         "operations":[
                             "mqtt:subscribe"
@@ -359,27 +379,40 @@ Feature: GGMQ-1
     Then the Greengrass deployment is COMPLETED on the device after 299 seconds
 
     And I discover core device broker as "default_broker" from "subscriber" in OTF
-    And I connect device "publisher" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker" using mqtt "<mqtt-v>"
-    And I connect device "subscriber" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker" using mqtt "<mqtt-v>"
+    And I connect device "publisher" on <agent> to "default_broker" using mqtt "<mqtt-v>"
+    And I connect device "subscriber" on <agent> to "default_broker" using mqtt "<mqtt-v>"
 
-    When I subscribe "subscriber" to "iot_data_0" with qos 0 and expect status "<subscribe-status>"
-    When I subscribe "subscriber" to "iot_data_1" with qos 1 and expect status "<subscribe-status-auth>"
+    When I subscribe "subscriber" to "iot_data_0" with qos 0 and expect status "<subscribe-status-na>"
+    When I subscribe "subscriber" to "iot_data_1" with qos 1 and expect status "<subscribe-status-good>"
 
-    When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world"
-    Then message "Hello world" received on "subscriber" from "iot_data_0" topic within 10 seconds is false expected
+    When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world 2"
+    Then message "Hello world 2" received on "subscriber" from "iot_data_0" topic within 10 seconds is false expected
 
-    When I publish from "publisher" to "iot_data_1" with qos 1 and message "Hello world"
-    Then message "Hello world" received on "subscriber" from "iot_data_1" topic within 10 seconds
+    When I publish from "publisher" to "iot_data_1" with qos 1 and message "Hello world 3"
+    Then message "Hello world 3" received on "subscriber" from "iot_data_1" topic within 10 seconds
 
+    # WARNING: AWS IoT device SDK Java v2 MQTT v3 client in software.amazon.awssdk.crt.mqtt.MqttClientConnection
+    #  missing API to getting actual reason code, client always return reason code 0 on publish and subscribe.
+    #  It makes sdk-java client useless for T13
     @mqtt3 @sdk-java
     Examples:
-      | mqtt-v | subscribe-status | publish-status | subscribe-status-auth |
-      | v3     | GRANTED_QOS_0    | 0              | GRANTED_QOS_0         |
+      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
+      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    | GRANTED_QOS_0       | GRANTED_QOS_0         | 0                  |
+
+    @mqtt3 @mosquitto-c
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
+      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | UNSPECIFIED_ERROR   | GRANTED_QOS_1         | 0                  |
 
     @mqtt5 @sdk-java
     Examples:
-      | mqtt-v | subscribe-status | publish-status | subscribe-status-auth |
-      | v5     | NOT_AUTHORIZED   | 16             | GRANTED_QOS_1         |
+      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
+      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    | NOT_AUTHORIZED      | GRANTED_QOS_1         | 16                 |
+
+    @mqtt5 @mosquitto-c
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
+      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | NOT_AUTHORIZED      | GRANTED_QOS_1         | 16                 |
 
 
   @GGMQ-1-T14
@@ -462,7 +495,7 @@ Feature: GGMQ-1
 }
     """
     And I deploy the Greengrass deployment configuration
-    Then the Greengrass deployment is COMPLETED on the device after 300 seconds
+    Then the Greengrass deployment is COMPLETED on the device after 5 minutes
     And the greengrass log on the device contains the line "com.aws.greengrass.mqtt.bridge.clients.MQTTClient: Connected to broker" within 60 seconds
 
     When I discover core device broker as "localBroker" from "localMqttSubscriber" in OTF
@@ -578,7 +611,7 @@ Feature: GGMQ-1
 }
     """
     And I deploy the Greengrass deployment configuration
-    Then the Greengrass deployment is COMPLETED on the device after 300 seconds
+    Then the Greengrass deployment is COMPLETED on the device after 5 minutes
     And the greengrass log on the device contains the line "com.aws.greengrass.mqtt.bridge.clients.MQTTClient: Connected to broker" within 60 seconds
 
     Then I discover core device broker as "default_broker" from "subscriber" in OTF
@@ -686,7 +719,7 @@ Feature: GGMQ-1
 }
     """
     And I deploy the Greengrass deployment configuration
-    Then the Greengrass deployment is COMPLETED on the device after 300 seconds
+    Then the Greengrass deployment is COMPLETED on the device after 5 minutes
 
     Then I discover core device broker as "localMqttBroker1" from "publisher" in OTF
     Then I discover core device broker as "localMqttBroker2" from "subscriber" in OTF


### PR DESCRIPTION
**Issue #, if available:**
Both GGMQ-1-T13-vX failed on Windows and linux

**Description of changes:**
- Update GGMQ-1-T13 to fix CDA misconfigure issue and add mosquitto-c client
- Fix bug in missing reason code in publish of mosquitto client
- Updated uat/README.md by adding requirements and build steps description
- Update mosquitto REAME.md by adding commands for docker build and limitations
- Fix missing jar.plugin.version in control's pom.xml

**Why is this change necessary:**
Scenarios in T13 outline are invalid

**How was this change tested:**
Run scenarios locally manually and on CI

**Test results:**
```
[INFO ] 2023-06-14 01:18:24.535 [main] StepTrackingReporting - Passed: 'GGMQ-1-T13-v3-sdk-java: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration'
[INFO ] 2023-06-14 01:18:24.535 [main] StepTrackingReporting - Passed: 'GGMQ-1-T13-v3-mosquitto-c: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration'
[INFO ] 2023-06-14 01:18:24.535 [main] StepTrackingReporting - Passed: 'GGMQ-1-T13-v5-sdk-java: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration'
[INFO ] 2023-06-14 01:18:24.535 [main] StepTrackingReporting - Passed: 'GGMQ-1-T13-v5-mosquitto-c: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration'
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
