### PR TITLE
feat(uat): integrate paho java client to existing scenarios

### DIFF
--- a/uat/custom-components/client-java-paho/README.md
+++ b/uat/custom-components/client-java-paho/README.md
@@ -40,17 +40,22 @@ java -jar target/client-devices-auth-uat-client-java-paho.jar agent1 127.0.0.1 4
 ```
 
 # Limitations
-That client support both MQTT v5.0 and MQTT v3.1.1 protocols. 
-But version v3.1.1 doesn't support **"reason string"** in subscribe on success. 
 
 ## MQTT v5.0 client
 Currenly information from packets related to QoS2 like PUBREC PUBREL PUBCOMP is missing.
 
-Topic alias maximum is not provided by [ConnAckPacket](https://awslabs.github.io/aws-crt-java/software/amazon/awssdk/crt/mqtt5/packets/ConnAckPacket.html).
+On success Reason string is not available for SUBACK and UNSUBACK responses.
+
+Subscription Id does not supported for SUBSCRIBE.
 
 ## MQTT v3.1.1 client
 String result code is not available in MQTT 3.1.1, corresponding fields of gRPC messages will not be set.
 
+MQTT v3.1.1 protocol doesn't support Retain handling in SUBSCRIBE.
+
 Real SUBACK information is not available from that client. Instead hard-coded Result Code 0 is used to create a response on gRPC request.
 
+Real UNSUBACK information is not available from that client. Instead hard-coded Result Code 0 is used to create a response on gRPC request.
+
 Real PUBACK information is not available from that client. Instead hard-coded Result Code 0 is used to create a response on gRPC request.
+

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -360,6 +360,7 @@ class GRPCControlServer {
             if (request.hasSubscriptionId()) {
                 logger.warn("paho-agent doesn't support getSubscriptionId {}", request.getSubscriptionId());
             }
+
             List<Mqtt5Subscription> subscriptions = request.getSubscriptionsList();
             if (subscriptions.isEmpty()) {
                 logger.atWarn().log("empty subscriptions list");

--- a/uat/custom-components/client-java-sdk/README.md
+++ b/uat/custom-components/client-java-sdk/README.md
@@ -40,10 +40,11 @@ java -jar target/client-devices-auth-uat-client-java-sdk.jar agent1 127.0.0.1 47
 ```
 
 # Limitations
-That client support both MQTT v5.0 and MQTT v3.1.1 protocols.
-But because both clients are based on separated clients implemented in IoT device SDK and CRT libraries it differs in protocol-level information provided to control.
+That client support both MQTT v5.0 and MQTT v3.1.1 protocols but because both clients are based on separated clients implemented in IoT device SDK and CRT libraries it differs in protocol-level information provided to control.
 
-Will message not yet supported.<br>
+Will message not yet supported.
+
+
 MQTT v3.1.1 protocol doesn't support RetainHandling in subscription method.
 
 ## MQTT v5.0 client
@@ -52,12 +53,16 @@ Currenly information from packets related to QoS2 like PUBREC PUBREL PUBCOMP is 
 Topic alias maximum is not provided by [ConnAckPacket](https://awslabs.github.io/aws-crt-java/software/amazon/awssdk/crt/mqtt5/packets/ConnAckPacket.html).
 
 ## MQTT v3.1.1 client
-String result code is not available in MQTT 3.1.1, corresponding fields of gRPC messages will not be set.
+Reason string is not available in MQTT 3.1.1, corresponding fields of gRPC messages will not be set.
 
 SDK-based client does not provide OS specific error code or string, corresponding fields of gRPC messages will be not set.
 
 SDK-based client provides only session present flag of CONNACK packet. The Connect Return code of CONNACK is missing.
 
 Real SUBACK information is not available from that client. Instead hard-coded Result Code 0 is used to create a response on gRPC request.
+
+Real UNSUBACK information is not available from that client. Instead hard-coded Result Code 0 is used to create a response on gRPC request.
+
+SUBSCRIBE and UNSUBSCRIBE requests are limited to only one filter due to SDK client API limitation.
 
 Real PUBACK information is not available from that client. Instead hard-coded Result Code 0 is used to create a response on gRPC request.

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
@@ -263,7 +263,6 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
             logger.atError().withThrowable(ex).log(EXCEPTION_WHEN_UNSUBSCRIBING);
             throw new MqttException(EXCEPTION_WHEN_UNSUBSCRIBING, ex);
         }
