### PR TITLE
feat(uat): added content type to paho-java-client

### DIFF
--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
@@ -214,13 +214,13 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
 
     private void checkUserProperties(List<Mqtt5Properties> userProperties) {
         if (userProperties != null && !userProperties.isEmpty()) {
-            logger.warn("MQTT V3 doesn't support user properties");
+            logger.warn("MQTT V3.1.1 doesn't support user properties");
         }
     }
 
     private void checkContentType(String contentType) {
         if (contentType != null && !contentType.isEmpty()) {
-            logger.warn("MQTT V3 doesn't support 'content type'");
+            logger.warn("MQTT V3.1.1 doesn't support 'content type'");
         }
     }
 }

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
@@ -220,7 +220,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
 
     private void checkContentType(String contentType) {
         if (contentType != null && !contentType.isEmpty()) {
-            logger.warn("MQTT V3 doesn't support content type");
+            logger.warn("MQTT V3 doesn't support 'content type'");
         }
     }
 }

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
@@ -125,6 +125,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
     @Override
     public MqttPublishReply publish(long timeout, @NonNull Message message) {
         checkUserProperties(message.getUserProperties());
+        checkContentType(message.getContentType());
 
         MqttMessage mqttMessage = new MqttMessage();
         mqttMessage.setQos(message.getQos());
@@ -202,7 +203,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
         @Override
         public void messageArrived(String topic, MqttMessage mqttMessage) throws Exception {
             GRPCClient.MqttReceivedMessage message = new GRPCClient.MqttReceivedMessage(
-                    mqttMessage.getQos(), mqttMessage.isRetained(), topic, mqttMessage.getPayload(), null);
+                    mqttMessage.getQos(), mqttMessage.isRetained(), topic, mqttMessage.getPayload(), null, null);
             executorService.submit(() -> {
                 grpcClient.onReceiveMqttMessage(connectionId, message);
                 logger.atInfo().log("Received MQTT message: connectionId {} topic {} QoS {} retain {}",
@@ -214,6 +215,12 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
     private void checkUserProperties(List<Mqtt5Properties> userProperties) {
         if (userProperties != null && !userProperties.isEmpty()) {
             logger.warn("MQTT V3 doesn't support user properties");
+        }
+    }
+
+    private void checkContentType(String contentType) {
+        if (contentType != null && !contentType.isEmpty()) {
+            logger.warn("MQTT V3 doesn't support content type");
         }
     }
 }

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCClient.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCClient.java
@@ -35,6 +35,9 @@ public interface GRPCClient {
 
         /** User properties. */
         private List<Mqtt5Properties> userProperties;
+
+        /** Payload content type. */
+        private String contentType;
     }
 
 

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCClient.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/GRPCClient.java
@@ -36,7 +36,7 @@ public interface GRPCClient {
         /** User properties. */
         private List<Mqtt5Properties> userProperties;
 
-        /** Payload content type. */
+        /** Optional content type. */
         private String contentType;
     }
 

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -115,7 +115,7 @@ public interface MqttConnection {
         /** User properties. */
         private List<Mqtt5Properties>  userProperties;
 
-        /** Payload content type. */
+        /** Optional content type. */
         private String contentType;
 
         // TODO: add user's properties and so one

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -115,6 +115,9 @@ public interface MqttConnection {
         /** User properties. */
         private List<Mqtt5Properties>  userProperties;
 
+        /** Payload content type. */
+        private String contentType;
+
         // TODO: add user's properties and so one
     }
 

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -290,6 +290,10 @@ class GRPCControlServer {
                 internalMessage.userProperties(message.getPropertiesList());
             }
 
+            if (message.hasContentType()) {
+                internalMessage.contentType(message.getContentType());
+            }
+
             MqttPublishReply publishReply = connection.publish(timeout, internalMessage.build());
                 if (publishReply != null) {
                     logger.atInfo().log("Publish response: connectionId {} reason code {} reason string {}",

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
@@ -125,8 +125,9 @@ class GRPCDiscoveryClient implements GRPCClient {
             msgBuilder.addAllProperties(message.getUserProperties());
         }
 
-        if (message.getContentType() != null && !message.getContentType().isEmpty()) {
-            msgBuilder.setContentType(message.getContentType());
+        String contentType = message.getContentType();
+        if (contentType != null && !contentType.isEmpty()) {
+            msgBuilder.setContentType(contentType);
         }
 
         OnReceiveMessageRequest request = OnReceiveMessageRequest.newBuilder()

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
@@ -125,6 +125,10 @@ class GRPCDiscoveryClient implements GRPCClient {
             msgBuilder.addAllProperties(message.getUserProperties());
         }
 
+        if (message.getContentType() != null && !message.getContentType().isEmpty()) {
+            msgBuilder.setContentType(message.getContentType());
+        }
+
         OnReceiveMessageRequest request = OnReceiveMessageRequest.newBuilder()
                         .setAgentId(agentId)
                         .setConnectionId(MqttConnectionId.newBuilder().setConnectionId(connectionId).build())

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
@@ -188,7 +188,6 @@ public class MqttConnectionImpl implements MqttConnection {
                 if (ackUserProperties != null) {
                     builder.addAllProperties(ackUserProperties);
                 }
-                responseProps.getContentType();
             }
         } catch (org.eclipse.paho.mqttv5.common.MqttException ex) {
             logger.atError().withThrowable(ex)

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
@@ -161,7 +161,7 @@ public class MqttConnectionImpl implements MqttConnection {
         String contentType = message.getContentType();
         if (contentType != null && !contentType.isEmpty()) {
             properties.setContentType(contentType);
-            logger.atInfo().log("Publish MQTT payload 'content type' {}", contentType);
+            logger.atInfo().log("Publish MQTT payload content type '{}'", contentType);
         }
 
         mqttMessage.setProperties(properties);
@@ -365,7 +365,7 @@ public class MqttConnectionImpl implements MqttConnection {
                         .log("Received MQTT userProperties: {}, {}", p.getKey(), p.getValue()));
             }
             if (contentType != null) {
-                logger.atInfo().log("Received MQTT message has 'content type' {}", contentType);
+                logger.atInfo().log("Received MQTT message has content type '{}'", contentType);
             }
         }
     }

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
@@ -150,14 +150,18 @@ public class MqttConnectionImpl implements MqttConnection {
         mqttMessage.setPayload(message.getPayload());
         mqttMessage.setRetained(message.isRetain());
 
+        MqttProperties properties = new MqttProperties();
         if (message.getUserProperties() != null && !message.getUserProperties().isEmpty()) {
-            MqttProperties properties = new MqttProperties();
             List<UserProperty> userProperties = convertToUserProperties(message.getUserProperties());
             properties.setUserProperties(userProperties);
             userProperties.forEach(p -> logger.atInfo()
                     .log("Publish MQTT userProperties: {}, {}", p.getKey(), p.getValue()));
-            mqttMessage.setProperties(properties);
         }
+        if (message.getContentType() != null && !message.getContentType().isEmpty()) {
+            properties.setContentType(message.getContentType());
+            logger.atInfo().log("Publish MQTT payload content type: {}", message.getContentType());
+        }
+        mqttMessage.setProperties(properties);
 
         MqttPublishReply.Builder builder = MqttPublishReply.newBuilder();
         try {
@@ -181,6 +185,7 @@ public class MqttConnectionImpl implements MqttConnection {
                 if (ackUserProperties != null) {
                     builder.addAllProperties(ackUserProperties);
                 }
+                responseProps.getContentType();
             }
         } catch (org.eclipse.paho.mqttv5.common.MqttException ex) {
             logger.atError().withThrowable(ex)
@@ -340,9 +345,13 @@ public class MqttConnectionImpl implements MqttConnection {
     private class MqttMessageListener implements IMqttMessageListener {
         @Override
         public void messageArrived(String topic, MqttMessage mqttMessage) {
-            List<Mqtt5Properties> userProps = convertToMqtt5Properties(mqttMessage.getProperties());
+            MqttProperties receivedProperties = mqttMessage.getProperties();
+            String contentType = receivedProperties != null ? receivedProperties.getContentType() : null;
+
+            List<Mqtt5Properties> userProps = convertToMqtt5Properties(receivedProperties);
             GRPCClient.MqttReceivedMessage message = new GRPCClient.MqttReceivedMessage(
-                    mqttMessage.getQos(), mqttMessage.isRetained(), topic, mqttMessage.getPayload(), userProps);
+                    mqttMessage.getQos(), mqttMessage.isRetained(), topic,
+                    mqttMessage.getPayload(), userProps, contentType);
             executorService.submit(() -> {
                 grpcClient.onReceiveMqttMessage(connectionId, message);
                 logger.atInfo().log("Received MQTT message: connectionId {} topic {} QoS {} retain {}",
@@ -351,6 +360,9 @@ public class MqttConnectionImpl implements MqttConnection {
             if (userProps != null) {
                 userProps.forEach(p -> logger.atInfo()
                         .log("Received MQTT userProperties: {}, {}", p.getKey(), p.getValue()));
+            }
+            if (contentType != null) {
+                logger.atInfo().log("Received MQTT message has content type: {}", contentType);
             }
         }
     }

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
@@ -157,10 +157,13 @@ public class MqttConnectionImpl implements MqttConnection {
             userProperties.forEach(p -> logger.atInfo()
                     .log("Publish MQTT userProperties: {}, {}", p.getKey(), p.getValue()));
         }
-        if (message.getContentType() != null && !message.getContentType().isEmpty()) {
-            properties.setContentType(message.getContentType());
-            logger.atInfo().log("Publish MQTT payload content type: {}", message.getContentType());
+
+        String contentType = message.getContentType();
+        if (contentType != null && !contentType.isEmpty()) {
+            properties.setContentType(contentType);
+            logger.atInfo().log("Publish MQTT payload 'content type' {}", contentType);
         }
+
         mqttMessage.setProperties(properties);
 
         MqttPublishReply.Builder builder = MqttPublishReply.newBuilder();
@@ -362,7 +365,7 @@ public class MqttConnectionImpl implements MqttConnection {
                         .log("Received MQTT userProperties: {}, {}", p.getKey(), p.getValue()));
             }
             if (contentType != null) {
-                logger.atInfo().log("Received MQTT message has content type: {}", contentType);
+                logger.atInfo().log("Received MQTT message has 'content type' {}", contentType);
             }
         }
     }


### PR DESCRIPTION
**Issue #, if available:**
added content type to paho  client

**Description of changes:**
- added content type to paho  client

**Why is this change necessary:**
to implement Mqtt 5.0 features

**How was this change tested:**
Scenarios run manually and on CI

**Test results:**
*Paho client's logs*:
```
[INFO ] 2023-06-22 18:55:37.022 [main] GRPCLinkImpl - Making gPRC client connection with 127.0.0.1:47619 as best-thing-akezhan...
[INFO ] 2023-06-22 18:55:37.403 [main] GRPCLinkImpl - Client connection with Control is established, local address is 127.0.0.1
[INFO ] 2023-06-22 18:55:37.442 [main] GRPCControlServer - GRPCControlServer created and listed on 127.0.0.1:38373
[INFO ] 2023-06-22 18:55:37.532 [main] GRPCLinkImpl - Handle gRPC requests
[INFO ] 2023-06-22 18:55:37.532 [main] GRPCControlServer - Server awaitTermination
[INFO ] 2023-06-22 18:55:40.601 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId best-thing-akezhan broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[INFO ] 2023-06-22 18:55:40.840 [grpc-default-executor-0] MqttConnectionImpl - Connect MQTT userProperties: region, US
[INFO ] 2023-06-22 18:55:40.840 [grpc-default-executor-0] MqttConnectionImpl - Connect MQTT userProperties: type, JSON
[INFO ] 2023-06-22 18:55:47.027 [grpc-default-executor-0] GRPCControlServer - Subscription: filter test/topic QoS 0 noLocal false retainAsPublished false retainHandling 2
[INFO ] 2023-06-22 18:55:47.027 [grpc-default-executor-0] GRPCControlServer - Subscribe: connectionId 1 for 1 filters
[INFO ] 2023-06-22 18:55:47.029 [grpc-default-executor-0] MqttConnectionImpl - Subscribe MQTT userProperties: region, US
[INFO ] 2023-06-22 18:55:47.029 [grpc-default-executor-0] MqttConnectionImpl - Subscribe MQTT userProperties: type, JSON
[INFO ] 2023-06-22 18:55:47.174 [grpc-default-executor-0] GRPCControlServer - Subscribe response: connectionId 1 reason codes [0] reason string 
[INFO ] 2023-06-22 18:55:52.203 [grpc-default-executor-0] GRPCControlServer - Publish: connectionId 1 topic test/topic QoS 1 retain false
[INFO ] 2023-06-22 18:55:52.204 [grpc-default-executor-0] MqttConnectionImpl - Publish MQTT userProperties: region, US
[INFO ] 2023-06-22 18:55:52.204 [grpc-default-executor-0] MqttConnectionImpl - Publish MQTT userProperties: type, JSON
[INFO ] 2023-06-22 18:55:52.204 [grpc-default-executor-0] MqttConnectionImpl - Publish MQTT payload content type: text/plain; charset=utf-8
[INFO ] 2023-06-22 18:55:52.334 [grpc-default-executor-0] GRPCControlServer - Publish response: connectionId 1 reason code 0 reason string 
[INFO ] 2023-06-22 18:55:52.341 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT userProperties: region, US
[INFO ] 2023-06-22 18:55:52.342 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT userProperties: type, JSON
[INFO ] 2023-06-22 18:55:52.342 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT message has content type: text/plain; charset=utf-8
[INFO ] 2023-06-22 18:55:52.357 [pool-3-thread-1] MqttConnectionImpl - Received MQTT message: connectionId 1 topic test/topic QoS 0 retain false
[INFO ] 2023-06-22 18:55:57.354 [grpc-default-executor-0] GRPCControlServer - Unsubscribe: connectionId 1 for [test/topic] filters
[INFO ] 2023-06-22 18:55:57.355 [grpc-default-executor-0] MqttConnectionImpl - Unsubscribe MQTT userProperties: region, US
[INFO ] 2023-06-22 18:55:57.355 [grpc-default-executor-0] MqttConnectionImpl - Unsubscribe MQTT userProperties: type, JSON
[INFO ] 2023-06-22 18:55:57.480 [grpc-default-executor-0] GRPCControlServer - Unsubscribe response: connectionId 1 reason codes [0] reason string 
[INFO ] 2023-06-22 18:56:12.500 [grpc-default-executor-0] GRPCControlServer - closeMqttConnection: connectionId 1 reason 4
[INFO ] 2023-06-22 18:56:12.501 [grpc-default-executor-0] MqttConnectionImpl - Disconnect MQTT userProperties: region, US
[INFO ] 2023-06-22 18:56:12.501 [grpc-default-executor-0] MqttConnectionImpl - Disconnect MQTT userProperties: type, JSON
[INFO ] 2023-06-22 18:56:12.635 [grpc-default-executor-0] GRPCControlServer - shutdownAgent: reason That's it.
[INFO ] 2023-06-22 18:56:12.648 [main] GRPCControlServer - Server awaitTermination done
[INFO ] 2023-06-22 18:56:12.648 [main] GRPCLinkImpl - Shutdown gPRC link
[INFO ] 2023-06-22 18:56:12.662 [main] Main - Execution done successfully
```
*Control's logs*:
```
[INFO ] 2023-06-22 18:55:33.277 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] ExampleControl - Control: port 47619, with TLS, MQTT v5
[INFO ] 2023-06-22 18:55:33.492 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] EngineControlImpl - MQTT client control gRPC server started, listening on 47619
[INFO ] 2023-06-22 18:55:37.366 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId best-thing-akezhan
[INFO ] 2023-06-22 18:55:37.447 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId best-thing-akezhan address 127.0.0.1 port 38373
[INFO ] 2023-06-22 18:55:37.450 [grpc-default-executor-0] EngineControlImpl - Created new agent control for best-thing-akezhan on 127.0.0.1:38373
[INFO ] 2023-06-22 18:55:37.488 [grpc-default-executor-0] ExampleControl - Agent best-thing-akezhan is connected
[INFO ] 2023-06-22 18:55:37.491 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id best-thing-akezhan
[INFO ] 2023-06-22 18:55:40.499 [pool-2-thread-1] AgentTestScenario - Connect MQTT userProperties: region, US
[INFO ] 2023-06-22 18:55:40.499 [pool-2-thread-1] AgentTestScenario - Connect MQTT userProperties: type, JSON
[INFO ] 2023-06-22 18:55:42.006 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
receiveMaximum: 100
maximumQoS: 1
retainAvailable: true
maximumPacketSize: 149504
serverKeepAlive: 60
'
[INFO ] 2023-06-22 18:55:42.006 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-06-22 18:55:42.006 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-06-22 18:55:47.011 [pool-2-thread-1] AgentTestScenario - Subscribe MQTT userProperties: region, US
[INFO ] 2023-06-22 18:55:47.012 [pool-2-thread-1] AgentTestScenario - Subscribe MQTT userProperties: type, JSON
[INFO ] 2023-06-22 18:55:47.013 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-06-22 18:55:47.181 [pool-2-thread-1] AgentTestScenario - Subscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-06-22 18:55:52.186 [pool-2-thread-1] AgentTestScenario - Publish MQTT userProperties: region, US
[INFO ] 2023-06-22 18:55:52.186 [pool-2-thread-1] AgentTestScenario - Publish MQTT userProperties: type, JSON
[INFO ] 2023-06-22 18:55:52.188 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic test/topic
[INFO ] 2023-06-22 18:55:52.340 [pool-2-thread-1] AgentTestScenario - Published connectionId 1 reason code 0 reason string ''
[INFO ] 2023-06-22 18:55:52.352 [grpc-default-executor-0] GRPCDiscoveryServer - OnReceiveMessage: agentId best-thing-akezhan connectionId 1 topic test/topic QoS 0
[INFO ] 2023-06-22 18:55:52.353 [grpc-default-executor-0] AgentTestScenario - Message received on agentId best-thing-akezhan connectionId 1 topic test/topic QoS 0 content <ByteString@482f0023 size=12 contents="Hello World!">
[INFO ] 2023-06-22 18:55:52.353 [grpc-default-executor-0] AgentTestScenario - Message has user property key region value US
[INFO ] 2023-06-22 18:55:52.353 [grpc-default-executor-0] AgentTestScenario - Message has user property key type value JSON
[INFO ] 2023-06-22 18:55:52.353 [grpc-default-executor-0] AgentTestScenario - Message has content type 'text/plain; charset=utf-8'
[INFO ] 2023-06-22 18:55:57.341 [pool-2-thread-1] AgentTestScenario - Unsubscribe MQTT userProperties: region, US
[INFO ] 2023-06-22 18:55:57.342 [pool-2-thread-1] AgentTestScenario - Unsubscribe MQTT userProperties: type, JSON
[INFO ] 2023-06-22 18:55:57.347 [pool-2-thread-1] AgentControlImpl - UnsubscribeMqtt: unsubscribe on connectionId 1
[INFO ] 2023-06-22 18:55:57.485 [pool-2-thread-1] AgentTestScenario - Unsubscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-06-22 18:56:12.486 [pool-2-thread-1] AgentTestScenario - Disconnect MQTT userProperties: region, US
[INFO ] 2023-06-22 18:56:12.487 [pool-2-thread-1] AgentTestScenario - Disconnect MQTT userProperties: type, JSON
[INFO ] 2023-06-22 18:56:12.624 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-06-22 18:56:12.641 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-06-22 18:56:12.657 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId best-thing-akezhan reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-06-22 18:56:12.659 [grpc-default-executor-0] ExampleControl - Agent best-thing-akezhan is disconnected
^C[INFO ] 2023-06-22 18:57:25.451 [Thread-1] ExampleControl - *** shutting down gRPC server since JVM is shutting down
```


**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

