### PR TITLE
feat(uat): added to t103 scenario userProperties and related steps

### DIFF
--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/addon/EventFilter.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/addon/EventFilter.java
@@ -5,11 +5,13 @@
 
 package com.aws.greengrass.testing.mqtt.client.control.api.addon;
 
+import com.aws.greengrass.testing.mqtt.client.Mqtt5Properties;
 import com.aws.greengrass.testing.mqtt.client.control.api.ConnectionControl;
 import lombok.Getter;
 import lombok.NonNull;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 /**
  * Filter of events in event storage.
@@ -27,6 +29,7 @@ public final class EventFilter {
     private final String topicFilter;
     private final byte[] content;
     private final Boolean retain;
+    private final List<Mqtt5Properties> userProperties;
 
     EventFilter(Builder builder) {
         super();
@@ -41,6 +44,7 @@ public final class EventFilter {
         this.topicFilter = builder.topicFilter;
         this.content = builder.content;
         this.retain = builder.retain;
+        this.userProperties = builder.userProperties;
     }
 
     /**
@@ -58,6 +62,7 @@ public final class EventFilter {
         private String topicFilter;
         private byte[] content;
         private Boolean retain;
+        private List<Mqtt5Properties> userProperties;
 
         /**
          * Sets type of event.
@@ -194,6 +199,17 @@ public final class EventFilter {
          */
         public Builder withRetain(Boolean retain) {
             this.retain = retain;
+            return this;
+        }
+
+        /**
+         * Sets user properties.
+         * Applicable only for MQTT message events
+         *
+         * @param userProperties the user properties of the published message
+         */
+        public Builder withUserProperties(List<Mqtt5Properties> userProperties) {
+            this.userProperties = userProperties;
             return this;
         }
 

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/addon/MqttMessageEvent.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/addon/MqttMessageEvent.java
@@ -6,6 +6,7 @@
 package com.aws.greengrass.testing.mqtt.client.control.implementation.addon;
 
 import com.aws.greengrass.testing.mqtt.client.Mqtt5Message;
+import com.aws.greengrass.testing.mqtt.client.Mqtt5Properties;
 import com.aws.greengrass.testing.mqtt.client.control.api.ConnectionControl;
 import com.aws.greengrass.testing.mqtt.client.control.api.addon.EventFilter;
 import com.google.protobuf.ByteString;
@@ -13,6 +14,7 @@ import lombok.Getter;
 import lombok.NonNull;
 
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Implements received MQTT message event.
@@ -75,6 +77,11 @@ public class MqttMessageEvent extends EventImpl {
             return false;
         }
 
+        matched = isUserPropertiesMatched(filter.getUserProperties());
+        if (!matched) {
+            return false;
+        }
+
         // TODO: check QoS ?
 
         // check content