-
     }
 
     /**

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -83,6 +83,11 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q1 |
       | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | GRANTED_QOS_1       |
 
+    @mqtt3 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q1 |
+      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   | GRANTED_QOS_0       |
+
     @mqtt5 @sdk-java
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q1 |
@@ -93,6 +98,10 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q1 |
       | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | GRANTED_QOS_1       |
 
+    @mqtt5 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q1 |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   | GRANTED_QOS_1       |
 
   @GGMQ-1-T8
   Scenario Outline: GGMQ-1-T8-<mqtt-v>-<name>: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic
@@ -232,6 +241,11 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  |
       | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
 
+    @mqtt3 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
+
     @mqtt5 @sdk-java
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
@@ -242,6 +256,10 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
 
+    @mqtt5 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
 
   @GGMQ-1-T9
   Scenario Outline: GGMQ-1-T9-<mqtt-v>-<name>: As a customer,I can configure local MQTT messages to be forwarded to an IoT Core MQTT topic
@@ -358,6 +376,11 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  |
       | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
 
+    @mqtt3 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
+
     @mqtt5 @sdk-java
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
@@ -367,6 +390,11 @@ Feature: GGMQ-1
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
+
+    @mqtt5 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
 
 
   @GGMQ-1-T13
@@ -532,6 +560,11 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
       | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | UNSPECIFIED_ERROR   | GRANTED_QOS_1         | 0                  |
 
+    @mqtt3 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
+      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   | UNSPECIFIED_ERROR   | GRANTED_QOS_1         | 0                  |
+
     @mqtt5 @sdk-java
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
@@ -541,6 +574,11 @@ Feature: GGMQ-1
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
       | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | NOT_AUTHORIZED      | GRANTED_QOS_1         | 16                 |
+
+    @mqtt5 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   | NOT_AUTHORIZED      | GRANTED_QOS_1         | 16                 |
 
 
   @GGMQ-1-T14
@@ -658,6 +696,11 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  |
       | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
 
+    @mqtt3 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
+
     @mqtt5 @sdk-java
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
@@ -667,6 +710,11 @@ Feature: GGMQ-1
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
+
+    @mqtt5 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
 
 
   @GGMQ-1-T15
@@ -786,6 +834,11 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  |
       | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
 
+    @mqtt3 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
+
     @mqtt5 @sdk-java
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
@@ -795,6 +848,11 @@ Feature: GGMQ-1
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
+
+    @mqtt5 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
 
 
   @GGMQ-1-T101
@@ -872,15 +930,15 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  |
       | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
 
-    @mqtt3 @paho-java
-    Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
-
     @mqtt3 @mosquitto-c
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
       | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
+
+    @mqtt3 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
 
 
   @GGMQ-1-T102
@@ -1002,12 +1060,12 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
 
-    @mqtt5 @paho-java
-    Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
-
     @mqtt5 @mosquitto-c
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
+
+    @mqtt5 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -548,7 +548,7 @@ Feature: GGMQ-1
     Then message "Hello world 3" received on "subscriber" from "iot_data_1" topic within 10 seconds
 
     # WARNING: AWS IoT device SDK Java v2 MQTT v3 client in software.amazon.awssdk.crt.mqtt.MqttClientConnection
-    #  missing API to getting actual reason code, client always return reason code 0 on publish and subscribe.
+    #  missing API to getting actual reason code of SUBACK/PUBACK/UNSUBACK, client always return reason code 0 on publish and subscribe.
     #  It makes sdk-java client useless for T13
     @mqtt3 @sdk-java
     Examples:
@@ -560,10 +560,13 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
       | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | UNSPECIFIED_ERROR   | GRANTED_QOS_1         | 0                  |
 
+    # WARNING: Paho Java MQTT v3 client in org.eclipse.paho.client.mqttv3.IMqttAsyncClient
+    #  missing API to getting actual reason code of SUBACK/PUBACK/UNSUBACK, client always return reason code 0 on publish and subscribe.
+    #  It makes sdk-java client useless for T13
     @mqtt3 @paho-java
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
-      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   | UNSPECIFIED_ERROR   | GRANTED_QOS_1         | 0                  |
+      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   | GRANTED_QOS_0       | GRANTED_QOS_0         | 0                  |
 
     @mqtt5 @sdk-java
     Examples:


### PR DESCRIPTION
**Issue #, if available:**
Integrate paho java client to existing scenarios

**Description of changes:**
- Update existing scenario outline by adding example with paho-java client MQTT v3/v5 
- Fix bug in paho-java MQTT v3 with sending single reason code in subscribe() and unsubscribe()
- Update README files of paho-java and sdk-java clients
 

**Why is this change necessary:**
Currently paho java client is used only in T101 and T102 scenarios and do not pass base checks


**How was this change tested:**
Run scenarios on codeBuild

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
