### PR TITLE
feat(uat): added logs to user properties

### DIFF
--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttConnectionImpl.java
@@ -462,12 +462,7 @@ public class MqttConnectionImpl implements MqttConnection {
 
         ConnAckPacket.ConnectReasonCode reasonCode = packet.getReasonCode();
 
-        List<Mqtt5Properties> userProperties = null;
-        if (packet.getUserProperties() != null && !packet.getUserProperties().isEmpty()) {
-            userProperties = convertToMqtt5Properties(packet.getUserProperties());
-            userProperties.forEach(p -> logger.atInfo()
-                    .log("ConnAck MQTT userProperties: {}, {}", p.getKey(), p.getValue()));
-        }
+        List<Mqtt5Properties> userProperties = getAckUserProperties(packet.getUserProperties(), "ConAck");
 
         QOS maximumQOS = packet.getMaximumQOS();
         return new ConnAckInfo(packet.getSessionPresent(),
@@ -507,12 +502,7 @@ public class MqttConnectionImpl implements MqttConnection {
             resultCodes = codes.stream().map(c -> c == null ? null : c.getValue()).collect(Collectors.toList());
         }
 
-        List<Mqtt5Properties> userProperties = null;
-        if (packet.getUserProperties() != null && !packet.getUserProperties().isEmpty()) {
-            userProperties = convertToMqtt5Properties(packet.getUserProperties());
-            userProperties.forEach(p -> logger.atInfo()
-                    .log("SubAck MQTT userProperties: {}, {}", p.getKey(), p.getValue()));
-        }
+        List<Mqtt5Properties> userProperties = getAckUserProperties(packet.getUserProperties(), "SubAck");
 
         return new SubAckInfo(resultCodes, packet.getReasonString(), userProperties);
     }
@@ -528,12 +518,7 @@ public class MqttConnectionImpl implements MqttConnection {
             resultCodes = codes.stream().map(c -> c == null ? null : c.getValue()).collect(Collectors.toList());
         }
 
-        List<Mqtt5Properties> userProperties = null;
-        if (packet.getUserProperties() != null && !packet.getUserProperties().isEmpty()) {
-            userProperties = convertToMqtt5Properties(packet.getUserProperties());
-            userProperties.forEach(p -> logger.atInfo()
-                    .log("UnsubAck MQTT userProperties: {}, {}", p.getKey(), p.getValue()));
-        }
+        List<Mqtt5Properties> userProperties = getAckUserProperties(packet.getUserProperties(), "UnsubAck");
 
         return new UnsubAckInfo(resultCodes, packet.getReasonString(), userProperties);
     }
@@ -548,12 +533,7 @@ public class MqttConnectionImpl implements MqttConnection {
         }
         PubAckPacket.PubAckReasonCode reasonCode = pubAckPacket.getReasonCode();
 
-        List<Mqtt5Properties> userProperties = null;
-        if (pubAckPacket.getUserProperties() != null && !pubAckPacket.getUserProperties().isEmpty()) {
-            userProperties = convertToMqtt5Properties(pubAckPacket.getUserProperties());
-            userProperties.forEach(p -> logger.atInfo()
-                    .log("PUBACK MQTT userProperties: {}, {}", p.getKey(), p.getValue()));
-        }
+        List<Mqtt5Properties> userProperties = getAckUserProperties(pubAckPacket.getUserProperties(), "PubAck");
 
         return new PubAckInfo(reasonCode == null ? null : reasonCode.getValue(), pubAckPacket.getReasonString(),
                 userProperties);
