### PR TITLE
fix(uat): attempt to fix connection failed issue

### DIFF
--- a/uat/README.md
+++ b/uat/README.md
@@ -1,5 +1,5 @@
 ## Client Devices Auth User Acceptance Tests
-User Acceptance Tests for Client Devices Auth run using `aws-greengrass-testing-standalone` as a library.
+User Acceptance Tests for Client Devices Auth run using `aws-greengrass-testing` as a library.
 They execute E2E tests which will spin up an instance of Greengrass on your device and execute different sets of tests, 
 by installing the `aws.greengrass.clientdevices.Auth` component.
 
@@ -29,6 +29,7 @@ Please update your /etc/sudoers on Linux to satisfy this requirement.
 Ensure credentials are available by setting them in environment variables. In unix based systems:
 
 ```bash
+export AWS_REGION=<AWS_REGION>
 export AWS_ACCESS_KEY_ID=<AWS_ACCESS_KEY_ID>
 export AWS_SECRET_ACCESS_KEY=<AWS_SECRET_ACCESS_KEY>
 ```
@@ -36,13 +37,14 @@ export AWS_SECRET_ACCESS_KEY=<AWS_SECRET_ACCESS_KEY>
 on Windows Powershell
 
 ```bash
+$Env:AWS_REGION=<AWS_REGION>
 $Env:AWS_ACCESS_KEY_ID=<AWS_ACCESS_KEY_ID>
 $Env:AWS_SECRET_ACCESS_KEY=<AWS_SECRET_ACCESS_KEY>
 ```
 
 - Configure user credentials for Windows devices
     - create user ggc_user
-    - assign gcc_user to Administrators group and remove from Users group
+    - assign ggc_user to Administrators group and remove from Users group
     - log out as your used and log in as ggc_user
     - open cmd as Administrator
 
@@ -71,15 +73,14 @@ curl -s https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-nucleus-latest
 Execute the UATs by running the following commands from the uat directory of the project.
 
 ```bash
-java -Dggc.archive=<path-to-nucleus-zip> -Dtest.log.path=<path-to-test-results-folder> -Dtags=GGMQ -jar <path-to-test-jar>
+sudo java -Dggc.archive=<path-to-nucleus-zip> -Dtest.log.path=<path-to-test-results-folder> -Dtags=GGMQ -jar <path-to-test-jar>
 ```
 An example to run from uat directory:
 ```bash
-java -Dggc.archive=greengrass-nucleus-latest.zip -Dtest.log.path=logs -Dtags="GGMQ" -jar testing-features/target/client-devices-auth-testing-features.jar
+sudo java -Dggc.archive=greengrass-nucleus-latest.zip -Dtest.log.path=logs -Dtags="GGMQ" -jar testing-features/target/client-devices-auth-testing-features.jar
 ```
 
-On Windows
-Due to mosquitto-based client is not yet build on Windows use a little modified command.
+On Windows due to mosquitto-based client is not yet build on Windows use a little modified command.
 ```cmd
 java -Dggc.archive=greengrass-nucleus-latest.zip -Dtest.log.path=logs -Dtags="@GGMQ and not @mosquitto-c" -jar testing-features/target/client-devices-auth-testing-features.jar
 ```

--- a/uat/custom-components/client-mosquitto-c/pom.xml
+++ b/uat/custom-components/client-mosquitto-c/pom.xml
@@ -74,6 +74,7 @@
                             <useDefaultExcludes>true</useDefaultExcludes>
                             <excludes>
                                 <exclude>*</exclude>
