### PR TITLE
feat(uat): added new step for scenario

### DIFF
--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -601,6 +601,16 @@ public class MqttControlSteps {
     }
 
     /**
+     * Clear message storage.
+     *
+     */
+    @And("I clear message storage")
+    public void clearStorage() {
+        eventStorage.clear();
+        log.info("Storage was cleared");
+    }
+
+    /**
      * Discover IoT core device broker directly in OTF.
      *
      * @param brokerId       broker name in tests

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -529,6 +529,24 @@ public class MqttControlSteps {
         log.info("MQTT message {} has been succesfully published", message);
     }
 
+    /**
+     * Verify is MQTT message is received in limited duration of time.
+     *
+     * @param message content of message to receive
+     * @param clientDeviceId the user defined client device id
+     * @param topicString the topic (not a filter) which message has been sent
+     * @param value the duration of time to wait for message
+     * @param unit the time unit to wait
+     * @throws TimeoutException when matched message was not received in specified duration of time
+     * @throws RuntimeException on internal errors
+     * @throws InterruptedException then thread has been interrupted
+     */
+    @SuppressWarnings("PMD.UseObjectForClearerAPI")
+    @And("message {string} is not received on {string} from {string} topic within {int} {word}")
+    public void notReceivedMessage(String message, String clientDeviceId, String topicString, int value, String unit)
+            throws TimeoutException, InterruptedException {
+        receive(message, clientDeviceId, topicString, value, unit, false);
+    }
 
     /**
      * Verify is MQTT message is received in limited duration of time.
@@ -563,7 +581,6 @@ public class MqttControlSteps {
      * @throws InterruptedException then thread has been interrupted
      */
     @SuppressWarnings("PMD.UseObjectForClearerAPI")