@@ -590,6 +570,16 @@ public class MqttConnectionImpl implements MqttConnection {
         List<Mqtt5Properties> userProperties = new ArrayList<>();
         properties.forEach(p ->  userProperties.add(Mqtt5Properties.newBuilder()
                 .setKey(p.key).setValue(p.value).build()));
+        return userProperties;
+    }
+
+    private static List<Mqtt5Properties> getAckUserProperties(List<UserProperty> userPropertyList, String commandName) {
+        List<Mqtt5Properties> userProperties = null;
+        if (userPropertyList != null && !userPropertyList.isEmpty()) {
+            userProperties = convertToMqtt5Properties(userPropertyList);
+            userProperties.forEach(p -> logger.atInfo()
+                    .log("{} MQTT userProperties: {}, {}", commandName, p.getKey(), p.getValue()));
+        }
         return userProperties;
     }
 }

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttConnectionImpl.java
@@ -233,9 +233,13 @@ public class MqttConnectionImpl implements MqttConnection {
                     = DisconnectPacket.DisconnectReasonCode.getEnumValueFromInteger(reasonCode);
             DisconnectPacket.DisconnectPacketBuilder disconnectBuilder = new DisconnectPacket.DisconnectPacketBuilder()
                     .withReasonCode(disconnectReason);
+
             if (userProperties != null && !userProperties.isEmpty()) {
                 disconnectBuilder.withUserProperties(convertToUserProperties(userProperties));
+                userProperties.forEach(p -> logger.atInfo()
+                        .log("Disconnect MQTT userProperties: {}, {}", p.getKey(), p.getValue()));
             }
+
             client.stop(disconnectBuilder.build());
 
             try {
@@ -283,9 +287,14 @@ public class MqttConnectionImpl implements MqttConnection {
                                             .withQOS(qosEnum)
                                             .withRetain(message.isRetain())
                                             .withPayload(message.getPayload());
+
         if (message.getUserProperties() != null && !message.getUserProperties().isEmpty()) {
+            List<UserProperty> userProperties = convertToUserProperties(message.getUserProperties());
             publishPacket.withUserProperties(convertToUserProperties(message.getUserProperties()));
+            userProperties.forEach(p -> logger.atInfo()
+                    .log("Publish MQTT userProperties: {}, {}", p.key, p.value));
         }
+
         CompletableFuture<PublishResult> publishFuture = client.publish(publishPacket.build());
         try {
             PublishResult publishResult = publishFuture.get(timeout, TimeUnit.SECONDS);
@@ -319,6 +328,8 @@ public class MqttConnectionImpl implements MqttConnection {
                                     handling);
             if (userProperties != null && !userProperties.isEmpty()) {
                 builder.withUserProperties(convertToUserProperties(userProperties));
+                userProperties.forEach(p -> logger.atInfo()
+                        .log("Subscribe MQTT userProperties: {}, {}", p.getKey(), p.getValue()));
             }
         }
 
@@ -344,6 +355,8 @@ public class MqttConnectionImpl implements MqttConnection {
         UnsubscribePacket.UnsubscribePacketBuilder builder = new UnsubscribePacket.UnsubscribePacketBuilder();
         if (userProperties != null && !userProperties.isEmpty()) {
             builder.withUserProperties(convertToUserProperties(userProperties));
+            userProperties.forEach(p -> logger.atInfo()
+                    .log("Unsubscribe MQTT userProperties: {}, {}", p.getKey(), p.getValue()));
         }
         filters.forEach(builder::withSubscription);
 
@@ -368,8 +381,11 @@ public class MqttConnectionImpl implements MqttConnection {
             ConnectPacket.ConnectPacketBuilder connectProperties = new ConnectPacket.ConnectPacketBuilder()
                 .withClientId(connectionParams.getClientId())
                 .withKeepAliveIntervalSeconds(Long.valueOf(connectionParams.getKeepalive()));
+
             if (connectionParams.getUserProperties() != null && !connectionParams.getUserProperties().isEmpty()) {
-                connectProperties.withUserProperties(convertToUserProperties(connectionParams.getUserProperties()));
+                List<UserProperty> userProperties = convertToUserProperties(connectionParams.getUserProperties());
+                userProperties.forEach(p -> logger.atInfo()
+                        .log("Connect MQTT userProperties: {}, {}", p.key, p.value));
             }
 
             ClientSessionBehavior clientSessionBehavior = connectionParams.isCleanSession()
@@ -445,10 +461,14 @@ public class MqttConnectionImpl implements MqttConnection {
         }
 
         ConnAckPacket.ConnectReasonCode reasonCode = packet.getReasonCode();
+
         List<Mqtt5Properties> userProperties = null;
         if (packet.getUserProperties() != null && !packet.getUserProperties().isEmpty()) {
             userProperties = convertToMqtt5Properties(packet.getUserProperties());
+            userProperties.forEach(p -> logger.atInfo()
+                    .log("ConnAck MQTT userProperties: {}, {}", p.getKey(), p.getValue()));
         }
+
         QOS maximumQOS = packet.getMaximumQOS();
         return new ConnAckInfo(packet.getSessionPresent(),
                                 reasonCode == null ? null : reasonCode.getValue(),
@@ -486,10 +506,14 @@ public class MqttConnectionImpl implements MqttConnection {
         if (codes != null) {
             resultCodes = codes.stream().map(c -> c == null ? null : c.getValue()).collect(Collectors.toList());
         }
+
         List<Mqtt5Properties> userProperties = null;
         if (packet.getUserProperties() != null && !packet.getUserProperties().isEmpty()) {
             userProperties = convertToMqtt5Properties(packet.getUserProperties());
+            userProperties.forEach(p -> logger.atInfo()
+                    .log("SubAck MQTT userProperties: {}, {}", p.getKey(), p.getValue()));
         }
+
         return new SubAckInfo(resultCodes, packet.getReasonString(), userProperties);
     }
 
@@ -503,10 +527,14 @@ public class MqttConnectionImpl implements MqttConnection {
         if (codes != null) {
             resultCodes = codes.stream().map(c -> c == null ? null : c.getValue()).collect(Collectors.toList());
         }
+
         List<Mqtt5Properties> userProperties = null;
         if (packet.getUserProperties() != null && !packet.getUserProperties().isEmpty()) {
             userProperties = convertToMqtt5Properties(packet.getUserProperties());
+            userProperties.forEach(p -> logger.atInfo()
+                    .log("UnsubAck MQTT userProperties: {}, {}", p.getKey(), p.getValue()));
         }
+
         return new UnsubAckInfo(resultCodes, packet.getReasonString(), userProperties);
     }
 
@@ -519,10 +547,14 @@ public class MqttConnectionImpl implements MqttConnection {
             return null;
         }
         PubAckPacket.PubAckReasonCode reasonCode = pubAckPacket.getReasonCode();
+
         List<Mqtt5Properties> userProperties = null;
         if (pubAckPacket.getUserProperties() != null && !pubAckPacket.getUserProperties().isEmpty()) {
             userProperties = convertToMqtt5Properties(pubAckPacket.getUserProperties());
+            userProperties.forEach(p -> logger.atInfo()
+                    .log("PUBACK MQTT userProperties: {}, {}", p.getKey(), p.getValue()));
         }
+
         return new PubAckInfo(reasonCode == null ? null : reasonCode.getValue(), pubAckPacket.getReasonString(),
                 userProperties);
     }
@@ -534,6 +566,8 @@ public class MqttConnectionImpl implements MqttConnection {
         List<Mqtt5Properties> userProperties = null;
         if (packet.getUserProperties() != null && !packet.getUserProperties().isEmpty()) {
             userProperties = convertToMqtt5Properties(packet.getUserProperties());
+            userProperties.forEach(p -> logger.atInfo()
+                    .log("Disconnect MQTT userProperties: {}, {}", p.getKey(), p.getValue()));
         }
 
         DisconnectPacket.DisconnectReasonCode reasonCode = packet.getReasonCode();

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
@@ -167,7 +167,7 @@ class AgentTestScenario implements Runnable {
                 // close MQTT connection
                 List<Mqtt5Properties> userProperties = null;
                 if (mqtt50) {
-                    userProperties = createMqtt5Properties();
+                    userProperties = createMqtt5Properties("Disconnect");
                 }
                 connectionControl.closeMqttConnection(DISCONNECT_REASON, userProperties);
             }
@@ -189,7 +189,7 @@ class AgentTestScenario implements Runnable {
                                                 : MqttProtoVersion.MQTT_PROTOCOL_V_311);
 
         if (mqtt50) {
-            builder.addAllProperties(createMqtt5Properties());
+            builder.addAllProperties(createMqtt5Properties("Connect"));
         }
 
         if (useTLS) {
@@ -207,7 +207,7 @@ class AgentTestScenario implements Runnable {
 
         List<Mqtt5Properties> userProperties = null;
         if (mqtt50) {
-            userProperties = createMqtt5Properties();
+            userProperties = createMqtt5Properties("Subscribe");
         }
 
         MqttSubscribeReply reply = connectionControl.subscribeMqtt(SUBSCRIPTION_ID, userProperties, subscription);
@@ -243,22 +243,24 @@ class AgentTestScenario implements Runnable {
                             .setQos(qos)
                             .setRetain(retain);
         if (mqtt50) {
-            builder.addAllProperties(createMqtt5Properties());
+            builder.addAllProperties(createMqtt5Properties("Publish"));
         }
         return builder.build();
     }
 
-    private List<Mqtt5Properties> createMqtt5Properties() {
+    private List<Mqtt5Properties> createMqtt5Properties(String commandName) {
         List<Mqtt5Properties> properties = new ArrayList<>();
         properties.add(Mqtt5Properties.newBuilder().setKey("region").setValue("US").build());
         properties.add(Mqtt5Properties.newBuilder().setKey("type").setValue("JSON").build());
+        properties.forEach(p -> logger.atInfo()
+                .log("{} MQTT userProperties: {}, {}", commandName, p.getKey(), p.getValue()));
         return properties;
     }
 
     private void testUnsubscribe(ConnectionControl connectionControl) {
         List<Mqtt5Properties> userProperties = null;
         if (mqtt50) {
-            userProperties = createMqtt5Properties();
+            userProperties = createMqtt5Properties("Unsubscribe");
         }
         MqttSubscribeReply reply = connectionControl.unsubscribeMqtt(userProperties, SUBSCRIBE_FILTER);
         logger.atInfo().log("Unsubscribe response: connectionId {} reason codes {} reason string '{}'",


### PR DESCRIPTION
**Issue #, if available:**
Added logs for user properties

**Description of changes:**
- Added logs for user properties

**Why is this change necessary:**
for correct working of clients

**How was this change tested:**
Scenarios run manually and on CI

**SDK Client' log:**
```
[INFO ] 2023-06-19 13:15:28.549 [main] GRPCLinkImpl - Making gPRC client connection with 127.0.0.1:47619 as best-thing-akezhan...
[INFO ] 2023-06-19 13:15:28.895 [main] GRPCLinkImpl - Client connection with Control is established, local address is 127.0.0.1
[INFO ] 2023-06-19 13:15:28.937 [main] GRPCControlServer - GRPCControlServer created and listed on 127.0.0.1:46393
[INFO ] 2023-06-19 13:15:28.945 [main] GRPCLinkImpl - Handle gRPC requests
[INFO ] 2023-06-19 13:15:28.945 [main] GRPCControlServer - Server awaitTermination
[INFO ] 2023-06-19 13:15:31.991 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId best-thing-akezhan broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[INFO ] 2023-06-19 13:15:31.996 [grpc-default-executor-0] MqttConnectionImpl - Creating Mqtt5Client with TLS
[INFO ] 2023-06-19 13:15:32.134 [grpc-default-executor-0] MqttConnectionImpl - Connect MQTT userProperties: region, US
[INFO ] 2023-06-19 13:15:32.134 [grpc-default-executor-0] MqttConnectionImpl - Connect MQTT userProperties: type, JSON
[INFO ] 2023-06-19 13:15:32.137 [Thread-2] MqttConnectionImpl - MQTT connectionId 1 connecting...
[INFO ] 2023-06-19 13:15:32.967 [Thread-2] MqttConnectionImpl - MQTT connectionId 1 connected, client id best-thing-akezhan
[INFO ] 2023-06-19 13:15:37.998 [grpc-default-executor-0] GRPCControlServer - Subscription: filter test/topic QoS 0 noLocal false retainAsPublished false retainHandling 2
[INFO ] 2023-06-19 13:15:37.998 [grpc-default-executor-0] GRPCControlServer - Subscribe: connectionId 1 subscriptionId null for 1 filters
[INFO ] 2023-06-19 13:15:38.000 [grpc-default-executor-0] MqttConnectionImpl - Subscribe MQTT userProperties: region, US
[INFO ] 2023-06-19 13:15:38.000 [grpc-default-executor-0] MqttConnectionImpl - Subscribe MQTT userProperties: type, JSON
[INFO ] 2023-06-19 13:15:38.192 [grpc-default-executor-0] GRPCControlServer - Subscribe response: connectionId 1 reason codes [0] reason string null
[INFO ] 2023-06-19 13:15:43.216 [grpc-default-executor-0] GRPCControlServer - Publish: connectionId 1 topic test/topic QoS 1 retain false
[INFO ] 2023-06-19 13:15:43.219 [grpc-default-executor-0] MqttConnectionImpl - Publish MQTT userProperties: region, US
[INFO ] 2023-06-19 13:15:43.219 [grpc-default-executor-0] MqttConnectionImpl - Publish MQTT userProperties: type, JSON
[INFO ] 2023-06-19 13:15:43.419 [grpc-default-executor-0] GRPCControlServer - Publish response: connectionId 1 reason code 0 reason string null
[INFO ] 2023-06-19 13:15:43.423 [Thread-2] MqttConnectionImpl - Received MQTT message: connectionId 1 topic test/topic QoS 0 retain false
[INFO ] 2023-06-19 13:15:43.425 [Thread-2] MqttConnectionImpl - Received MQTT userProperties: region, US
[INFO ] 2023-06-19 13:15:43.429 [Thread-2] MqttConnectionImpl - Received MQTT userProperties: type, JSON
[INFO ] 2023-06-19 13:15:48.435 [grpc-default-executor-0] GRPCControlServer - Unsubscribe: connectionId 1 for [test/topic] filters
[INFO ] 2023-06-19 13:15:48.437 [grpc-default-executor-0] MqttConnectionImpl - Unsubscribe MQTT userProperties: region, US
[INFO ] 2023-06-19 13:15:48.437 [grpc-default-executor-0] MqttConnectionImpl - Unsubscribe MQTT userProperties: type, JSON
[INFO ] 2023-06-19 13:15:48.637 [grpc-default-executor-0] GRPCControlServer - Unsubscribe response: connectionId 1 reason codes [0] reason string null
[INFO ] 2023-06-19 13:16:03.654 [grpc-default-executor-0] GRPCControlServer - closeMqttConnection: connectionId 1 reason 4
[INFO ] 2023-06-19 13:16:03.655 [grpc-default-executor-0] MqttConnectionImpl - Disconnect MQTT userProperties: region, US
[INFO ] 2023-06-19 13:16:03.656 [grpc-default-executor-0] MqttConnectionImpl - Disconnect MQTT userProperties: type, JSON
[INFO ] 2023-06-19 13:16:03.659 [Thread-2] MqttConnectionImpl - MQTT connectionId 1 disconnected error 'Mqtt5 client connection interrupted by user request.' disconnectPacket 'null'
[INFO ] 2023-06-19 13:16:03.659 [Thread-2] MqttConnectionImpl - MQTT connectionId 1 stopped
[INFO ] 2023-06-19 13:16:03.682 [grpc-default-executor-0] GRPCControlServer - shutdownAgent: reason That's it.
[INFO ] 2023-06-19 13:16:03.689 [main] GRPCControlServer - Server awaitTermination done
[INFO ] 2023-06-19 13:16:03.689 [main] GRPCLinkImpl - Shutdown gPRC link
[INFO ] 2023-06-19 13:16:03.697 [main] Main - Execution done successfully
```
**Paho Client' log:**
```
[INFO ] 2023-06-19 13:19:57.563 [main] GRPCLinkImpl - Making gPRC client connection with 127.0.0.1:47619 as best-thing-akezhan...
[INFO ] 2023-06-19 13:19:58.012 [main] GRPCLinkImpl - Client connection with Control is established, local address is 127.0.0.1
[INFO ] 2023-06-19 13:19:58.036 [main] GRPCControlServer - GRPCControlServer created and listed on 127.0.0.1:39983
[INFO ] 2023-06-19 13:19:58.111 [main] GRPCLinkImpl - Handle gRPC requests
[INFO ] 2023-06-19 13:19:58.111 [main] GRPCControlServer - Server awaitTermination
[INFO ] 2023-06-19 13:20:01.133 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId best-thing-akezhan broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[INFO ] 2023-06-19 13:20:01.328 [grpc-default-executor-0] MqttConnectionImpl - Connect MQTT userProperties: region, US
[INFO ] 2023-06-19 13:20:01.328 [grpc-default-executor-0] MqttConnectionImpl - Connect MQTT userProperties: type, JSON
[INFO ] 2023-06-19 13:20:07.582 [grpc-default-executor-0] GRPCControlServer - Subscription: filter test/topic QoS 0 noLocal false retainAsPublished false retainHandling 2
[INFO ] 2023-06-19 13:20:07.582 [grpc-default-executor-0] GRPCControlServer - Subscribe: connectionId 1 for 1 filters
[INFO ] 2023-06-19 13:20:07.583 [grpc-default-executor-0] MqttConnectionImpl - Subscribe MQTT userProperties: region, US
[INFO ] 2023-06-19 13:20:07.583 [grpc-default-executor-0] MqttConnectionImpl - Subscribe MQTT userProperties: type, JSON
[INFO ] 2023-06-19 13:20:07.744 [grpc-default-executor-0] GRPCControlServer - Subscribe response: connectionId 1 reason codes [0] reason string 
[INFO ] 2023-06-19 13:20:12.767 [grpc-default-executor-0] GRPCControlServer - Publish: connectionId 1 topic test/topic QoS 1 retain false
[INFO ] 2023-06-19 13:20:12.768 [grpc-default-executor-0] MqttConnectionImpl - Publish MQTT userProperties: region, US
[INFO ] 2023-06-19 13:20:12.768 [grpc-default-executor-0] MqttConnectionImpl - Publish MQTT userProperties: type, JSON
[INFO ] 2023-06-19 13:20:12.889 [grpc-default-executor-0] GRPCControlServer - Publish response: connectionId 1 reason code 0 reason string 
[INFO ] 2023-06-19 13:20:12.899 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT userProperties: region, US
[INFO ] 2023-06-19 13:20:12.900 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT userProperties: type, JSON
[INFO ] 2023-06-19 13:20:12.916 [pool-3-thread-1] MqttConnectionImpl - Received MQTT message: connectionId 1 topic test/topic QoS 0 retain false
[INFO ] 2023-06-19 13:20:17.910 [grpc-default-executor-0] GRPCControlServer - Unsubscribe: connectionId 1 for [test/topic] filters
[INFO ] 2023-06-19 13:20:17.911 [grpc-default-executor-0] MqttConnectionImpl - Unsubscribe MQTT userProperties: region, US
[INFO ] 2023-06-19 13:20:17.911 [grpc-default-executor-0] MqttConnectionImpl - Unsubscribe MQTT userProperties: type, JSON
[INFO ] 2023-06-19 13:20:18.073 [grpc-default-executor-0] GRPCControlServer - Unsubscribe response: connectionId 1 reason codes [0] reason string 
[INFO ] 2023-06-19 13:20:33.091 [grpc-default-executor-0] GRPCControlServer - closeMqttConnection: connectionId 1 reason 4
[INFO ] 2023-06-19 13:20:33.092 [grpc-default-executor-0] MqttConnectionImpl - Disconnect MQTT userProperties: region, US
[INFO ] 2023-06-19 13:20:33.092 [grpc-default-executor-0] MqttConnectionImpl - Disconnect MQTT userProperties: type, JSON
[INFO ] 2023-06-19 13:20:33.222 [grpc-default-executor-0] GRPCControlServer - shutdownAgent: reason That's it.
[INFO ] 2023-06-19 13:20:33.240 [main] GRPCControlServer - Server awaitTermination done
[INFO ] 2023-06-19 13:20:33.241 [main] GRPCLinkImpl - Shutdown gPRC link
[INFO ] 2023-06-19 13:20:33.254 [main] Main - Execution done successfully

```

**Agent' log:**
```
[INFO ] 2023-06-19 13:15:28.854 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId best-thing-akezhan
[INFO ] 2023-06-19 13:15:28.941 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId best-thing-akezhan address 127.0.0.1 port 46393
[INFO ] 2023-06-19 13:15:28.941 [grpc-default-executor-0] EngineControlImpl - Created new agent control for best-thing-akezhan on 127.0.0.1:46393
[INFO ] 2023-06-19 13:15:28.942 [grpc-default-executor-0] ExampleControl - Agent best-thing-akezhan is connected
[INFO ] 2023-06-19 13:15:28.942 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id best-thing-akezhan
[INFO ] 2023-06-19 13:15:31.943 [pool-2-thread-1] AgentTestScenario - Connect MQTT userProperties: region, US
[INFO ] 2023-06-19 13:15:31.944 [pool-2-thread-1] AgentTestScenario - Connect MQTT userProperties: type, JSON
[INFO ] 2023-06-19 13:15:32.980 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
reasonCode: 0
receiveMaximum: 100
maximumQoS: 1
retainAvailable: true
maximumPacketSize: 149504
wildcardSubscriptionsAvailable: true
subscriptionIdentifiersAvailable: false
sharedSubscriptionsAvailable: true
serverKeepAlive: 60
'
[INFO ] 2023-06-19 13:15:32.980 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-06-19 13:15:32.980 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-06-19 13:15:37.981 [pool-2-thread-1] AgentTestScenario - Subscribe MQTT userProperties: region, US
[INFO ] 2023-06-19 13:15:37.981 [pool-2-thread-1] AgentTestScenario - Subscribe MQTT userProperties: type, JSON
[INFO ] 2023-06-19 13:15:37.982 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-06-19 13:15:38.197 [pool-2-thread-1] AgentTestScenario - Subscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-06-19 13:15:43.198 [pool-2-thread-1] AgentTestScenario - Publish MQTT userProperties: region, US
[INFO ] 2023-06-19 13:15:43.198 [pool-2-thread-1] AgentTestScenario - Publish MQTT userProperties: type, JSON
[INFO ] 2023-06-19 13:15:43.199 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic test/topic
[INFO ] 2023-06-19 13:15:43.424 [pool-2-thread-1] AgentTestScenario - Published connectionId 1 reason code 0 reason string ''
[INFO ] 2023-06-19 13:15:43.441 [grpc-default-executor-0] GRPCDiscoveryServer - OnReceiveMessage: agentId best-thing-akezhan connectionId 1 topic test/topic QoS 0
[INFO ] 2023-06-19 13:15:43.442 [grpc-default-executor-0] AgentTestScenario - Message received on agentId best-thing-akezhan connectionId 1 topic test/topic QoS 0 content <ByteString@3db5ae9 size=12 contents="Hello World!">
[INFO ] 2023-06-19 13:15:48.425 [pool-2-thread-1] AgentTestScenario - Unsubscribe MQTT userProperties: region, US
[INFO ] 2023-06-19 13:15:48.425 [pool-2-thread-1] AgentTestScenario - Unsubscribe MQTT userProperties: type, JSON
[INFO ] 2023-06-19 13:15:48.426 [pool-2-thread-1] AgentControlImpl - UnsubscribeMqtt: unsubscribe on connectionId 1
[INFO ] 2023-06-19 13:15:48.642 [pool-2-thread-1] AgentTestScenario - Unsubscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-06-19 13:16:03.643 [pool-2-thread-1] AgentTestScenario - Disconnect MQTT userProperties: region, US
[INFO ] 2023-06-19 13:16:03.644 [pool-2-thread-1] AgentTestScenario - Disconnect MQTT userProperties: type, JSON
[INFO ] 2023-06-19 13:16:03.672 [grpc-default-executor-0] GRPCDiscoveryServer - OnMqttDisconnect: agentId best-thing-akezhan connectionId 1 disconnect '' error 'Mqtt5 client connection interrupted by user request.'
[INFO ] 2023-06-19 13:16:03.672 [grpc-default-executor-0] AgentTestScenario - MQTT disconnected on agentId best-thing-akezhan connectionId 1 disconnect '' error 'Mqtt5 client connection interrupted by user request.'
[INFO ] 2023-06-19 13:16:03.679 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-06-19 13:16:03.684 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-06-19 13:16:03.693 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId best-thing-akezhan reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-06-19 13:16:03.693 [grpc-default-executor-0] ExampleControl - Agent best-thing-akezhan is disconnected

```
**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

