### PR TITLE
ci(uat): enable otf uats on for push and manually selected branch

### DIFF
--- a/.github/workflows/otf.yml
+++ b/.github/workflows/otf.yml
@@ -6,6 +6,9 @@ name: OTF UATS
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - uat-dev
   push:
     branches:
       - uat-dev

--- a/.github/workflows/otf.yml
+++ b/.github/workflows/otf.yml
@@ -5,9 +5,9 @@
 name: OTF UATS
 
 on:
-  pull_request:
+  workflow_dispatch:
+  push:
     branches:
-      - main
       - uat-dev
 
 env:
@@ -31,6 +31,7 @@ jobs:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           role-session-name: cdaCI
           aws-region: ${{ env.AWS_REGION }}
+          role-duration-seconds: 14400
       - name: Run UAT on linux
         uses: aws-actions/aws-codebuild-run-build@v1
         with:


### PR DESCRIPTION
**Issue #, if available:**
Tune OTF UATS startup events

**Description of changes:**
- Enable for push to uat-dev
- Enable run otf uats manually for selected branch

**Why is this change necessary:**
Avoid workflow failures on PRs created from external repos
Run scenarios automatically on push to uar-dev
Run scenarios by request

**How was this change tested:**
Automatically by github CI

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