-    @And("message {string} received on {string} from {string} topic within {int} {word} is {booleanValue} expected")
     public void receive(String message, String clientDeviceId, String topicString, int value,
                         String unit, Boolean isExpectedMessage)
                             throws TimeoutException, InterruptedException {

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -670,7 +670,7 @@ Feature: GGMQ-1
 
 
   @GGMQ-1-T101
-  Scenario Outline: GGMQ-1-T101-<mqtt-v>-<name>: As a customer, I can use publish retain flag and subscribe retain handling as expected
+  Scenario Outline: GGMQ-1-T101-<mqtt-v>-<name>: As a customer, I can use publish retain flag
     When I create a Greengrass deployment with components
       | aws.greengrass.clientdevices.Auth       | LATEST                                  |
       | aws.greengrass.clientdevices.mqtt.EMQX  | LATEST                                  |
@@ -729,20 +729,126 @@ Feature: GGMQ-1
     And I set MQTT publish retain flag to true
 
     When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world0"
-    And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION"
     When I subscribe "subscriber" to "iot_data_0" with qos 0
     And message "Hello world0" received on "subscriber" from "iot_data_0" topic within 5 seconds
 
+    And I set MQTT publish retain flag to false
+
     When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world1"
-    And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_NEW_SUBSCRIPTION"
     When I subscribe "subscriber" to "iot_data_1" with qos 0
-    And message "Hello world1" received on "subscriber" from "iot_data_1" topic within 5 seconds
+    And message "Hello world1" received on "subscriber" from "iot_data_1" topic within 5 seconds is false expected
+
+    @mqtt3 @sdk-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
+
+    @mqtt3 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
+
+    @mqtt3 @mosquitto-c
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
+
+
+  @GGMQ-1-T102
+  Scenario Outline: GGMQ-1-T102-<mqtt-v>-<name>: As a customer, I can use publish retain flag and subscribe retain handling as expected
+    When I create a Greengrass deployment with components
+      | aws.greengrass.clientdevices.Auth       | LATEST                                  |
+      | aws.greengrass.clientdevices.mqtt.EMQX  | LATEST                                  |
+      | aws.greengrass.clientdevices.IPDetector | LATEST                                  |
+      | <agent>                                 | classpath:/local-store/recipes/<recipe> |
+    And I create client device "publisher"
+    And I create client device "subscriber"
+    When I associate "subscriber" with ggc
+    When I associate "publisher" with ggc
+    And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:
+    """
+{
+    "MERGE":{
+        "deviceGroups":{
+            "formatVersion":"2021-03-05",
+            "definitions":{
+                "MyPermissiveDeviceGroup":{
+                    "selectionRule":"thingName: ${publisher} OR thingName: ${subscriber}",
+                    "policyName":"MyPermissivePolicy"
+                }
+            },
+            "policies":{
+                "MyPermissivePolicy":{
+                    "AllowAll":{
+                        "statementDescription":"Allow client devices to perform all actions.",
+                        "operations":[
+                            "*"
+                        ],
+                        "resources":[
+                            "*"
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}
+    """
+    And I update my Greengrass deployment configuration, setting the component <agent> configuration to:
+    """
+{
+    "MERGE":{
+        "controlAddresses":"${mqttControlAddresses}",
+        "controlPort":"${mqttControlPort}"
+    }
+}
+    """
+    And I deploy the Greengrass deployment configuration
+    Then the Greengrass deployment is COMPLETED on the device after 300 seconds
+
+    Then I discover core device broker as "localMqttBroker1" from "publisher" in OTF
+    Then I discover core device broker as "localMqttBroker2" from "subscriber" in OTF
+    And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
+    And I connect device "subscriber" on <agent> to "localMqttBroker2" using mqtt "<mqtt-v>"
+
+    And I set MQTT publish retain flag to true
+    When I publish from "publisher" to "iot_data_001" with qos 0 and message "Old retained message"
+    When I publish from "publisher" to "iot_data_001" with qos 0 and message "New retained message"
+    And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION"
+    When I subscribe "subscriber" to "iot_data_001" with qos 0
+    And message "Old retained message" received on "subscriber" from "iot_data_001" topic within 5 seconds is false expected
+    And message "New retained message" received on "subscriber" from "iot_data_001" topic within 5 seconds
+
+    And I set MQTT publish retain flag to true
+    When I publish from "publisher" to "iot_data_002" with qos 0 and message "Old retained message 002"
+    And I set MQTT publish retain flag to false
+    When I publish from "publisher" to "iot_data_002" with qos 0 and message "New retained message 002"
+    When I subscribe "subscriber" to "iot_data_002" with qos 0
+    And message "New retained message 002" received on "subscriber" from "iot_data_002" topic within 5 seconds is false expected
+    And message "Old retained message 002" received on "subscriber" from "iot_data_002" topic within 5 seconds
+
+    And I set MQTT publish retain flag to true
+
+    When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world0"
+    And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION"
+    When I subscribe "subscriber" to "iot_data_0" with qos 0
+    And message "Hello world0" received on "subscriber" from "iot_data_0" topic within 5 seconds
+    And I clear message storage
+    When I subscribe "subscriber" to "iot_data_0" with qos 0
+    And message "Hello world0" received on "subscriber" from "iot_data_0" topic within 5 seconds
+
+    When I publish from "publisher" to "retained/iot_data_1" with qos 1 and message "Hello world1" and expect status 16
+    And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_NEW_SUBSCRIPTION"
+    When I subscribe "subscriber" to "retained/iot_data_1" with qos 0
+    And message "Hello world1" received on "subscriber" from "retained/iot_data_1" topic within 5 seconds
+    And I clear message storage
+    When I subscribe "subscriber" to "retained/iot_data_1" with qos 0
+    And message "Hello world1" received on "subscriber" from "retained/iot_data_1" topic within 5 seconds is false expected
 
     When I publish from "publisher" to "iot_data_2" with qos 0 and message "Hello world2"
     And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_DO_NOT_SEND_AT_SUBSCRIPTION"
     When I subscribe "subscriber" to "iot_data_2" with qos 0
-    And message "Hello world2" received on "subscriber" from "iot_data_2" topic within 5 seconds is <retainHandling-2> expected
-
+    And message "Hello world2" received on "subscriber" from "iot_data_2" topic within 5 seconds is false expected
 
     And I set MQTT publish retain flag to false
 
@@ -761,32 +867,17 @@ Feature: GGMQ-1
     When I subscribe "subscriber" to "iot_data_5" with qos 0
     And message "Hello world5" received on "subscriber" from "iot_data_5" topic within 5 seconds is false expected
 
-    @mqtt3 @sdk-java
-    Examples:
-      | mqtt-v | name        | agent                                     | recipe                  | retainHandling-2 |
-      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    | true             |
-
-    @mqtt3 @paho-java
-    Examples:
-      | mqtt-v | name        | agent                                     | recipe                  | retainHandling-2 |
-      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   | true             |
-
-    @mqtt3 @mosquitto-c
-    Examples:
-      | mqtt-v | name        | agent                                     | recipe                  | retainHandling-2 |
-      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | true             |
-
     @mqtt5 @sdk-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  | retainHandling-2 |
-      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    | false            |
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
 
     @mqtt5 @paho-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  | retainHandling-2 |
-      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   | false            |
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
 
     @mqtt5 @mosquitto-c
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  | retainHandling-2 |
-      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | false            |
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -314,10 +314,10 @@ Feature: GGMQ-1
     When I subscribe "subscriber" to "iot_data_1" with qos 1 and expect status "<subscribe-status-na>"
 
     When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world 0"
-    Then message "Hello world 0" received on "subscriber" from "iot_data_0" topic within 10 seconds is false expected
+    Then message "Hello world 0" is not received on "subscriber" from "iot_data_0" topic within 10 seconds
 
     When I publish from "publisher" to "iot_data_1" with qos 1 and message "Hello world 1" and expect status <publish-status-nms>
-    Then message "Hello world 1" received on "subscriber" from "iot_data_1" topic within 10 seconds is false expected
+    Then message "Hello world 1" is not received on "subscriber" from "iot_data_1" topic within 10 seconds
 
     And I disconnect device "subscriber" with reason code 0
     And I disconnect device "publisher" with reason code 0
@@ -386,7 +386,7 @@ Feature: GGMQ-1
     When I subscribe "subscriber" to "iot_data_1" with qos 1 and expect status "<subscribe-status-good>"
 
     When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world 2"
-    Then message "Hello world 2" received on "subscriber" from "iot_data_0" topic within 10 seconds is false expected
+    Then message "Hello world 2" is not received on "subscriber" from "iot_data_0" topic within 10 seconds
 
     When I publish from "publisher" to "iot_data_1" with qos 1 and message "Hello world 3"
     Then message "Hello world 3" received on "subscriber" from "iot_data_1" topic within 10 seconds
@@ -736,7 +736,7 @@ Feature: GGMQ-1
 
     When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world1"
     When I subscribe "subscriber" to "iot_data_1" with qos 0
-    And message "Hello world1" received on "subscriber" from "iot_data_1" topic within 5 seconds is false expected
+    And message "Hello world1" is not received on "subscriber" from "iot_data_1" topic within 5 seconds
 
     @mqtt3 @sdk-java
     Examples:
@@ -816,7 +816,7 @@ Feature: GGMQ-1
     When I publish from "publisher" to "iot_data_001" with qos 0 and message "New retained message"
     And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION"
     When I subscribe "subscriber" to "iot_data_001" with qos 0
-    And message "Old retained message" received on "subscriber" from "iot_data_001" topic within 5 seconds is false expected
+    And message "Old retained message" is not received on "subscriber" from "iot_data_001" topic within 5 seconds
     And message "New retained message" received on "subscriber" from "iot_data_001" topic within 5 seconds
 
     And I set MQTT publish retain flag to true
@@ -824,7 +824,7 @@ Feature: GGMQ-1
     And I set MQTT publish retain flag to false
     When I publish from "publisher" to "iot_data_002" with qos 0 and message "New retained message 002"
     When I subscribe "subscriber" to "iot_data_002" with qos 0
-    And message "New retained message 002" received on "subscriber" from "iot_data_002" topic within 5 seconds is false expected
+    And message "New retained message 002" is not received on "subscriber" from "iot_data_002" topic within 5 seconds
     And message "Old retained message 002" received on "subscriber" from "iot_data_002" topic within 5 seconds
 
     And I set MQTT publish retain flag to true
@@ -843,29 +843,29 @@ Feature: GGMQ-1
     And message "Hello world1" received on "subscriber" from "retained/iot_data_1" topic within 5 seconds
     And I clear message storage
     When I subscribe "subscriber" to "retained/iot_data_1" with qos 0
-    And message "Hello world1" received on "subscriber" from "retained/iot_data_1" topic within 5 seconds is false expected
+    And message "Hello world1" is not received on "subscriber" from "retained/iot_data_1" topic within 5 seconds
 
     When I publish from "publisher" to "iot_data_2" with qos 0 and message "Hello world2"
     And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_DO_NOT_SEND_AT_SUBSCRIPTION"
     When I subscribe "subscriber" to "iot_data_2" with qos 0
-    And message "Hello world2" received on "subscriber" from "iot_data_2" topic within 5 seconds is false expected
+    And message "Hello world2" is not received on "subscriber" from "iot_data_2" topic within 5 seconds
 
     And I set MQTT publish retain flag to false
 
     When I publish from "publisher" to "iot_data_3" with qos 0 and message "Hello world3"
     And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION"
     When I subscribe "subscriber" to "iot_data_3" with qos 0
-    And message "Hello world3" received on "subscriber" from "iot_data_3" topic within 5 seconds is false expected
+    And message "Hello world3" is not received on "subscriber" from "iot_data_3" topic within 5 seconds
 
     When I publish from "publisher" to "iot_data_4" with qos 0 and message "Hello world4"
     And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_NEW_SUBSCRIPTION"
     When I subscribe "subscriber" to "iot_data_4" with qos 0
-    And message "Hello world4" received on "subscriber" from "iot_data_4" topic within 5 seconds is false expected
+    And message "Hello world4" is not received on "subscriber" from "iot_data_4" topic within 5 seconds
 
     When I publish from "publisher" to "iot_data_5" with qos 0 and message "Hello world5"
     And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_DO_NOT_SEND_AT_SUBSCRIPTION"
     When I subscribe "subscriber" to "iot_data_5" with qos 0
-    And message "Hello world5" received on "subscriber" from "iot_data_5" topic within 5 seconds is false expected
+    And message "Hello world5" is not received on "subscriber" from "iot_data_5" topic within 5 seconds
 
     @mqtt5 @sdk-java
     Examples:


### PR DESCRIPTION
**Issue #, if available:**
feat(uat): added new step for scenario

**Description of changes:**
- Extend test scenario
- Add new step

**Why is this change necessary:**
In GGMQ-1-T102 we testing ability to subscribe with retain handling

**How was this change tested:**
Scenarios run manually and on CI

**Test results:**
```
Given my device is registered as a Thing....................................passed
And my device is running Greengrass.........................................passed
When I create a Greengrass deployment with components.......................passed
And I create client device "publisher"......................................passed
And I create client device "subscriber".....................................passed
When I associate "subscriber" with ggc......................................passed
When I associate "publisher" with ggc.......................................passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:.passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.client.Mqtt5JavaSdkClient configuration to:.passed
And I deploy the Greengrass deployment configuration........................passed
Then the Greengrass deployment is COMPLETED on the device after 300 seconds.passed
Then I discover core device broker as "localMqttBroker1" from "publisher" in OTF.passed
Then I discover core device broker as "localMqttBroker2" from "subscriber" in OTF.passed
And I connect device "publisher" on aws.greengrass.client.Mqtt5JavaSdkClient to "localMqttBroker1" using mqtt "v5".passed
And I connect device "subscriber" on aws.greengrass.client.Mqtt5JavaSdkClient to "localMqttBroker2" using mqtt "v5".passed
And I set MQTT publish retain flag to true..................................passed
When I publish from "publisher" to "iot_data_001" with qos 0 and message "Old retained message".passed
When I publish from "publisher" to "iot_data_001" with qos 0 and message "New retained message".passed
And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION".passed
When I subscribe "subscriber" to "iot_data_001" with qos 0..................passed
And message "Old retained message" received on "subscriber" from "iot_data_001" topic within 5 seconds is false expected.passed
And message "New retained message" received on "subscriber" from "iot_data_001" topic within 5 seconds.passed
And I set MQTT publish retain flag to true..................................passed
When I publish from "publisher" to "iot_data_002" with qos 0 and message "Old retained message 002".passed
And I set MQTT publish retain flag to false.................................passed
When I publish from "publisher" to "iot_data_002" with qos 0 and message "New retained message 002".passed
When I subscribe "subscriber" to "iot_data_002" with qos 0..................passed
And message "New retained message 002" received on "subscriber" from "iot_data_002" topic within 5 seconds is false expected.passed
And message "Old retained message 002" received on "subscriber" from "iot_data_002" topic within 5 seconds.passed
And I set MQTT publish retain flag to true..................................passed
When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world0".passed
And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION".passed
When I subscribe "subscriber" to "iot_data_0" with qos 0....................passed
And message "Hello world0" received on "subscriber" from "iot_data_0" topic within 5 seconds.passed
And I clear message storage.................................................passed
When I subscribe "subscriber" to "iot_data_0" with qos 0....................passed
And message "Hello world0" received on "subscriber" from "iot_data_0" topic within 5 seconds.passed
When I publish from "publisher" to "retained/iot_data_1" with qos 1 and message "Hello world1" and expect status 16.passed
And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_NEW_SUBSCRIPTION".passed
When I subscribe "subscriber" to "retained/iot_data_1" with qos 0...........passed
And message "Hello world1" received on "subscriber" from "retained/iot_data_1" topic within 5 seconds.passed
And I clear message storage.................................................passed
When I subscribe "subscriber" to "retained/iot_data_1" with qos 0...........passed
And message "Hello world1" received on "subscriber" from "retained/iot_data_1" topic within 5 seconds is false expected.passed
When I publish from "publisher" to "iot_data_2" with qos 0 and message "Hello world2".passed
And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_DO_NOT_SEND_AT_SUBSCRIPTION".passed
When I subscribe "subscriber" to "iot_data_2" with qos 0....................passed
And message "Hello world2" received on "subscriber" from "iot_data_2" topic within 5 seconds is false expected.passed
And I set MQTT publish retain flag to false.................................passed
When I publish from "publisher" to "iot_data_3" with qos 0 and message "Hello world3".passed
And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION".passed
When I subscribe "subscriber" to "iot_data_3" with qos 0....................passed
And message "Hello world3" received on "subscriber" from "iot_data_3" topic within 5 seconds is false expected.passed
When I publish from "publisher" to "iot_data_4" with qos 0 and message "Hello world4".passed
And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_SEND_AT_NEW_SUBSCRIPTION".passed
When I subscribe "subscriber" to "iot_data_4" with qos 0....................passed
And message "Hello world4" received on "subscriber" from "iot_data_4" topic within 5 seconds is false expected.passed
When I publish from "publisher" to "iot_data_5" with qos 0 and message "Hello world5".passed
And I set MQTT subscribe retain handling property to "MQTT5_RETAIN_DO_NOT_SEND_AT_SUBSCRIPTION".passed
When I subscribe "subscriber" to "iot_data_5" with qos 0....................passed
And message "Hello world5" received on "subscriber" from "iot_data_5" topic within 5 seconds is false expected.passed

```
**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

