### PR TITLE
fix(uat): resolve thread unsafe operations in IPC client

### DIFF
--- a/uat/custom-components/client-ipc/src/main/java/com/aws/greengrass/testing/ipc/IpcClientMainRouter.java
+++ b/uat/custom-components/client-ipc/src/main/java/com/aws/greengrass/testing/ipc/IpcClientMainRouter.java
@@ -22,6 +22,7 @@ public class IpcClientMainRouter {
      * @param args arguments to main
      * @throws Exception on errors
      */
+    @SuppressWarnings("PMD.SignatureDeclareThrowsException")
     public static void main(String[] args) throws Exception {
         String operationName = System.getProperty(COMPONENT_NAME_SYS_PROP);
 

--- a/uat/custom-components/client-ipc/src/main/java/com/aws/greengrass/testing/ipc/IpcClientMainRouter.java
+++ b/uat/custom-components/client-ipc/src/main/java/com/aws/greengrass/testing/ipc/IpcClientMainRouter.java
@@ -33,7 +33,7 @@ public class IpcClientMainRouter {
                                .getPublisher()
                                .accept(args);
         } else {
-            log.error("Unsupported ipc operation");
+            log.error("Unsupported operation {}", operationName);
             System.exit(1);
         }
     }

--- a/uat/custom-components/client-ipc/src/main/java/com/aws/greengrass/testing/ipc/IpcClientMainRouter.java
+++ b/uat/custom-components/client-ipc/src/main/java/com/aws/greengrass/testing/ipc/IpcClientMainRouter.java
@@ -20,8 +20,9 @@ public class IpcClientMainRouter {
      * Main entry method.
      *
      * @param args arguments to main
+     * @throws Exception on errors
      */
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         String operationName = System.getProperty(COMPONENT_NAME_SYS_PROP);
 
         if (LOCAL_IPC_SUBSCRIBER.equals(operationName)) {

--- a/uat/custom-components/client-ipc/src/main/java/com/aws/greengrass/testing/ipc/LocalIpcPublisher.java
+++ b/uat/custom-components/client-ipc/src/main/java/com/aws/greengrass/testing/ipc/LocalIpcPublisher.java
@@ -32,6 +32,7 @@ public class LocalIpcPublisher {
      * @param args command line args
      * @throws Exception on errors
      */
+    @SuppressWarnings("PMD.SignatureDeclareThrowsException")
     public void accept(String... args) throws Exception {
         log.info("Args {}", args);
         String messageText = args[1];
@@ -40,7 +41,7 @@ public class LocalIpcPublisher {
         publish(topics, messageText);
     }
 
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.SignatureDeclareThrowsException"})
     private void publish(List<String> topics, String message) throws Exception {
         log.info("Publish to topics {}", topics);
 

--- a/uat/custom-components/client-ipc/src/main/java/com/aws/greengrass/testing/ipc/LocalIpcPublisher.java
+++ b/uat/custom-components/client-ipc/src/main/java/com/aws/greengrass/testing/ipc/LocalIpcPublisher.java
@@ -54,9 +54,8 @@ public class LocalIpcPublisher implements Consumer<String[]> {
             if (e.getCause() instanceof UnauthorizedError) {
                 log.error("Unauthorized error while publishing to topic: {}", topic);
             } else {
-                log.error("Exception occurred when using IPC.");
+                log.error("Exception occurred when using IPC while publishing to topic: {}", topic);
             }
-            System.exit(2);
         }
     }
 

--- a/uat/custom-components/client-ipc/src/main/java/com/aws/greengrass/testing/ipc/LocalIpcSubscriber.java
+++ b/uat/custom-components/client-ipc/src/main/java/com/aws/greengrass/testing/ipc/LocalIpcSubscriber.java
@@ -89,19 +89,21 @@ public class LocalIpcSubscriber implements Consumer<String[]> {
             responseHandler.closeStream();
         } catch (Exception e) {
             if (e.getCause() instanceof UnauthorizedError) {
-                log.error("Unauthorized error while publishing to topic: " + topic);
+                log.error("Unauthorized error while publishing to topic: {}", topic);
             } else {
-                log.error("Exception occurred when using IPC.", e);
+                log.error("Exception occurred when using IPC while publishing to topic: {} exception: {}", topic, e);
             }
         }
     }
 
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
     private void onStreamEvent(SubscriptionResponseMessage subscriptionResponseMessage) {
+        String message = null;
+        String topic = null;
         try {
             BinaryMessage binaryMessage = subscriptionResponseMessage.getBinaryMessage();
-            String message = new String(binaryMessage.getMessage(), StandardCharsets.UTF_8);
-            String topic = binaryMessage.getContext()
+            message = new String(binaryMessage.getMessage(), StandardCharsets.UTF_8);
+            topic = binaryMessage.getContext()
                                         .getTopic();
             log.info("RECEIVED TOPIC={}, MESSAGE: {}", topic, message);
             MessageDto dto = MessageDto.builder()
@@ -111,7 +113,8 @@ public class LocalIpcSubscriber implements Consumer<String[]> {
                                        .build();
             postToAssertionServer(dto);
         } catch (Exception e) {
-            log.error(e);
+            log.error("Exception occurred when forward IPC message {} on topic {} to assertion server exception {}",
+                        message, topic, e);
         }
     }
 

--- a/uat/custom-components/client-ipc/src/main/java/com/aws/greengrass/testing/ipc/LocalIpcSubscriber.java
+++ b/uat/custom-components/client-ipc/src/main/java/com/aws/greengrass/testing/ipc/LocalIpcSubscriber.java
@@ -51,6 +51,7 @@ public class LocalIpcSubscriber {
      * @param args command line args
      * @throws Exception on errors
      */
+    @SuppressWarnings("PMD.SignatureDeclareThrowsException")
     public void accept(String... args) throws Exception {
         log.info("Args {}", args);
 
@@ -63,7 +64,7 @@ public class LocalIpcSubscriber {
         subscribe(topics);
     }
 
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.SignatureDeclareThrowsException"})
     private void subscribe(final List<String> topics) throws Exception {
         log.info("Subscribe to topics {}", topics);
 

--- a/uat/custom-components/client-ipc/src/main/java/com/aws/greengrass/testing/ipc/LocalIpcSubscriber.java
+++ b/uat/custom-components/client-ipc/src/main/java/com/aws/greengrass/testing/ipc/LocalIpcSubscriber.java
@@ -23,16 +23,16 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.function.Consumer;
 import javax.inject.Inject;
 
+import static software.amazon.awssdk.aws.greengrass.GreengrassCoreIPCClientV2.StreamingResponse;
+
 @Log4j2
-public class LocalIpcSubscriber implements Consumer<String[]> {
+public class LocalIpcSubscriber {
 
     private static final int DEFAULT_PORT = 8033;
     private static final String TOPICS_SEPARATOR = ",";
@@ -40,8 +40,6 @@ public class LocalIpcSubscriber implements Consumer<String[]> {
     private static final String DEFAULT_CONTEXT = "ReceivedPubsubMessage";
 
     private String assertionServerUrl = "http://localhost:8080";
-
-    private final ExecutorService executor = Executors.newCachedThreadPool();
 
     @Inject
     public LocalIpcSubscriber() {
@@ -51,48 +49,61 @@ public class LocalIpcSubscriber implements Consumer<String[]> {
      * Start LocalIpcSubscriber execution.
      *
      * @param args command line args
+     * @throws Exception on errors
      */
-    @Override
-    public void accept(String[] args) {
-        log.info("Args: {}", args);
-        List<String> topics = Arrays.asList(args[0].split(TOPICS_SEPARATOR));
-        log.info("Subscribe to topics: {}", topics);
-        topics.forEach(topic -> executor.execute(() -> subscribe(topic)));
+    public void accept(String... args) throws Exception {
+        log.info("Args {}", args);
+
         final String url = Optional.ofNullable(args[1])
                                    .orElse(assertionServerUrl);
-        log.info("Assertion server URL: {}", url);
+        log.info("Assertion server URL {}", url);
         assertionServerUrl = url;
+
+        List<String> topics = Arrays.asList(args[0].split(TOPICS_SEPARATOR));
+        subscribe(topics);
     }
 
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
-    private void subscribe(String topic) {
+    private void subscribe(final List<String> topics) throws Exception {
+        log.info("Subscribe to topics {}", topics);
+
+        List<SubscribeToTopicResponseHandler> responseHandlers = new ArrayList<>();
+
+        String topic = null;
         try (GreengrassCoreIPCClientV2 ipcClient = GreengrassCoreIPCClientV2.builder()
                                                                             .withPort(DEFAULT_PORT)
                                                                             .build()) {
-            SubscribeToTopicRequest request = new SubscribeToTopicRequest().withTopic(topic);
-            GreengrassCoreIPCClientV2.StreamingResponse<SubscribeToTopicResponse, SubscribeToTopicResponseHandler>
-                    response = ipcClient.subscribeToTopic(request,
-                                                          this::onStreamEvent,
-                                                          Optional.of(this::onStreamError),
-                                                          Optional.of(this::onStreamClosed));
-            SubscribeToTopicResponseHandler responseHandler = response.getHandler();
-            log.info("Successfully subscribed to topic: {}", topic);
+            for (String t : topics) {
+                topic = t;
+                SubscribeToTopicRequest request = new SubscribeToTopicRequest().withTopic(topic);
+
+                StreamingResponse<SubscribeToTopicResponse, SubscribeToTopicResponseHandler> response = 
+                            ipcClient.subscribeToTopic(request,
+                                                        this::onStreamEvent,
+                                                        Optional.of(this::onStreamError),
+                                                        Optional.of(this::onStreamClosed));
+                SubscribeToTopicResponseHandler responseHandler = response.getHandler();
+                responseHandlers.add(responseHandler);
+                log.info("Successfully subscribed to topic {}", topic);
+            }
 
             try {
                 while (true) {
                     Thread.sleep(10_000);
                 }
             } catch (InterruptedException e) {
-                log.info("Subscribe interrupted.");
+                log.info("LocalIpcSubscriber interrupted");
             }
 
-            responseHandler.closeStream();
+            responseHandlers.forEach(responseHandler -> responseHandler.closeStream());
+
         } catch (Exception e) {
             if (e.getCause() instanceof UnauthorizedError) {
-                log.error("Unauthorized error while publishing to topic: {}", topic);
+                log.error("Unauthorized error while subscribing to topic " + topic, e);
             } else {
-                log.error("Exception occurred when using IPC while publishing to topic: {} exception: {}", topic, e);
+                log.error("Exception occurred when using IPC while subscribing to topic " + topic, e);
             }
+            throw e;
         }
     }
 
@@ -105,7 +116,7 @@ public class LocalIpcSubscriber implements Consumer<String[]> {
             message = new String(binaryMessage.getMessage(), StandardCharsets.UTF_8);
             topic = binaryMessage.getContext()
                                         .getTopic();
-            log.info("RECEIVED TOPIC={}, MESSAGE: {}", topic, message);
+            log.info("Received IPC event topic {} message {}", topic, message);
             MessageDto dto = MessageDto.builder()
                                        .topic(topic)
                                        .message(message)
@@ -113,8 +124,8 @@ public class LocalIpcSubscriber implements Consumer<String[]> {
                                        .build();
             postToAssertionServer(dto);
         } catch (Exception e) {
-            log.error("Exception occurred when forward IPC message {} on topic {} to assertion server exception {}",
-                        message, topic, e);
+            log.error("Exception occurred when forwarding IPC message " + message + " on topic " + topic
+                        + " to assertion server", e);
         }
     }
 
@@ -144,11 +155,11 @@ public class LocalIpcSubscriber implements Consumer<String[]> {
     }
 
     private boolean onStreamError(Throwable error) {
-        log.error("Received a stream error.", error);
+        log.error("Received a stream error", error);
         return false;
     }
 
     private void onStreamClosed() {
-        log.info("Subscribe to topic stream closed.");
+        log.info("Subscribe to topic stream closed");
     }
 }

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -213,7 +213,7 @@ Feature: GGMQ-1
 }
     """
     And I deploy the Greengrass deployment configuration
-    Then the Greengrass deployment is COMPLETED on the device after 120 seconds
+    Then the Greengrass deployment is COMPLETED on the device after 2 minutes
     And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes
 
     And I discover core device broker as "default_broker" from "clientDeviceTest" in OTF
@@ -367,6 +367,7 @@ Feature: GGMQ-1
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 5 minutes
     And the greengrass log on the device contains the line "com.aws.greengrass.mqtt.bridge.clients.MQTTClient: Connected to broker" within 1 minutes
+    And the aws.greengrass.client.LocalIpcSubscriber log on the device contains the line "Connection established with event stream RPC server" within 1 minutes
 
     Then I discover core device broker as "default_broker" from "publisher" in OTF
     And I connect device "publisher" on <agent> to "default_broker" using mqtt "<mqtt-v>"
@@ -988,7 +989,7 @@ Feature: GGMQ-1
     }
 }
     """
-    Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
+    Then the local Greengrass deployment is SUCCEEDED on the device after 2 minutes
 
     Then I wait 5 seconds
     Then message "Hello world" received on "subscriber" from "pubsub/topic/to/publish/on" topic within 10 seconds

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -367,7 +367,6 @@ Feature: GGMQ-1
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 5 minutes
     And the greengrass log on the device contains the line "com.aws.greengrass.mqtt.bridge.clients.MQTTClient: Connected to broker" within 1 minutes
-    And the aws.greengrass.client.LocalIpcSubscriber log on the device contains the line "Connection established with event stream RPC server" within 1 minutes
 
     Then I discover core device broker as "default_broker" from "publisher" in OTF
     And I connect device "publisher" on <agent> to "default_broker" using mqtt "<mqtt-v>"


### PR DESCRIPTION
**Issue #, if available:**
GGMQ-1-T8 failed on Windows

**Description of changes:**
- Rework IPC client to serialize subscribe/publish in the same IPC connection
- Fix errors propagation in IPC client
- Tune error logging in IPC client

**Why is this change necessary:**
Fix run T8 on Windows

**How was this change tested:**
Run GGMQ-1-T8 scenarios on Windows and Linux.

**Test result:**
Windows:
```
[INFO ] 2023-06-23 13:25:40.848 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v3-sdk-java: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'^M
[INFO ] 2023-06-23 13:25:40.848 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v3-paho-java: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'^M
[INFO ] 2023-06-23 13:25:40.848 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v5-sdk-java: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'^M
[INFO ] 2023-06-23 13:25:40.848 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v5-paho-java: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'^M
```

Linux:
```
[INFO ] 2023-06-23 00:10:45.958 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v3-sdk-java: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'
[INFO ] 2023-06-23 00:10:45.958 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v3-mosquitto-c: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'
[ERROR] 2023-06-23 00:10:45.958 [main] StepTrackingReporting - Failed: 'GGMQ-1-T8-v3-paho-java: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic': Failed at 'the Greengrass de
[INFO ] 2023-06-23 00:10:45.958 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v5-sdk-java: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'
[INFO ] 2023-06-23 00:10:45.958 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v5-mosquitto-c: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'
[INFO ] 2023-06-23 00:10:45.958 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v5-paho-java: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
