### PR TITLE
feat(uat): update protocol, mosquitto client, control app to handle payload format indicator

### DIFF
--- a/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
@@ -253,6 +253,13 @@ Status GRPCControlServer::PublishMqtt(ServerContext *, const MqttPublishRequest 
         p_content_type = &content_type;
     }
 
+    bool payload_format_indicator;
+    bool * p_payload_format_indicator = NULL;
+    if (message.has_payloadformatindicator()) {
+        payload_format_indicator = message.payloadformatindicator();
+        p_payload_format_indicator = &payload_format_indicator;
+    }
+
     const MqttConnectionId & connection_id_obj = request->connectionid();
     int connection_id = connection_id_obj.connectionid();
 
@@ -268,7 +275,7 @@ Status GRPCControlServer::PublishMqtt(ServerContext *, const MqttPublishRequest 
     try {
         ClientControl::MqttPublishReply * result = connection->publish(timeout, qos, is_retain, topic,
                                                                         message.payload(), message.properties(),
-                                                                        p_content_type);
+                                                                        p_content_type, p_payload_format_indicator);
         if (result) {
             if (result->has_reasoncode()) {
                 reply->set_reasoncode(result->reasoncode());

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
@@ -113,13 +113,14 @@ public:
      * @param payload the payload of the message
      * @param user_properties the user properties of the PUBLISH request
      * @param content_type the optional content type
+     * @param payload_format_indicator the pointer to optional value of 'payload format indicator' of the message
      * @return pointer to allocated gRPC MqttPublishReply
      * @throw MqttException on errors
      */
     ClientControl::MqttPublishReply * publish(unsigned timeout, int qos, bool is_retain, const std::string & topic,
                                                 const std::string & payload,
                                                 const RepeatedPtrField<ClientControl::Mqtt5Properties> & user_properties,
-                                                const std::string * content_type);
+                                                const std::string * content_type, bool * payload_format_indicator);
 
     /**
      * Disconnect from the broker.

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
@@ -76,6 +76,7 @@ class AgentTestScenario implements Runnable {
     private static final MqttQoS PUBLISH_QOS = MqttQoS.MQTT_QOS_1;
     private static final boolean PUBLISH_RETAIN = false;
     private static final String PUBLISH_CONTENT_TYPE = "text/plain; charset=utf-8";
+    private static final Boolean PUBLISH_PAYLOAD_FORMAT_INDICATOR = true;
 
     private static final Integer SUBSCRIPTION_ID = null;                        // NOTE: do not set for IoT Core !!!
     private static final String SUBSCRIBE_FILTER = "test/topic";
@@ -111,7 +112,11 @@ class AgentTestScenario implements Runnable {
             }
 
             if (message.hasContentType()) {
-                logger.atInfo().log("Message has content type {}", message.getContentType());
+                logger.atInfo().log("Message has content type '{}'", message.getContentType());
+            }
+
+            if (message.hasPayloadFormatIndicator()) {
+                logger.atInfo().log("Message has payload format indicator {}", message.getPayloadFormatIndicator());
             }
 
             eventStorage.addEvent(new MqttMessageEvent(connectionControl, message));
@@ -240,14 +245,14 @@ class AgentTestScenario implements Runnable {
 
     private void testPublish(ConnectionControl connectionControl) {
         Mqtt5Message msg = createPublishMessage(PUBLISH_QOS, PUBLISH_RETAIN, PUBLISH_TOPIC, PUBLISH_TEXT.getBytes(),
-                                                PUBLISH_CONTENT_TYPE);
+                                                PUBLISH_CONTENT_TYPE, PUBLISH_PAYLOAD_FORMAT_INDICATOR);
         MqttPublishReply reply = connectionControl.publishMqtt(msg);
         logger.atInfo().log("Published connectionId {} reason code {} reason string '{}'",
                                 connectionControl.getConnectionId(), reply.getReasonCode(), reply.getReasonString());
     }
 
     private Mqtt5Message createPublishMessage(MqttQoS qos, boolean retain, String topic, byte[] data,
-                                                String contentType) {
+                                                String contentType, Boolean payloadFormatIndicator) {
         Mqtt5Message.Builder builder = Mqtt5Message.newBuilder()
                             .setTopic(topic)
                             .setPayload(ByteString.copyFrom(data))
@@ -259,6 +264,9 @@ class AgentTestScenario implements Runnable {
 
             if (contentType != null) {
                 builder.setContentType(contentType);
+            }
+            if (payloadFormatIndicator != null) {
+                builder.setPayloadFormatIndicator(payloadFormatIndicator);
             }
         }
 

--- a/uat/proto/mqtt_client_control.proto
+++ b/uat/proto/mqtt_client_control.proto
@@ -36,6 +36,7 @@ message Mqtt5Message {
     bool retain = 4;
     repeated Mqtt5Properties properties = 5;
     optional string contentType = 6;
+    optional bool payloadFormatIndicator = 7;
 };
 
 // End of common part


### PR DESCRIPTION
**Issue #, if available:**
Set payload format indicator

**Description of changes:**
- Update protocol to add optional payloadFormatIndicator to message Mqtt5Message
- Add handling of optional payload format indicator to mosquitto client in both tx and rx directions of PUBLISH
- Update Control app to pass payload format to publish() request and log it from received messages

**Why is this change necessary:**

**How was this change tested:**
Manually by run Control as standalone application

**Test results:**
Please find the lines related to 'payload format indicator'
Control output
```
[INFO ] 2023-06-20 18:44:58.286 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] ExampleControl - Control: port 47619, with TLS, MQTT v5
[INFO ] 2023-06-20 18:44:58.490 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] EngineControlImpl - MQTT client control gRPC server started, listening on 47619
[INFO ] 2023-06-20 18:44:59.703 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId agent-mosquitto
[INFO ] 2023-06-20 18:44:59.720 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId agent-mosquitto address 127.0.0.1 port 37527
[INFO ] 2023-06-20 18:44:59.723 [grpc-default-executor-0] EngineControlImpl - Created new agent control for agent-mosquitto on 127.0.0.1:37527
[INFO ] 2023-06-20 18:44:59.769 [grpc-default-executor-0] ExampleControl - Agent agent-mosquitto is connected
[INFO ] 2023-06-20 18:44:59.772 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id agent-mosquitto
[INFO ] 2023-06-20 18:45:02.786 [pool-2-thread-1] AgentTestScenario - Connect MQTT userProperties: region, US
[INFO ] 2023-06-20 18:45:02.786 [pool-2-thread-1] AgentTestScenario - Connect MQTT userProperties: type, JSON
[INFO ] 2023-06-20 18:45:05.560 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
reasonCode: 0
receiveMaximum: 100
maximumQoS: 1
retainAvailable: true
maximumPacketSize: 149504
wildcardSubscriptionsAvailable: true
subscriptionIdentifiersAvailable: false
sharedSubscriptionsAvailable: true
serverKeepAlive: 60
topicAliasMaximum: 8
'
[INFO ] 2023-06-20 18:45:05.560 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-06-20 18:45:05.560 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-06-20 18:45:10.567 [pool-2-thread-1] AgentTestScenario - Subscribe MQTT userProperties: region, US
[INFO ] 2023-06-20 18:45:10.567 [pool-2-thread-1] AgentTestScenario - Subscribe MQTT userProperties: type, JSON
[INFO ] 2023-06-20 18:45:10.576 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-06-20 18:45:10.660 [pool-2-thread-1] AgentTestScenario - Subscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-06-20 18:45:15.666 [pool-2-thread-1] AgentTestScenario - Publish MQTT userProperties: region, US
[INFO ] 2023-06-20 18:45:15.667 [pool-2-thread-1] AgentTestScenario - Publish MQTT userProperties: type, JSON
[INFO ] 2023-06-20 18:45:15.669 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic test/topic
[INFO ] 2023-06-20 18:45:15.706 [pool-2-thread-1] AgentTestScenario - Published connectionId 1 reason code 0 reason string ''
[INFO ] 2023-06-20 18:45:15.706 [grpc-default-executor-0] GRPCDiscoveryServer - OnReceiveMessage: agentId agent-mosquitto connectionId 1 topic test/topic QoS 0
[INFO ] 2023-06-20 18:45:15.707 [grpc-default-executor-0] AgentTestScenario - Message received on agentId agent-mosquitto connectionId 1 topic test/topic QoS 0 content <ByteString@7249b3e0 size=12 contents="Hello World!">
[INFO ] 2023-06-20 18:45:15.708 [grpc-default-executor-0] AgentTestScenario - Message has user property key region value US
[INFO ] 2023-06-20 18:45:15.708 [grpc-default-executor-0] AgentTestScenario - Message has user property key type value JSON
[INFO ] 2023-06-20 18:45:15.708 [grpc-default-executor-0] AgentTestScenario - Message has content type 'text/plain; charset=utf-8'
[INFO ] 2023-06-20 18:45:15.708 [grpc-default-executor-0] AgentTestScenario - Message has payload format indicator true
[INFO ] 2023-06-20 18:45:20.706 [pool-2-thread-1] AgentTestScenario - Unsubscribe MQTT userProperties: region, US
[INFO ] 2023-06-20 18:45:20.707 [pool-2-thread-1] AgentTestScenario - Unsubscribe MQTT userProperties: type, JSON
[INFO ] 2023-06-20 18:45:20.716 [pool-2-thread-1] AgentControlImpl - UnsubscribeMqtt: unsubscribe on connectionId 1
[INFO ] 2023-06-20 18:45:20.771 [pool-2-thread-1] AgentTestScenario - Unsubscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-06-20 18:45:35.772 [pool-2-thread-1] AgentTestScenario - Disconnect MQTT userProperties: region, US
[INFO ] 2023-06-20 18:45:35.773 [pool-2-thread-1] AgentTestScenario - Disconnect MQTT userProperties: type, JSON
[INFO ] 2023-06-20 18:45:35.789 [grpc-default-executor-0] GRPCDiscoveryServer - OnMqttDisconnect: agentId agent-mosquitto connectionId 1 disconnect 'reasonCode: 0
' error ''
[INFO ] 2023-06-20 18:45:35.789 [grpc-default-executor-0] AgentTestScenario - MQTT disconnected on agentId agent-mosquitto connectionId 1 disconnect 'reasonCode: 0
' error ''
[INFO ] 2023-06-20 18:45:35.793 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-06-20 18:45:35.798 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-06-20 18:45:35.804 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId agent-mosquitto reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-06-20 18:45:35.806 [grpc-default-executor-0] ExampleControl - Agent agent-mosquitto is disconnected
```

Mosquitto client output:
```
 build/src/mosquitto-test-client agent-mosquitto 47619 127.0.0.1 
[DEBUG]: Initialize gRPC library
[DEBUG]: Making gPRC link with 127.0.0.1:47619 as agent_id 'agent-mosquitto'
[DEBUG]: Sending RegisterAgent request with agent_id agent-mosquitto
[DEBUG]: Local address is 127.0.0.1
[DEBUG]: GRPCControlServer created and listed on 127.0.0.1:37527
[DEBUG]: Sending DiscoveryAgent request agent_id 'agent-mosquitto' host:port 127.0.0.1:37527
[DEBUG]: gPRC link established with 127.0.0.1:47619 as agent_id 'agent-mosquitto'
[DEBUG]: Initialize Mosquitto MQTT library
[DEBUG]: Mosquitto library version 2.0.15
[DEBUG]: Handle gRPC requests
[DEBUG]: CreateMqttConnection client_id 'GGMQ-test-device2' broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[DEBUG]: Creating Mosquitto MQTT v5 connection for a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[DEBUG]: Copied TX user property region:US
[DEBUG]: Copied TX user property type:JSON
[DEBUG]: Establishing Mosquitto MQTT v5 connection to a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883 in 10 seconds
[DEBUG]: Use provided TLS credentials
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending CONNECT
[DEBUG]: mosquitto: Client GGMQ-test-device2 received CONNACK (0)
[DEBUG]: onConnect rc 0 flags 0 props 0x7fc1b4010780
[DEBUG]: Establishing MQTT connection to a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883 completed with reason code 0
[DEBUG]: Connection registered with id 1
[DEBUG]: Subscription: filter test/topic QoS 0 noLocal 0 retainAsPublished 0 retainHandling 2
[DEBUG]: SubscribeMqtt connection_id 1
[DEBUG]: Copied TX user property region:US
[DEBUG]: Copied TX user property type:JSON
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending SUBSCRIBE (Mid: 1, Topic: test/topic, QoS: 0, Options: 0x20)
[DEBUG]: mosquitto: Client GGMQ-test-device2 received SUBACK
[DEBUG]: onSubscribe mid 1 qos_count 1 granted_qos 0x7fc1b4014040 props (nil)
[DEBUG]: Subscribed on filters 'test/topic,' QoS 0 no local 0 retain as published 0 retain handing 2 with message id 1
[DEBUG]: Copied RX reason code 0
[DEBUG]: PublishMqtt connection_id 1 topic test/topic retain 0
[DEBUG]: Copied TX content type "text/plain; charset=utf-8"
[DEBUG]: Copied TX payload format indicator 1
[DEBUG]: Copied TX user property region:US
[DEBUG]: Copied TX user property type:JSON
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending PUBLISH (d0, q1, r0, m2, 'test/topic', ... (12 bytes))
[DEBUG]: mosquitto: Client GGMQ-test-device2 received PUBACK (Mid: 2, RC:0)
[DEBUG]: onPublish mid 2 rc 0 props (nil)
[DEBUG]: Published on topic 'test/topic' QoS 1 retain 0 with rc 0 message id 2
[DEBUG]: mosquitto: Client GGMQ-test-device2 received PUBLISH (d0, q0, r0, m0, 'test/topic', ... (12 bytes))
[DEBUG]: onMessage message 0x7fc1b4015908 props 0x7fc1b4011f00
[DEBUG]: Copied RX payload format indicator 1
[DEBUG]: Copied RX content type "text/plain; charset=utf-8"
[DEBUG]: Copied RX user property region:US
[DEBUG]: Copied RX user property type:JSON
[DEBUG]: Sending OnReceiveMessage request agent_id 'agent-mosquitto' connection_id 1
[DEBUG]: UnsubscribeMqtt connection_id 1
[DEBUG]: Copied TX user property region:US
[DEBUG]: Copied TX user property type:JSON
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending UNSUBSCRIBE (Mid: 3, Topic: test/topic)
[DEBUG]: mosquitto: Client GGMQ-test-device2 received UNSUBACK
[DEBUG]: onUnsubscribe mid 3 props (nil)
[DEBUG]: Unsubscribed from filters 'test/topic,' with message id 3
[DEBUG]: Copied RX reason code 0
[DEBUG]: CloseMqttConnection connection_id 1 reason 4
[DEBUG]: Disconnect Mosquitto MQTT connection with reason code 4
[DEBUG]: Copied TX user property region:US
[DEBUG]: Copied TX user property type:JSON
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending DISCONNECT
[DEBUG]: onDisconnect rc 0 props (nil)
[DEBUG]: Sending OnMqttDisconnect request agent_id 'agent-mosquitto' connection_id 1 error '(null)'
[DEBUG]: Destroy Mosquitto MQTT connection
[DEBUG]: ShutdownAgent with reason 'That's it.'
[DEBUG]: Shutdown gPRC link
[DEBUG]: Sending UnregisterAgent request agent_id 'agent-mosquitto' reason 'Agent shutdown by OTF request 'That's it.''
[DEBUG]: Shutdown MQTT library
[DEBUG]: Shutdown gRPC library
[DEBUG]: Execution done
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