+                                <exclude>build/**</exclude>
                             </excludes>
                         </licenseSet>
                     </licenseSets>

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.cpp
@@ -199,7 +199,7 @@ ClientControl::Mqtt5ConnAck * MqttConnection::start(unsigned timeout) {
         rc = mosquitto_connect_bind_v5(m_mosq, m_host.c_str(), m_port, m_keepalive, NULL, m_conn_properties);
         // rc = mosquitto_connect_bind_async(m_mosq, m_host.c_str(), m_port, m_keepalive, NULL);
         if (rc != MOSQ_ERR_SUCCESS) {
-            loge("mosquitto_connect_bind_async failed with code %d: %s\n", rc, mosquitto_strerror(rc));
+            loge("mosquitto_connect_bind_v5 failed with code %d: %s\n", rc, mosquitto_strerror(rc));
             destroyLocked();
             throw MqttException("couldn't establish MQTT connection", rc);
         }

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -57,6 +57,7 @@ Feature: GGMQ-1
 
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 5 minutes
+    And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes
 
     And I discover core device broker as "default_broker" from "clientDeviceTest" in OTF
     And I connect device "clientDeviceTest" on <agent> to "default_broker" using mqtt "<mqtt-v>"
@@ -200,7 +201,7 @@ Feature: GGMQ-1
     """
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 5 minutes
-    And the greengrass log on the device contains the line "com.aws.greengrass.mqtt.bridge.clients.MQTTClient: Connected to broker" within 60 seconds
+    And the greengrass log on the device contains the line "com.aws.greengrass.mqtt.bridge.clients.MQTTClient: Connected to broker" within 1 minutes
 
     Then I discover core device broker as "default_broker" from "publisher" in OTF
     And I connect device "publisher" on <agent> to "default_broker" using mqtt "<mqtt-v>"
@@ -305,6 +306,7 @@ Feature: GGMQ-1
 
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 5 minutes
+    And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes
 
     And I discover core device broker as "default_broker" from "publisher" in OTF
     And I connect device "publisher" on <agent> to "default_broker" using mqtt "<mqtt-v>"
@@ -496,7 +498,7 @@ Feature: GGMQ-1
     """
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 5 minutes
-    And the greengrass log on the device contains the line "com.aws.greengrass.mqtt.bridge.clients.MQTTClient: Connected to broker" within 60 seconds
+    And the greengrass log on the device contains the line "com.aws.greengrass.mqtt.bridge.clients.MQTTClient: Connected to broker" within 1 minutes
 
     When I discover core device broker as "localBroker" from "localMqttSubscriber" in OTF
     And I label IoT Core broker as "iotCoreBroker"
@@ -612,7 +614,7 @@ Feature: GGMQ-1
     """
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 5 minutes
-    And the greengrass log on the device contains the line "com.aws.greengrass.mqtt.bridge.clients.MQTTClient: Connected to broker" within 60 seconds
+    And the greengrass log on the device contains the line "com.aws.greengrass.mqtt.bridge.clients.MQTTClient: Connected to broker" within 1 minutes
 
     Then I discover core device broker as "default_broker" from "subscriber" in OTF
     And I connect device "subscriber" on <agent> to "default_broker" using mqtt "<mqtt-v>"
@@ -720,6 +722,7 @@ Feature: GGMQ-1
     """
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 5 minutes
+    And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes
 
     Then I discover core device broker as "localMqttBroker1" from "publisher" in OTF
     Then I discover core device broker as "localMqttBroker2" from "subscriber" in OTF
@@ -804,7 +807,8 @@ Feature: GGMQ-1
 }
     """
     And I deploy the Greengrass deployment configuration
-    Then the Greengrass deployment is COMPLETED on the device after 300 seconds
+    Then the Greengrass deployment is COMPLETED on the device after 5 minutes
+    And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes
 
     Then I discover core device broker as "localMqttBroker1" from "publisher" in OTF
     Then I discover core device broker as "localMqttBroker2" from "subscriber" in OTF


### PR DESCRIPTION
**Issue #, if available:**
Connection error in mosquitto client

**Description of changes:**
- Add EMQX log line check  after deployment and before starting other operations
- Update README.md by add region to env variables
- Exclude build of mosquitto client from license check
- Tune error log message

**Why is this change necessary:**
That change try to resolve issues when client can't establish MQTT connection

**How was this change tested:**
Run all scenarios and check fail reason. When no related to connect failed that means problem is resolved.

**Test results:**
```
[INFO ] 2023-06-16 02:13:05.499 [main] StepTrackingReporting - Passed: 'GGMQ-1-T1-v3-sdk-java: As a customer, I can connect, subscribe/publish at QoS 0 and 1 and receive using client application to MQTT topic'
[INFO ] 2023-06-16 02:13:05.499 [main] StepTrackingReporting - Passed: 'GGMQ-1-T1-v3-mosquitto-c: As a customer, I can connect, subscribe/publish at QoS 0 and 1 and receive using client application to MQTT topic'
[INFO ] 2023-06-16 02:13:05.499 [main] StepTrackingReporting - Passed: 'GGMQ-1-T1-v5-sdk-java: As a customer, I can connect, subscribe/publish at QoS 0 and 1 and receive using client application to MQTT topic'
[INFO ] 2023-06-16 02:13:05.499 [main] StepTrackingReporting - Passed: 'GGMQ-1-T1-v5-mosquitto-c: As a customer, I can connect, subscribe/publish at QoS 0 and 1 and receive using client application to MQTT topic'

[ERROR] 2023-06-16 02:13:05.500 [main] StepTrackingReporting - Failed: 'GGMQ-1-T8-v3-sdk-java: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic': Failed at 'the Greengrass deployment is COMPLETED on the device after 5 minutes'
[INFO ] 2023-06-16 02:13:05.500 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v3-mosquitto-c: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'
[ERROR] 2023-06-16 02:13:05.500 [main] StepTrackingReporting - Failed: 'GGMQ-1-T8-v5-sdk-java: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic': Failed at 'my device is registered as a Thing'
[ERROR] 2023-06-16 02:13:05.500 [main] StepTrackingReporting - Failed: 'GGMQ-1-T8-v5-mosquitto-c: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic': Failed at 'the Greengrass deployment is COMPLETED on the device after 5 minutes'

[INFO ] 2023-06-16 02:13:05.500 [main] StepTrackingReporting - Passed: 'GGMQ-1-T13-v3-sdk-java: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration'
[INFO ] 2023-06-16 02:13:05.500 [main] StepTrackingReporting - Passed: 'GGMQ-1-T13-v3-mosquitto-c: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration'
[INFO ] 2023-06-16 02:13:05.500 [main] StepTrackingReporting - Passed: 'GGMQ-1-T13-v5-sdk-java: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration'
[INFO ] 2023-06-16 02:13:05.500 [main] StepTrackingReporting - Passed: 'GGMQ-1-T13-v5-mosquitto-c: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration'

[INFO ] 2023-06-16 02:13:05.500 [main] StepTrackingReporting - Passed: 'GGMQ-1-T14-v3-sdk-java: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic'
[INFO ] 2023-06-16 02:13:05.500 [main] StepTrackingReporting - Passed: 'GGMQ-1-T14-v3-mosquitto-c: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic'
[INFO ] 2023-06-16 02:13:05.500 [main] StepTrackingReporting - Passed: 'GGMQ-1-T14-v5-sdk-java: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic'
[INFO ] 2023-06-16 02:13:05.500 [main] StepTrackingReporting - Passed: 'GGMQ-1-T14-v5-mosquitto-c: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic'

[INFO ] 2023-06-16 02:13:05.500 [main] StepTrackingReporting - Passed: 'GGMQ-1-T15-v3-sdk-java: As a customer, I can configure Pubsub messages to be forwarded to local MQTT topic'
[ERROR] 2023-06-16 02:13:05.500 [main] StepTrackingReporting - Failed: 'GGMQ-1-T15-v3-mosquitto-c: As a customer, I can configure Pubsub messages to be forwarded to local MQTT topic': Failed at 'the Greengrass deployment is COMPLETED on the device after 5 minutes'
[INFO ] 2023-06-16 02:13:05.500 [main] StepTrackingReporting - Passed: 'GGMQ-1-T15-v5-sdk-java: As a customer, I can configure Pubsub messages to be forwarded to local MQTT topic'
[INFO ] 2023-06-16 02:13:05.500 [main] StepTrackingReporting - Passed: 'GGMQ-1-T15-v5-mosquitto-c: As a customer, I can configure Pubsub messages to be forwarded to local MQTT topic'

[INFO ] 2023-06-16 02:13:05.500 [main] StepTrackingReporting - Passed: 'GGMQ-1-T101-v3-sdk-java: As a customer, I can use publish retain flag'
[INFO ] 2023-06-16 02:13:05.500 [main] StepTrackingReporting - Passed: 'GGMQ-1-T101-v3-paho-java: As a customer, I can use publish retain flag'
[ERROR] 2023-06-16 02:13:05.500 [main] StepTrackingReporting - Failed: 'GGMQ-1-T101-v3-mosquitto-c: As a customer, I can use publish retain flag': Failed at 'the Greengrass deployment is COMPLETED on the device after 5 minutes'

[INFO ] 2023-06-16 02:13:05.500 [main] StepTrackingReporting - Passed: 'GGMQ-1-T102-v5-sdk-java: As a customer, I can use publish retain flag and subscribe retain handling as expected'
[ERROR] 2023-06-16 02:13:05.500 [main] StepTrackingReporting - Failed: 'GGMQ-1-T102-v5-paho-java: As a customer, I can use publish retain flag and subscribe retain handling as expected': Failed at 'I publish from "publisher" to "retained/iot_data_1" with qos 1 and message "Hello world1" and expect status 16'
[INFO ] 2023-06-16 02:13:05.500 [main] StepTrackingReporting - Passed: 'GGMQ-1-T102-v5-mosquitto-c: As a customer, I can use publish retain flag and subscribe retain handling as expected'
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