@@ -116,6 +123,17 @@ public class MqttMessageEvent extends EventImpl {
 
     private boolean isRetainMatched(Boolean retain) {
         return retain == null || retain == message.getRetain();
+    }
+
+    private boolean isUserPropertiesMatched(List<Mqtt5Properties> userProperties) {
+        if (userProperties == null) {
+            if (message.getPropertiesList() == null) {
+                return true;
+            } else {
+                return message.getPropertiesList().isEmpty();
+            }
+        }
+        return userProperties.equals(message.getPropertiesList());
     }
 
     private static boolean isTopicMatched(@NonNull String topic, @NonNull String topicFilter) {

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/addon/MqttMessageEvent.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/addon/MqttMessageEvent.java
@@ -126,14 +126,7 @@ public class MqttMessageEvent extends EventImpl {
     }
 
     private boolean isUserPropertiesMatched(List<Mqtt5Properties> userProperties) {
-        if (userProperties == null) {
-            if (message.getPropertiesList() == null) {
-                return true;
-            } else {
-                return message.getPropertiesList().isEmpty();
-            }
-        }
-        return userProperties.equals(message.getPropertiesList());
+        return userProperties == null || userProperties.equals(message.getPropertiesList());
     }
 
     private static boolean isTopicMatched(@NonNull String topic, @NonNull String topicFilter) {

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -143,7 +143,10 @@ public class MqttControlSteps {
 
 
     /** Actual list of user properties to transmit. */
-    private static final List<Mqtt5Properties> txUserProperties = null;
+    private static List<Mqtt5Properties> txUserProperties = null;
+
+    /** Actual list of user properties to receive. */
+    private static List<Mqtt5Properties> rxUserProperties = null;
 
     private final Map<String, List<MqttBrokerConnectionInfo>> brokers = new HashMap<>();
     private final Map<String, MqttProtoVersion> mqttVersions = new HashMap<>();
@@ -643,6 +646,7 @@ public class MqttControlSteps {
                                         .withTopic(topic)
                                         .withContent(message)
                                         .withRetain(receivedRetain)
+                                        .withUserProperties(rxUserProperties)
                                         .build();
         // convert time units
         TimeUnit timeUnit = TimeUnit.valueOf(unit.toUpperCase());
@@ -673,6 +677,63 @@ public class MqttControlSteps {
         eventStorage.clear();
         log.info("Storage was cleared");
     }
+
+    /**
+     * Sets MQTT user Properties to transmit.
+     *
+     * @param key the key of userProperties property.
+     * @param value the value of userProperties property.
+     */
+    @And("I set MQTT user property with key {string} and value {string} to transmit")
+    public void setTxUserProperties(String key, String value) {
+        if (txUserProperties == null) {
+            txUserProperties = new ArrayList<>();
+        }
+        Mqtt5Properties properties = Mqtt5Properties.newBuilder()
+                .setKey(key)
+                .setValue(value)
+                .build();
+        txUserProperties.add(properties);
+    }
+
+    /**
+     * Clear MQTT user properties to transmit.
+     *
+     */
+    @And("I clear MQTT user properties to transmit")
+    @SuppressWarnings("PMD.NullAssignment")
+    public void clearTxUserProperties() {
+        txUserProperties = null;
+    }
+
+    /**
+     * Sets MQTT user Properties to receive.
+     *
+     * @param key the key of userProperties property.
+     * @param value the value of userProperties property.
+     */
+    @And("I set MQTT user property with key {string} and value {string} to receive")
+    public void setRxUserProperties(String key, String value) {
+        if (rxUserProperties == null) {
+            rxUserProperties = new ArrayList<>();
+        }
+        Mqtt5Properties properties = Mqtt5Properties.newBuilder()
+                .setKey(key)
+                .setValue(value)
+                .build();
+        rxUserProperties.add(properties);
+    }
+
+    /**
+     * Clear MQTT user properties to receive.
+     *
+     */
+    @And("I clear MQTT user properties to receive")
+    @SuppressWarnings("PMD.NullAssignment")
+    public void clearRxUserProperties() {
+        rxUserProperties = null;
+    }
+
 
     /**
      * Discover IoT core device broker directly in OTF.

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -684,23 +684,23 @@ public class MqttControlSteps {
      * @param key the key of userProperties property.
      * @param value the value of userProperties property.
      */
-    @And("I set MQTT user property with key {string} and value {string} to transmit")
-    public void setTxUserProperties(String key, String value) {
+    @And("I add MQTT 'user property' with key {string} and value {string} to transmit")
+    public void addTxUserProperty(String key, String value) {
         if (txUserProperties == null) {
             txUserProperties = new ArrayList<>();
         }
-        Mqtt5Properties properties = Mqtt5Properties.newBuilder()
+        Mqtt5Properties userProperty = Mqtt5Properties.newBuilder()
                 .setKey(key)
                 .setValue(value)
                 .build();
-        txUserProperties.add(properties);
+        txUserProperties.add(userProperty);
     }
 
     /**
      * Clear MQTT user properties to transmit.
      *
      */
-    @And("I clear MQTT user properties to transmit")
+    @And("I clear MQTT 'user properties' to transmit")
     @SuppressWarnings("PMD.NullAssignment")
     public void clearTxUserProperties() {
         txUserProperties = null;
@@ -712,23 +712,23 @@ public class MqttControlSteps {
      * @param key the key of userProperties property.
      * @param value the value of userProperties property.
      */
-    @And("I set MQTT user property with key {string} and value {string} to receive")
-    public void setRxUserProperties(String key, String value) {
+    @And("I add MQTT 'user property' with key {string} and value {string} to receive")
+    public void addRxUserProperty(String key, String value) {
         if (rxUserProperties == null) {
             rxUserProperties = new ArrayList<>();
         }
-        Mqtt5Properties properties = Mqtt5Properties.newBuilder()
+        Mqtt5Properties userProperty = Mqtt5Properties.newBuilder()
                 .setKey(key)
                 .setValue(value)
                 .build();
-        rxUserProperties.add(properties);
+        rxUserProperties.add(userProperty);
     }
 
     /**
      * Clear MQTT user properties to receive.
      *
      */
-    @And("I clear MQTT user properties to receive")
+    @And("I clear MQTT 'user properties' to receive")
     @SuppressWarnings("PMD.NullAssignment")
     public void clearRxUserProperties() {
         rxUserProperties = null;

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1095,7 +1095,7 @@ Feature: GGMQ-1
 
 
   @GGMQ-1-T103
-  Scenario Outline: GGMQ-1-T103-<mqtt-v>-<name>: As a customer, I can use retain as published flag
+  Scenario Outline: GGMQ-1-T103-<mqtt-v>-<name>: As a customer, I can use: retain as published flag, user properties for MQTT v5.0
     When I create a Greengrass deployment with components
       | aws.greengrass.clientdevices.Auth       | LATEST                                  |
       | aws.greengrass.clientdevices.mqtt.EMQX  | LATEST                                  |
@@ -1187,104 +1187,52 @@ Feature: GGMQ-1
     When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world4"
     And message "Hello world4" received on "subscriber" from "iot_data_1" topic within 5 seconds
 
+    # 3. test case when publish 'user properties' are not empty.
+    #  In that case 'user properties' on receive should be equal to 'user properties' value on publish.
+
+    And I add MQTT 'user property' with key "type" and value "json" to transmit
+    And I add MQTT 'user property' with key "region" and value "Asia" to transmit
+    And I add MQTT 'user property' with key "type" and value "json" to receive
+    And I add MQTT 'user property' with key "region" and value "Asia" to receive
+    When I subscribe "subscriber" to "iot_data_2" with qos 0
+    When I publish from "publisher" to "iot_data_2" with qos 0 and message "Expected userProperties are received"
+    And message "Expected userProperties are received" received on "subscriber" from "iot_data_2" topic within 5 seconds
+
+    # 4. test case when publish 'user properties' are empty.
+    #  In that case 'user properties' on receive should not be equal to 'user properties' value on publish.
+
+    And I clear message storage
+    And I clear MQTT 'user properties' to transmit
+    And I clear MQTT 'user properties' to receive
+    And I add MQTT 'user property' with key "agent-control" and value "control" to receive
+    And I add MQTT 'user property' with key "timezone" and value "GMT6" to receive
+    When I subscribe "subscriber" to "iot_data_2" with qos 0
+    When I publish from "publisher" to "iot_data_2" with qos 0 and message "Expected userProperties are not received"
+    And message "Expected userProperties are not received" is not received on "subscriber" from "iot_data_2" topic within 5 seconds
+
+    # 5. test case when publish 'user properties' are empty.
+    #  In that case 'user properties' on receive should ignore 'user properties' value on publish.
+    And I clear message storage
+    And I clear MQTT 'user properties' to transmit
+    And I clear MQTT 'user properties' to receive
+    And I add MQTT 'user property' with key "agent-control" and value "control" to transmit
+    And I add MQTT 'user property' with key "timezone" and value "GMT6" to transmit
+    When I subscribe "subscriber" to "iot_data_3" with qos 0
+    When I publish from "publisher" to "iot_data_3" with qos 0 and message "Ignore userProperties"
+    And message "Ignore userProperties" received on "subscriber" from "iot_data_3" topic within 5 seconds
+
+    # 6. test case when publish 'user properties' are empty.
+    #  In that case 'user properties' on receive should be equal to 'user properties' value on publish.
+
+    And I clear message storage
+    And I clear MQTT 'user properties' to transmit
+    And I clear MQTT 'user properties' to receive
+    When I subscribe "subscriber" to "iot_data_4" with qos 0
+    When I publish from "publisher" to "iot_data_4" with qos 0 and message "Without userProperties"
+    And message "Without userProperties" received on "subscriber" from "iot_data_4" topic within 5 seconds
+
     And I disconnect device "subscriber" with reason code 0
     And I disconnect device "publisher" with reason code 0
-
-    @mqtt5 @sdk-java
-    Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
-
-    @mqtt5 @mosquitto-c
-    Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
-
-    @mqtt5 @paho-java
-    Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
-
-
-  @GGMQ-1-T104
-  Scenario Outline: GGMQ-1-T104-<mqtt-v>-<name>: As a customer, I can configure user properties for MQTT 5.0
-    When I create a Greengrass deployment with components
-      | aws.greengrass.clientdevices.Auth       | LATEST                                  |
-      | aws.greengrass.clientdevices.mqtt.EMQX  | LATEST                                  |
-      | aws.greengrass.clientdevices.IPDetector | LATEST                                  |
-      | <agent>                                 | classpath:/local-store/recipes/<recipe> |
-    And I create client device "publisher"
-    And I create client device "subscriber"
-    When I associate "subscriber" with ggc
-    When I associate "publisher" with ggc
-    And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:
-    """
-{
-    "MERGE":{
-        "deviceGroups":{
-            "formatVersion":"2021-03-05",
-            "definitions":{
-                "MyPermissiveDeviceGroup":{
-                    "selectionRule":"thingName: ${publisher} OR thingName: ${subscriber}",
-                    "policyName":"MyPermissivePolicy"
-                }
-            },
-            "policies":{
-                "MyPermissivePolicy":{
-                    "AllowAll":{
-                        "statementDescription":"Allow client devices to perform all actions.",
-                        "operations":[
-                            "*"
-                        ],
-                        "resources":[
-                            "*"
-                        ]
-                    }
-                }
-            }
-        }
-    }
-}
-    """
-    And I update my Greengrass deployment configuration, setting the component <agent> configuration to:
-    """
-{
-    "MERGE":{
-        "controlAddresses":"${mqttControlAddresses}",
-        "controlPort":"${mqttControlPort}"
-    }
-}
-    """
-    And I deploy the Greengrass deployment configuration
-    Then the Greengrass deployment is COMPLETED on the device after 5 minutes
-    And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes
-
-    Then I discover core device broker as "localMqttBroker1" from "publisher" in OTF
-    Then I discover core device broker as "localMqttBroker2" from "subscriber" in OTF
-    And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
-    And I connect device "subscriber" on <agent> to "localMqttBroker2" using mqtt "<mqtt-v>"
-
-    And I set MQTT user property with key "type" and value "json" to transmit
-    And I set MQTT user property with key "type" and value "json" to receive
-
-    When I subscribe "subscriber" to "iot_data_1" with qos 0
-    When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world"
-    And message "Hello world" received on "subscriber" from "iot_data_1" topic within 5 seconds
-
-    And I clear message storage
-    And I clear MQTT user properties to transmit
-    And I clear MQTT user properties to receive
-    And I set MQTT user property with key "agent-control" and value "control" to transmit
-    When I subscribe "subscriber" to "iot_data_2" with qos 0
-    When I publish from "publisher" to "iot_data_2" with qos 0 and message "Hello world1"
-    And message "Hello world1" is not received on "subscriber" from "iot_data_2" topic within 5 seconds
-
-    And I clear message storage
-    And I clear MQTT user properties to transmit
-    And I clear MQTT user properties to receive
-    When I subscribe "subscriber" to "iot_data_3" with qos 0
-    When I publish from "publisher" to "iot_data_3" with qos 0 and message "Hello world2"
-    And message "Hello world2" received on "subscriber" from "iot_data_3" topic within 5 seconds
 
     @mqtt5 @sdk-java
     Examples:

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1204,3 +1204,99 @@ Feature: GGMQ-1
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
+
+
+  @GGMQ-1-T104
+  Scenario Outline: GGMQ-1-T104-<mqtt-v>-<name>: As a customer, I can configure user properties for MQTT 5.0
+    When I create a Greengrass deployment with components
+      | aws.greengrass.clientdevices.Auth       | LATEST                                  |
+      | aws.greengrass.clientdevices.mqtt.EMQX  | LATEST                                  |
+      | aws.greengrass.clientdevices.IPDetector | LATEST                                  |
+      | <agent>                                 | classpath:/local-store/recipes/<recipe> |
+    And I create client device "publisher"
+    And I create client device "subscriber"
+    When I associate "subscriber" with ggc
+    When I associate "publisher" with ggc
+    And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:
+    """
+{
+    "MERGE":{
+        "deviceGroups":{
+            "formatVersion":"2021-03-05",
+            "definitions":{
+                "MyPermissiveDeviceGroup":{
+                    "selectionRule":"thingName: ${publisher} OR thingName: ${subscriber}",
+                    "policyName":"MyPermissivePolicy"
+                }
+            },
+            "policies":{
+                "MyPermissivePolicy":{
+                    "AllowAll":{
+                        "statementDescription":"Allow client devices to perform all actions.",
+                        "operations":[
+                            "*"
+                        ],
+                        "resources":[
+                            "*"
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}
+    """
+    And I update my Greengrass deployment configuration, setting the component <agent> configuration to:
+    """
+{
+    "MERGE":{
+        "controlAddresses":"${mqttControlAddresses}",
+        "controlPort":"${mqttControlPort}"
+    }
+}
+    """
+    And I deploy the Greengrass deployment configuration
+    Then the Greengrass deployment is COMPLETED on the device after 5 minutes
+    And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes
+
+    Then I discover core device broker as "localMqttBroker1" from "publisher" in OTF
+    Then I discover core device broker as "localMqttBroker2" from "subscriber" in OTF
+    And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
+    And I connect device "subscriber" on <agent> to "localMqttBroker2" using mqtt "<mqtt-v>"
+
+    And I set MQTT user property with key "type" and value "json" to transmit
+    And I set MQTT user property with key "type" and value "json" to receive
+
+    When I subscribe "subscriber" to "iot_data_1" with qos 0
+    When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world"
+    And message "Hello world" received on "subscriber" from "iot_data_1" topic within 5 seconds
+
+    And I clear message storage
+    And I clear MQTT user properties to transmit
+    And I clear MQTT user properties to receive
+    And I set MQTT user property with key "agent-control" and value "control" to transmit
+    When I subscribe "subscriber" to "iot_data_2" with qos 0
+    When I publish from "publisher" to "iot_data_2" with qos 0 and message "Hello world1"
+    And message "Hello world1" is not received on "subscriber" from "iot_data_2" topic within 5 seconds
+
+    And I clear message storage
+    And I clear MQTT user properties to transmit
+    And I clear MQTT user properties to receive
+    When I subscribe "subscriber" to "iot_data_3" with qos 0
+    When I publish from "publisher" to "iot_data_3" with qos 0 and message "Hello world2"
+    And message "Hello world2" received on "subscriber" from "iot_data_3" topic within 5 seconds
+
+    @mqtt5 @sdk-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
+
+    @mqtt5 @mosquitto-c
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
+
+    @mqtt5 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |


### PR DESCRIPTION
**Issue #, if available:**
Added to t103 scenario userProperties and related steps

**Description of changes:**
- Added t104 scenario

**Why is this change necessary:**
In GGMQ-1-T104 we testing ability to user user properties for MQTT 5.0

**How was this change tested:**
Scenarios run manually and on CI

**Test results:**
For all clients:
```
Given my device is registered as a Thing....................................passed
And my device is running Greengrass.........................................passed
When I create a Greengrass deployment with components.......................passed
And I create client device "publisher"......................................passed
And I create client device "subscriber".....................................passed
When I associate "subscriber" with ggc......................................passed
When I associate "publisher" with ggc.......................................passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:.passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.client.Mqtt5JavaSdkClient configuration to:.passed
And I deploy the Greengrass deployment configuration........................passed
Then the Greengrass deployment is COMPLETED on the device after 5 minutes...passed
And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes.passed
Then I discover core device broker as "localMqttBroker1" from "publisher" in OTF.passed
Then I discover core device broker as "localMqttBroker2" from "subscriber" in OTF.passed
And I connect device "publisher" on aws.greengrass.client.Mqtt5JavaSdkClient to "localMqttBroker1" using mqtt "v5".passed
And I connect device "subscriber" on aws.greengrass.client.Mqtt5JavaSdkClient to "localMqttBroker2" using mqtt "v5".passed
And I set MQTT subscribe 'retain as published' flag to false................passed
When I subscribe "subscriber" to "iot_data_0" with qos 0....................passed
And I set MQTT publish 'retain' flag to false...............................passed
And I set the 'retain' flag in expected received messages to false..........passed
When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world1".passed
And message "Hello world1" received on "subscriber" from "iot_data_0" topic within 5 seconds.passed
And I set MQTT publish 'retain' flag to true................................passed
When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world2".passed
And message "Hello world2" received on "subscriber" from "iot_data_0" topic within 5 seconds.passed
And I set MQTT subscribe 'retain as published' flag to true.................passed
When I subscribe "subscriber" to "iot_data_1" with qos 0....................passed
And I set MQTT publish 'retain' flag to false...............................passed
And I set the 'retain' flag in expected received messages to false..........passed
When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world3".passed
And message "Hello world3" received on "subscriber" from "iot_data_1" topic within 5 seconds.passed
And I set MQTT publish 'retain' flag to true................................passed
And I set the 'retain' flag in expected received messages to true...........passed
When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world4".passed
And message "Hello world4" received on "subscriber" from "iot_data_1" topic within 5 seconds.passed
And I add MQTT 'user property' with key "type" and value "json" to transmit.passed
And I add MQTT 'user property' with key "region" and value "Asia" to transmit.passed
And I add MQTT 'user property' with key "type" and value "json" to receive..passed
And I add MQTT 'user property' with key "region" and value "Asia" to receive.passed
When I subscribe "subscriber" to "iot_data_2" with qos 0....................passed
When I publish from "publisher" to "iot_data_2" with qos 0 and message "Expected userProperties are received".passed
And message "Expected userProperties are received" received on "subscriber" from "iot_data_2" topic within 5 seconds.passed
And I clear message storage.................................................passed
And I clear MQTT 'user properties' to transmit..............................passed
And I clear MQTT 'user properties' to receive...............................passed
And I add MQTT 'user property' with key "agent-control" and value "control" to receive.passed
And I add MQTT 'user property' with key "timezone" and value "GMT6" to receive.passed
When I subscribe "subscriber" to "iot_data_2" with qos 0....................passed
When I publish from "publisher" to "iot_data_2" with qos 0 and message "Expected userProperties are not received".passed
And message "Expected userProperties are not received" is not received on "subscriber" from "iot_data_2" topic within 5 seconds.passed
And I clear message storage.................................................passed
And I clear MQTT 'user properties' to transmit..............................passed
And I clear MQTT 'user properties' to receive...............................passed
And I add MQTT 'user property' with key "agent-control" and value "control" to transmit.passed
And I add MQTT 'user property' with key "timezone" and value "GMT6" to transmit.passed
When I subscribe "subscriber" to "iot_data_3" with qos 0....................passed
When I publish from "publisher" to "iot_data_3" with qos 0 and message "Ignore userProperties".passed
And message "Ignore userProperties" received on "subscriber" from "iot_data_3" topic within 5 seconds.passed
And I clear message storage.................................................passed
And I clear MQTT 'user properties' to transmit..............................passed
And I clear MQTT 'user properties' to receive...............................passed
When I subscribe "subscriber" to "iot_data_4" with qos 0....................passed
When I publish from "publisher" to "iot_data_4" with qos 0 and message "Without userProperties".passed
And message "Without userProperties" received on "subscriber" from "iot_data_4" topic within 5 seconds.passed
And I disconnect device "subscriber" with reason code 0.....................passed
And I disconnect device "publisher" with reason code 0......................passed
]]>
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

