### PR TITLE
feat(uat): add test cases to send and receive messages with payload format indicator

### DIFF
--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCDiscoveryClient.java
@@ -125,9 +125,14 @@ class GRPCDiscoveryClient implements GRPCClient {
             msgBuilder.addAllProperties(message.getUserProperties());
         }
 
-        String contentType = message.getContentType();
-        if (contentType != null && !contentType.isEmpty()) {
+        final String contentType = message.getContentType();
+        if (contentType != null) {
             msgBuilder.setContentType(contentType);
+        }
+
+        final Boolean payloadFormatIndicator = message.getPayloadFormatIndicator();
+        if (payloadFormatIndicator != null) {
+            msgBuilder.setPayloadFormatIndicator(payloadFormatIndicator);
         }
 
         OnReceiveMessageRequest request = OnReceiveMessageRequest.newBuilder()

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/addon/Event.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/addon/Event.java
@@ -16,7 +16,7 @@ public interface Event {
         /** MQTT message is received. */
         EVENT_TYPE_MQTT_MESSAGE,
 
-        // TODOL implement other events
+        // TODO: implement other events
         // /** MQTT Connecttion established. */
         // EVENT_TYPE_MQTT_CONNECTED,
 

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/addon/EventFilter.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/addon/EventFilter.java
@@ -30,6 +30,7 @@ public final class EventFilter {
     private final byte[] content;
     private final Boolean retain;
     private final List<Mqtt5Properties> userProperties;
+    private final Boolean payloadFormatIndicator;
 
     EventFilter(Builder builder) {
         super();
@@ -45,6 +46,7 @@ public final class EventFilter {
         this.content = builder.content;
         this.retain = builder.retain;
         this.userProperties = builder.userProperties;
+        this.payloadFormatIndicator = builder.payloadFormatIndicator;
     }
 
     /**
@@ -63,6 +65,7 @@ public final class EventFilter {
         private byte[] content;
         private Boolean retain;
         private List<Mqtt5Properties> userProperties;
+        private Boolean payloadFormatIndicator;
 
         /**
          * Sets type of event.
@@ -195,7 +198,7 @@ public final class EventFilter {
          * Sets retain flag.
          * Applicable only for MQTT message events
          *
-         * @param retain the retain flag of the message
+         * @param retain the retain flag of the message or null
          */
         public Builder withRetain(Boolean retain) {
             this.retain = retain;
@@ -210,6 +213,17 @@ public final class EventFilter {
          */
         public Builder withUserProperties(List<Mqtt5Properties> userProperties) {
             this.userProperties = userProperties;
+            return this;
+        }
+
+        /**
+         * Sets payload format indicator flag.
+         * Applicable only for MQTT message events
+         *
+         * @param payloadFormatIndicator the payload format indicator flag of the message or null
+         */
+        public Builder withPayloadFormatIndicator(Boolean payloadFormatIndicator) {
+            this.payloadFormatIndicator = payloadFormatIndicator;
             return this;
         }
 

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/addon/MqttMessageEvent.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/addon/MqttMessageEvent.java
@@ -82,6 +82,11 @@ public class MqttMessageEvent extends EventImpl {
             return false;
         }
 
+        matched = isPayloadFormatIndicatorMatched(filter.getPayloadFormatIndicator());
+        if (!matched) {
+            return false;
+        }
+
         // TODO: check QoS ?
 
         // check content
@@ -127,6 +132,10 @@ public class MqttMessageEvent extends EventImpl {
 
     private boolean isUserPropertiesMatched(List<Mqtt5Properties> userProperties) {
         return userProperties == null || userProperties.equals(message.getPropertiesList());
+    }
+
+    private boolean isPayloadFormatIndicatorMatched(Boolean payloadFormatIndicator) {
+        return payloadFormatIndicator == null || payloadFormatIndicator == message.getPayloadFormatIndicator();
     }
 
     private static boolean isTopicMatched(@NonNull String topic, @NonNull String topicFilter) {

--- a/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/addon/MqttMessageEventTest.java
+++ b/uat/mqtt-client-control/src/test/java/com/aws/greengrass/testing/mqtt/client/control/implementation/addon/MqttMessageEventTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -339,6 +340,26 @@ class MqttMessageEventTest {
     }
 
     @Test
+    void GIVEN_unknown_retain_and_filter_without_retain_WHEN_is_matched_THEN_is() {
+        // GIVEN
+        final long testRunTimestamp = System.currentTimeMillis();
+
+        EventFilter eventFilter = new EventFilter.Builder()
+                                        .withType(Event.Type.EVENT_TYPE_MQTT_MESSAGE)
+                                        .withToTimestamp(testRunTimestamp)
+                                        .withConnectionControl(connectionControl)
+                                        .build();
+
+
+        // WHEN
+        boolean result = mqttMessageEvent.isMatched(eventFilter);
+
+        // THEN
+        assertTrue(result);
+        verify(message, never()).getRetain();
+    }
+
+    @Test
     void GIVEN_user_properties_and_matched_filter_WHEN_is_matched_THEN_is() {
         final long testRunTimestamp = System.currentTimeMillis();
         final List<Mqtt5Properties> userProperties = Lists.newArrayList(
@@ -436,5 +457,121 @@ class MqttMessageEventTest {
         //THEN
         assertFalse(result);
         verify(message).getPropertiesList();
+    }
+
+
+    @Test
+    void GIVEN_payload_format_indicator_and_matched_filter_WHEN_is_matched_THEN_is() {
+        // GIVEN
+        final long testRunTimestamp = System.currentTimeMillis();
+        final boolean payloadFormatIndicator = true;
+
+        lenient().when(message.getPayloadFormatIndicator()).thenReturn(payloadFormatIndicator);
+
+        EventFilter eventFilter = new EventFilter.Builder()
+                                        .withType(Event.Type.EVENT_TYPE_MQTT_MESSAGE)
+                                        .withToTimestamp(testRunTimestamp)
+                                        .withConnectionControl(connectionControl)
+                                        .withPayloadFormatIndicator(payloadFormatIndicator)
+                                        .build();
+
+
+        // WHEN
+        boolean result = mqttMessageEvent.isMatched(eventFilter);
+
+        // THEN
+        assertTrue(result);
+        verify(message).getPayloadFormatIndicator();
+    }
+
+    @Test
+    void GIVEN_not_payload_format_indicator_and_matched_filter_WHEN_is_matched_THEN_is() {
+        // GIVEN
+        final long testRunTimestamp = System.currentTimeMillis();
+        final boolean payloadFormatIndicator = false;
+
+        lenient().when(message.getPayloadFormatIndicator()).thenReturn(payloadFormatIndicator);
+
+        EventFilter eventFilter = new EventFilter.Builder()
+                                        .withType(Event.Type.EVENT_TYPE_MQTT_MESSAGE)
+                                        .withToTimestamp(testRunTimestamp)
+                                        .withConnectionControl(connectionControl)
+                                        .withPayloadFormatIndicator(payloadFormatIndicator)
+                                        .build();
+
+
+        // WHEN
+        boolean result = mqttMessageEvent.isMatched(eventFilter);
+
+        // THEN
+        assertTrue(result);
+        verify(message).getPayloadFormatIndicator();
+    }
+
+    @Test
+    void GIVEN_payload_format_indicator_and_not_matched_filter_WHEN_is_matched_THEN_is_not() {
+        // GIVEN
+        final long testRunTimestamp = System.currentTimeMillis();
+        final boolean payloadFormatIndicator = true;
+
+        lenient().when(message.getPayloadFormatIndicator()).thenReturn(payloadFormatIndicator);
+
+        EventFilter eventFilter = new EventFilter.Builder()
+                                        .withType(Event.Type.EVENT_TYPE_MQTT_MESSAGE)
+                                        .withToTimestamp(testRunTimestamp)
+                                        .withConnectionControl(connectionControl)
+                                        .withPayloadFormatIndicator(!payloadFormatIndicator)
+                                        .build();
+
+
+        // WHEN
+        boolean result = mqttMessageEvent.isMatched(eventFilter);
+
+        // THEN
+        assertFalse(result);
+        verify(message).getPayloadFormatIndicator();
+    }
+
+    @Test
+    void GIVEN_not_payload_format_indicator_and_not_matched_filter_WHEN_is_matched_THEN_is_not() {
+        // GIVEN
+        final long testRunTimestamp = System.currentTimeMillis();
+        final boolean payloadFormatIndicator = false;
+
+        lenient().when(message.getPayloadFormatIndicator()).thenReturn(payloadFormatIndicator);
+
+        EventFilter eventFilter = new EventFilter.Builder()
+                                        .withType(Event.Type.EVENT_TYPE_MQTT_MESSAGE)
+                                        .withToTimestamp(testRunTimestamp)
+                                        .withConnectionControl(connectionControl)
+                                        .withPayloadFormatIndicator(!payloadFormatIndicator)
+                                        .build();
+
+
+        // WHEN
+        boolean result = mqttMessageEvent.isMatched(eventFilter);
+
+        // THEN
+        assertFalse(result);
+        verify(message).getPayloadFormatIndicator();
+    }
+
+    @Test
+    void GIVEN_unknown_payload_format_indicator_and_filter_without_payload_format_indicator_WHEN_is_matched_THEN_is() {
+        // GIVEN
+        final long testRunTimestamp = System.currentTimeMillis();
+
+        EventFilter eventFilter = new EventFilter.Builder()
+                                        .withType(Event.Type.EVENT_TYPE_MQTT_MESSAGE)
+                                        .withToTimestamp(testRunTimestamp)
+                                        .withConnectionControl(connectionControl)
+                                        .build();
+
+        // WHEN
+        boolean result = mqttMessageEvent.isMatched(eventFilter);
+
+        // THEN
+        assertTrue(result);
+        verify(message, never()).getPayloadFormatIndicator();
     }
 }

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1385,6 +1385,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
 
+  # TODO: when paho-java is ready to handle payload format indicator join all T1xx scenarios together
   @GGMQ-1-T104
   Scenario Outline: GGMQ-1-T104-<mqtt-v>-<name>: As a customer, I can send and receive MQTT v5.0 messages with 'payload format indicator'
     When I create a Greengrass deployment with components
@@ -1461,7 +1462,11 @@ Feature: GGMQ-1
     And I disconnect device "subscriber" with reason code 0
     And I disconnect device "publisher" with reason code 0
 
-    # TODO: add more agents here when 'payload format indicator' feature will be added to it
+    @mqtt5 @sdk-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
+
     @mqtt5 @mosquitto-c
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1155,141 +1155,107 @@ Feature: GGMQ-1
     And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
     And I connect device "subscriber" on <agent> to "localMqttBroker2" using mqtt "<mqtt-v>"
 
+    # publish 'retain' and subscribe 'retain control' tests
+
+    # 1. test case when publishing two messages with retain flag set and subscribe retain handling is 'send at subsription'
+    #  and only last message is received
     And I set MQTT publish 'retain' flag to true
-    When I publish from "publisher" to "iot_data_001" with qos 0 and message "Old retained message"
-    When I publish from "publisher" to "iot_data_001" with qos 0 and message "New retained message"
     And I set MQTT subscribe 'retain handling' property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION"
-    When I subscribe "subscriber" to "iot_data_001" with qos 0
-    And message "Old retained message" is not received on "subscriber" from "iot_data_001" topic within 5 seconds
-    And message "New retained message" received on "subscriber" from "iot_data_001" topic within 5 seconds
+    When I publish from "publisher" to "receive_last_retain_message" with qos 0 and message "First retained message"
+    When I publish from "publisher" to "receive_last_retain_message" with qos 0 and message "Second retained message"
+    When I subscribe "subscriber" to "receive_last_retain_message" with qos 0
+    And message "First retained message" is not received on "subscriber" from "receive_last_retain_message" topic within 5 seconds
+    And message "Second retained message" received on "subscriber" from "receive_last_retain_message" topic within 5 seconds
 
+    And I clear message storage
+
+    # 2. test case when first published message has retain and second not
     And I set MQTT publish 'retain' flag to true
-    When I publish from "publisher" to "iot_data_002" with qos 0 and message "Old retained message 002"
-    And I set MQTT publish 'retain' flag to false
-    When I publish from "publisher" to "iot_data_002" with qos 0 and message "New retained message 002"
-    When I subscribe "subscriber" to "iot_data_002" with qos 0
-    And message "New retained message 002" is not received on "subscriber" from "iot_data_002" topic within 5 seconds
-    And message "Old retained message 002" received on "subscriber" from "iot_data_002" topic within 5 seconds
-
-    And I set MQTT publish 'retain' flag to true
-
-    When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world0"
     And I set MQTT subscribe 'retain handling' property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION"
-    When I subscribe "subscriber" to "iot_data_0" with qos 0
-    And message "Hello world0" received on "subscriber" from "iot_data_0" topic within 5 seconds
-    And I clear message storage
-    When I subscribe "subscriber" to "iot_data_0" with qos 0
-    And message "Hello world0" received on "subscriber" from "iot_data_0" topic within 5 seconds
-
-    When I publish from "publisher" to "retained/iot_data_1" with qos 1 and message "Hello world1" and expect status 16
-    And I set MQTT subscribe 'retain handling' property to "MQTT5_RETAIN_SEND_AT_NEW_SUBSCRIPTION"
-    When I subscribe "subscriber" to "retained/iot_data_1" with qos 0
-    And message "Hello world1" received on "subscriber" from "retained/iot_data_1" topic within 5 seconds
-    And I clear message storage
-    When I subscribe "subscriber" to "retained/iot_data_1" with qos 0
-    And message "Hello world1" is not received on "subscriber" from "retained/iot_data_1" topic within 5 seconds
-
-    When I publish from "publisher" to "iot_data_2" with qos 0 and message "Hello world2"
-    And I set MQTT subscribe 'retain handling' property to "MQTT5_RETAIN_DO_NOT_SEND_AT_SUBSCRIPTION"
-    When I subscribe "subscriber" to "iot_data_2" with qos 0
-    And message "Hello world2" is not received on "subscriber" from "iot_data_2" topic within 5 seconds
+    When I publish from "publisher" to "receive_only_retain_message_on_subscribe" with qos 0 and message "First message with retain"
 
     And I set MQTT publish 'retain' flag to false
+    When I publish from "publisher" to "receive_only_retain_message_on_subscribe" with qos 0 and message "Second message without retain"
 
-    When I publish from "publisher" to "iot_data_3" with qos 0 and message "Hello world3"
+    When I subscribe "subscriber" to "receive_only_retain_message_on_subscribe" with qos 0
+    And message "Second message without retain" is not received on "subscriber" from "receive_only_retain_message_on_subscribe" topic within 5 seconds
+    And message "First message with retain" received on "subscriber" from "receive_only_retain_message_on_subscribe" topic within 5 seconds
+
+    And I clear message storage
+
+    # 3. test case when subscribe twice with 'retain send at subscription'
+    And I set MQTT publish 'retain' flag to true
     And I set MQTT subscribe 'retain handling' property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION"
-    When I subscribe "subscriber" to "iot_data_3" with qos 0
-    And message "Hello world3" is not received on "subscriber" from "iot_data_3" topic within 5 seconds
 
-    When I publish from "publisher" to "iot_data_4" with qos 0 and message "Hello world4"
+    When I publish from "publisher" to "subscribe_twice_with_send_at_subscription" with qos 0 and message "Single message in case3"
+
+    When I subscribe "subscriber" to "subscribe_twice_with_send_at_subscription" with qos 0
+    And message "Single message in case3" received on "subscriber" from "subscribe_twice_with_send_at_subscription" topic within 5 seconds
+
+    And I clear message storage
+    When I subscribe "subscriber" to "subscribe_twice_with_send_at_subscription" with qos 0
+    And message "Single message in case3" received on "subscriber" from "subscribe_twice_with_send_at_subscription" topic within 5 seconds
+
+    And I clear message storage
+
+    # 4. test case when subscribe twice with 'retain send at new subscription' when has retained message
+    And I set MQTT publish 'retain' flag to true
     And I set MQTT subscribe 'retain handling' property to "MQTT5_RETAIN_SEND_AT_NEW_SUBSCRIPTION"
-    When I subscribe "subscriber" to "iot_data_4" with qos 0
-    And message "Hello world4" is not received on "subscriber" from "iot_data_4" topic within 5 seconds
 
-    When I publish from "publisher" to "iot_data_5" with qos 0 and message "Hello world5"
+    When I publish from "publisher" to "send_at_new_subscription" with qos 1 and message "Single retained message in case4" and expect status 16
+    When I subscribe "subscriber" to "send_at_new_subscription" with qos 0
+    And message "Single retained message in case4" received on "subscriber" from "send_at_new_subscription" topic within 5 seconds
+
+    And I clear message storage
+    When I subscribe "subscriber" to "send_at_new_subscription" with qos 0
+    And message "Single retained message in case4" is not received on "subscriber" from "send_at_new_subscription" topic within 5 seconds
+
+    And I clear message storage
+
+    # 5. test case when has retained message and subscribe with 'do not send and subscription'
+    And I clear message storage
+    And I set MQTT publish 'retain' flag to true
     And I set MQTT subscribe 'retain handling' property to "MQTT5_RETAIN_DO_NOT_SEND_AT_SUBSCRIPTION"
-    When I subscribe "subscriber" to "iot_data_5" with qos 0
-    And message "Hello world5" is not received on "subscriber" from "iot_data_5" topic within 5 seconds
 
-    And I disconnect device "subscriber" with reason code 0
-    And I disconnect device "publisher" with reason code 0
+    When I publish from "publisher" to "do_not_send_at_subscription" with qos 0 and message "Single retained message in case5"
+    When I subscribe "subscriber" to "do_not_send_at_subscription" with qos 0
+    And message "Single retained message in case5" is not received on "subscriber" from "do_not_send_at_subscription" topic within 5 seconds
 
-    @mqtt5 @sdk-java
-    Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
+    And I clear message storage
 
-    @mqtt5 @mosquitto-c
-    Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
+    # 6. test case when has no retained messages and subscribed with 'send at subscription'
+    And I set MQTT publish 'retain' flag to false
+    And I set MQTT subscribe 'retain handling' property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION"
 
-    @mqtt5 @paho-java
-    Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
+    When I publish from "publisher" to "t102_case6" with qos 0 and message "Single not retained message in case6"
+    When I subscribe "subscriber" to "t102_case6" with qos 0
+    And message "Single not retained message in case6" is not received on "subscriber" from "t102_case6" topic within 5 seconds
+
+    And I clear message storage
+
+    # 7. test case when no retained messages and subscribed with 'send at new subscription'
+    And I set MQTT publish 'retain' flag to false
+    And I set MQTT subscribe 'retain handling' property to "MQTT5_RETAIN_SEND_AT_NEW_SUBSCRIPTION"
+
+    When I publish from "publisher" to "t102_case7" with qos 0 and message "Single not retained message in case7"
+    When I subscribe "subscriber" to "t102_case7" with qos 0
+    And message "Single not retained message in case7" is not received on "subscriber" from "t102_case7" topic within 5 seconds
 
 
-  @GGMQ-1-T103
-  Scenario Outline: GGMQ-1-T103-<mqtt-v>-<name>: As a customer, I can use: retain as published flag, user properties for MQTT v5.0
-    When I create a Greengrass deployment with components
-      | aws.greengrass.clientdevices.Auth       | LATEST                                  |
-      | aws.greengrass.clientdevices.mqtt.EMQX  | LATEST                                  |
-      | aws.greengrass.clientdevices.IPDetector | LATEST                                  |
-      | <agent>                                 | classpath:/local-store/recipes/<recipe> |
-    And I create client device "publisher"
-    And I create client device "subscriber"
-    When I associate "subscriber" with ggc
-    When I associate "publisher" with ggc
+    And I clear message storage
 
-    And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:
-    """
-{
-    "MERGE":{
-        "deviceGroups":{
-            "formatVersion":"2021-03-05",
-            "definitions":{
-                "MyPermissiveDeviceGroup":{
-                    "selectionRule":"thingName: ${publisher} OR thingName: ${subscriber}",
-                    "policyName":"MyPermissivePolicy"
-                }
-            },
-            "policies":{
-                "MyPermissivePolicy":{
-                    "AllowAll":{
-                        "statementDescription":"Allow client devices to perform all actions.",
-                        "operations":[
-                            "*"
-                        ],
-                        "resources":[
-                            "*"
-                        ]
-                    }
-                }
-            }
-        }
-    }
-}
-    """
-    And I update my Greengrass deployment configuration, setting the component <agent> configuration to:
-    """
-{
-    "MERGE":{
-        "controlAddresses":"${mqttControlAddresses}",
-        "controlPort":"${mqttControlPort}"
-    }
-}
-    """
-    And I deploy the Greengrass deployment configuration
-    Then the Greengrass deployment is COMPLETED on the device after 5 minutes
-    And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes
+    # 8. test case when no retaine messages and subscribed with 'do not send at subscription'
+    And I set MQTT publish 'retain' flag to false
+    And I set MQTT subscribe 'retain handling' property to "MQTT5_RETAIN_DO_NOT_SEND_AT_SUBSCRIPTION"
 
-    Then I discover core device broker as "localMqttBroker1" from "publisher" in OTF
-    Then I discover core device broker as "localMqttBroker2" from "subscriber" in OTF
-    And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
-    And I connect device "subscriber" on <agent> to "localMqttBroker2" using mqtt "<mqtt-v>"
+    When I publish from "publisher" to "t102_case8" with qos 0 and message "Single not retained message in case8"
+    When I subscribe "subscriber" to "t102_case8" with qos 0
+    And message "Single not retained message in case8" is not received on "subscriber" from "t102_case8" topic within 5 seconds
 
-    # 1. test case when subscribe 'retain as published' is false.
+    # 'retain as published' tests
+    And I clear message storage
+
+    # 9. test case when subscribe 'retain as published' is false.
     #  In that case 'retain' flag on receive should be false regardless 'retain' value on publish.
 
     And I set MQTT subscribe 'retain as published' flag to false
@@ -1306,7 +1272,7 @@ Feature: GGMQ-1
     And message "Hello world2" received on "subscriber" from "iot_data_0" topic within 5 seconds
 
 
-    # 2. test case when subscribe 'retain as published' is true.
+    # 10. test case when subscribe 'retain as published' is true.
     #  In that case 'retain' flag on receive should be equal to 'retain' value on publish.
 
     And I set MQTT subscribe 'retain as published' flag to true
@@ -1323,7 +1289,8 @@ Feature: GGMQ-1
     When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world4"
     And message "Hello world4" received on "subscriber" from "iot_data_1" topic within 5 seconds
 
-    # 3. test case when publish 'user properties' are not empty.
+    # 'user properties' tests
+    # 11. test case when publish 'user properties' are not empty.
     #  In that case 'user properties' on receive should be equal to 'user properties' value on publish.
 
     And I add MQTT 'user property' with key "type" and value "json" to transmit
@@ -1334,7 +1301,7 @@ Feature: GGMQ-1
     When I publish from "publisher" to "iot_data_2" with qos 0 and message "Expected userProperties are received"
     And message "Expected userProperties are received" received on "subscriber" from "iot_data_2" topic within 5 seconds
 
-    # 4. test case when publish 'user properties' are empty.
+    # 12. test case when publish 'user properties' are empty.
     #  In that case 'user properties' on receive should not be equal to 'user properties' value on publish.
 
     And I clear message storage
@@ -1346,7 +1313,7 @@ Feature: GGMQ-1
     When I publish from "publisher" to "iot_data_2" with qos 0 and message "Expected userProperties are not received"
     And message "Expected userProperties are not received" is not received on "subscriber" from "iot_data_2" topic within 5 seconds
 
-    # 5. test case when publish 'user properties' are empty.
+    # 13. test case when publish 'user properties' are empty.
     #  In that case 'user properties' on receive should ignore 'user properties' value on publish.
     And I clear message storage
     And I clear MQTT 'user properties' to transmit
@@ -1357,7 +1324,7 @@ Feature: GGMQ-1
     When I publish from "publisher" to "iot_data_3" with qos 0 and message "Ignore userProperties"
     And message "Ignore userProperties" received on "subscriber" from "iot_data_3" topic within 5 seconds
 
-    # 6. test case when publish 'user properties' are empty.
+    # 14. test case when publish 'user properties' are empty.
     #  In that case 'user properties' on receive should be equal to 'user properties' value on publish.
 
     And I clear message storage
@@ -1367,85 +1334,10 @@ Feature: GGMQ-1
     When I publish from "publisher" to "iot_data_4" with qos 0 and message "Without userProperties"
     And message "Without userProperties" received on "subscriber" from "iot_data_4" topic within 5 seconds
 
-    And I disconnect device "subscriber" with reason code 0
-    And I disconnect device "publisher" with reason code 0
+    # 'payload format indicator' tests
+    And I clear message storage
 
-    @mqtt5 @sdk-java
-    Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
-
-    @mqtt5 @mosquitto-c
-    Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
-
-    @mqtt5 @paho-java
-    Examples:
-      | mqtt-v | name        | agent                                     | recipe                  |
-      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
-
-  # TODO: when paho-java is ready to handle payload format indicator join all T1xx scenarios together
-  @GGMQ-1-T104
-  Scenario Outline: GGMQ-1-T104-<mqtt-v>-<name>: As a customer, I can send and receive MQTT v5.0 messages with 'payload format indicator'
-    When I create a Greengrass deployment with components
-      | aws.greengrass.clientdevices.Auth       | LATEST                                  |
-      | aws.greengrass.clientdevices.mqtt.EMQX  | LATEST                                  |
-      | aws.greengrass.clientdevices.IPDetector | LATEST                                  |
-      | <agent>                                 | classpath:/local-store/recipes/<recipe> |
-    And I create client device "publisher"
-    And I create client device "subscriber"
-    When I associate "subscriber" with ggc
-    When I associate "publisher" with ggc
-
-    And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:
-    """
-{
-    "MERGE":{
-        "deviceGroups":{
-            "formatVersion":"2021-03-05",
-            "definitions":{
-                "MyPermissiveDeviceGroup":{
-                    "selectionRule":"thingName: ${publisher} OR thingName: ${subscriber}",
-                    "policyName":"MyPermissivePolicy"
-                }
-            },
-            "policies":{
-                "MyPermissivePolicy":{
-                    "AllowAll":{
-                        "statementDescription":"Allow client devices to perform all actions.",
-                        "operations":[
-                            "*"
-                        ],
-                        "resources":[
-                            "*"
-                        ]
-                    }
-                }
-            }
-        }
-    }
-}
-    """
-    And I update my Greengrass deployment configuration, setting the component <agent> configuration to:
-    """
-{
-    "MERGE":{
-        "controlAddresses":"${mqttControlAddresses}",
-        "controlPort":"${mqttControlPort}"
-    }
-}
-    """
-    And I deploy the Greengrass deployment configuration
-    Then the Greengrass deployment is COMPLETED on the device after 5 minutes
-    And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes
-
-    Then I discover core device broker as "localMqttBroker1" from "publisher" in OTF
-    Then I discover core device broker as "localMqttBroker2" from "subscriber" in OTF
-    And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
-    And I connect device "subscriber" on <agent> to "localMqttBroker2" using mqtt "<mqtt-v>"
-
-    # 7. test case when both tx/rx payload format indicators are set to 0
+    # 15. test case when both tx/rx payload format indicators are set to 0
     And I clear message storage
     And I set MQTT publish 'payload format indicator' flag to false
     And I set the 'payload format indicator' flag in expected received messages to false
@@ -1453,40 +1345,45 @@ Feature: GGMQ-1
     When I publish from "publisher" to "payload_format_indicator_false_false" with qos 0 and message "Payload format indicators false/false"
     And message "Payload format indicators false/false" received on "subscriber" from "payload_format_indicator_false_false" topic within 5 seconds
 
-    # 8. test case when both tx/rx payload format indicators set to 1
     And I clear message storage
+
+    # 16. test case when both tx/rx payload format indicators set to 1
     And I set MQTT publish 'payload format indicator' flag to true
     And I set the 'payload format indicator' flag in expected received messages to true
     When I subscribe "subscriber" to "payload_format_indicator_true_true" with qos 0
     When I publish from "publisher" to "payload_format_indicator_true_true" with qos 0 and message "Payload format indicators true/true"
     And message "Payload format indicators true/true" received on "subscriber" from "payload_format_indicator_true_true" topic within 5 seconds
 
-    # 10. test case when tx payload format indicator set to 1 and rx to 0
     And I clear message storage
+
+    # 17. test case when tx payload format indicator set to 1 and rx to 0
     And I set MQTT publish 'payload format indicator' flag to true
     And I set the 'payload format indicator' flag in expected received messages to false
     When I subscribe "subscriber" to "payload_format_indicator_true_false" with qos 0
     When I publish from "publisher" to "payload_format_indicator_true_false" with qos 0 and message "Payload format indicators true/false"
     And message "Payload format indicators true/false" is not received on "subscriber" from "payload_format_indicator_true_false" topic within 5 seconds
 
-    # 11. test case when tx payload format indicator set to 0 and rx to 1
     And I clear message storage
+
+    # 18. test case when tx payload format indicator set to 0 and rx to 1
     And I set MQTT publish 'payload format indicator' flag to false
     And I set the 'payload format indicator' flag in expected received messages to true
     When I subscribe "subscriber" to "payload_format_indicator_false_true" with qos 0
     When I publish from "publisher" to "payload_format_indicator_false_true" with qos 0 and message "Payload format indicators false/true"
     And message "Payload format indicators false/true" is not received on "subscriber" from "payload_format_indicator_false_true" topic within 5 seconds
 
-    # 12. test case when tx payload format indicator set to 1 and rx is unset
     And I clear message storage
+
+    # 19. test case when tx payload format indicator set to 1 and rx is unset
     And I set MQTT publish 'payload format indicator' flag to true
     And I set the 'payload format indicator' flag in expected received messages to null
     When I subscribe "subscriber" to "payload_format_indicator_true_null" with qos 0
     When I publish from "publisher" to "payload_format_indicator_true_null" with qos 0 and message "Payload format indicators true/null"
     And message "Payload format indicators true/null" received on "subscriber" from "payload_format_indicator_true_null" topic within 5 seconds
 
-    # 13. test case when tx payload format indicator set to 0 and rx is unset
     And I clear message storage
+
+    # 20. test case when tx payload format indicator set to 0 and rx is unset
     And I set MQTT publish 'payload format indicator' flag to false
     And I set the 'payload format indicator' flag in expected received messages to null
     When I subscribe "subscriber" to "payload_format_indicator_false_null" with qos 0
@@ -1505,3 +1402,8 @@ Feature: GGMQ-1
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
+
+    @mqtt5 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1384,3 +1384,85 @@ Feature: GGMQ-1
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
+
+  @GGMQ-1-T104
+  Scenario Outline: GGMQ-1-T104-<mqtt-v>-<name>: As a customer, I can send and receive MQTT v5.0 messages with 'payload format indicator'
+    When I create a Greengrass deployment with components
+      | aws.greengrass.clientdevices.Auth       | LATEST                                  |
+      | aws.greengrass.clientdevices.mqtt.EMQX  | LATEST                                  |
+      | aws.greengrass.clientdevices.IPDetector | LATEST                                  |
+      | <agent>                                 | classpath:/local-store/recipes/<recipe> |
+    And I create client device "publisher"
+    And I create client device "subscriber"
+    When I associate "subscriber" with ggc
+    When I associate "publisher" with ggc
+
+    And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:
+    """
+{
+    "MERGE":{
+        "deviceGroups":{
+            "formatVersion":"2021-03-05",
+            "definitions":{
+                "MyPermissiveDeviceGroup":{
+                    "selectionRule":"thingName: ${publisher} OR thingName: ${subscriber}",
+                    "policyName":"MyPermissivePolicy"
+                }
+            },
+            "policies":{
+                "MyPermissivePolicy":{
+                    "AllowAll":{
+                        "statementDescription":"Allow client devices to perform all actions.",
+                        "operations":[
+                            "*"
+                        ],
+                        "resources":[
+                            "*"
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}
+    """
+    And I update my Greengrass deployment configuration, setting the component <agent> configuration to:
+    """
+{
+    "MERGE":{
+        "controlAddresses":"${mqttControlAddresses}",
+        "controlPort":"${mqttControlPort}"
+    }
+}
+    """
+    And I deploy the Greengrass deployment configuration
+    Then the Greengrass deployment is COMPLETED on the device after 5 minutes
+    And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes
+
+    Then I discover core device broker as "localMqttBroker1" from "publisher" in OTF
+    Then I discover core device broker as "localMqttBroker2" from "subscriber" in OTF
+    And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
+    And I connect device "subscriber" on <agent> to "localMqttBroker2" using mqtt "<mqtt-v>"
+
+    # 1. payload format indicator set to 0
+    When I subscribe "subscriber" to "iot_data_0" with qos 0
+    And I set MQTT publish 'payload format indicator' flag to false
+    When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world1"
+    And I set the 'payload format indicator' flag in expected received messages to false
+    And message "Hello world1" received on "subscriber" from "iot_data_0" topic within 5 seconds
+
+    # 2. payload format indicator set to 1
+    When I subscribe "subscriber" to "iot_data_1" with qos 0
+    And I set MQTT publish 'payload format indicator' flag to true
+    When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world2"
+    And I set the 'payload format indicator' flag in expected received messages to true
+    And message "Hello world2" received on "subscriber" from "iot_data_1" topic within 5 seconds
+
+    And I disconnect device "subscriber" with reason code 0
+    And I disconnect device "publisher" with reason code 0
+
+    # TODO: add more agents here when 'payload format indicator' feature will be added to it
+    @mqtt5 @mosquitto-c
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -78,7 +78,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q1 |
       | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    | GRANTED_QOS_0       |
 
-    @mqtt3 @mosquitto-c
+    @mqtt3 @mosquitto-c @SkipOnWindows
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q1 |
       | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | GRANTED_QOS_1       |
@@ -93,7 +93,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q1 |
       | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    | GRANTED_QOS_1       |
 
-    @mqtt5 @mosquitto-c
+    @mqtt5 @mosquitto-c @SkipOnWindows
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q1 |
       | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | GRANTED_QOS_1       |
@@ -374,7 +374,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  |
       | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
 
-    @mqtt3 @mosquitto-c
+    @mqtt3 @mosquitto-c @SkipOnWindows
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
       | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
@@ -389,7 +389,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
 
-    @mqtt5 @mosquitto-c
+    @mqtt5 @mosquitto-c @SkipOnWindows
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
@@ -512,7 +512,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  |
       | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
 
-    @mqtt3 @mosquitto-c
+    @mqtt3 @mosquitto-c @SkipOnWindows
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
       | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
@@ -527,7 +527,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
 
-    @mqtt5 @mosquitto-c
+    @mqtt5 @mosquitto-c @SkipOnWindows
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
@@ -699,7 +699,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
       | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    | GRANTED_QOS_0       | GRANTED_QOS_0         | 0                  |
 
-    @mqtt3 @mosquitto-c
+    @mqtt3 @mosquitto-c @SkipOnWindows
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
       | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | UNSPECIFIED_ERROR   | GRANTED_QOS_1         | 0                  |
@@ -717,7 +717,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
       | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    | NOT_AUTHORIZED      | GRANTED_QOS_1         | 16                 |
 
-    @mqtt5 @mosquitto-c
+    @mqtt5 @mosquitto-c @SkipOnWindows
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
       | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | NOT_AUTHORIZED      | GRANTED_QOS_1         | 16                 |
@@ -841,7 +841,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  |
       | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
 
-    @mqtt3 @mosquitto-c
+    @mqtt3 @mosquitto-c @SkipOnWindows
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
       | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
@@ -856,7 +856,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
 
-    @mqtt5 @mosquitto-c
+    @mqtt5 @mosquitto-c @SkipOnWindows
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
@@ -981,7 +981,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  |
       | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
 
-    @mqtt3 @mosquitto-c
+    @mqtt3 @mosquitto-c @SkipOnWindows
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
       | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
@@ -996,7 +996,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
 
-    @mqtt5 @mosquitto-c
+    @mqtt5 @mosquitto-c @SkipOnWindows
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
@@ -1085,7 +1085,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  |
       | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
 
-    @mqtt3 @mosquitto-c
+    @mqtt3 @mosquitto-c @SkipOnWindows
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
       | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |
@@ -1398,7 +1398,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
 
-    @mqtt5 @mosquitto-c
+    @mqtt5 @mosquitto-c @SkipOnWindows
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml |

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1445,19 +1445,53 @@ Feature: GGMQ-1
     And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
     And I connect device "subscriber" on <agent> to "localMqttBroker2" using mqtt "<mqtt-v>"
 
-    # 1. payload format indicator set to 0
-    When I subscribe "subscriber" to "iot_data_0" with qos 0
+    # 7. test case when both tx/rx payload format indicators are set to 0
+    And I clear message storage
     And I set MQTT publish 'payload format indicator' flag to false
-    When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world1"
     And I set the 'payload format indicator' flag in expected received messages to false
-    And message "Hello world1" received on "subscriber" from "iot_data_0" topic within 5 seconds
+    When I subscribe "subscriber" to "payload_format_indicator_false_false" with qos 0
+    When I publish from "publisher" to "payload_format_indicator_false_false" with qos 0 and message "Payload format indicators false/false"
+    And message "Payload format indicators false/false" received on "subscriber" from "payload_format_indicator_false_false" topic within 5 seconds
 
-    # 2. payload format indicator set to 1
-    When I subscribe "subscriber" to "iot_data_1" with qos 0
+    # 8. test case when both tx/rx payload format indicators set to 1
+    And I clear message storage
     And I set MQTT publish 'payload format indicator' flag to true
-    When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world2"
     And I set the 'payload format indicator' flag in expected received messages to true
-    And message "Hello world2" received on "subscriber" from "iot_data_1" topic within 5 seconds
+    When I subscribe "subscriber" to "payload_format_indicator_true_true" with qos 0
+    When I publish from "publisher" to "payload_format_indicator_true_true" with qos 0 and message "Payload format indicators true/true"
+    And message "Payload format indicators true/true" received on "subscriber" from "payload_format_indicator_true_true" topic within 5 seconds
+
+    # 10. test case when tx payload format indicator set to 1 and rx to 0
+    And I clear message storage
+    And I set MQTT publish 'payload format indicator' flag to true
+    And I set the 'payload format indicator' flag in expected received messages to false
+    When I subscribe "subscriber" to "payload_format_indicator_true_false" with qos 0
+    When I publish from "publisher" to "payload_format_indicator_true_false" with qos 0 and message "Payload format indicators true/false"
+    And message "Payload format indicators true/false" is not received on "subscriber" from "payload_format_indicator_true_false" topic within 5 seconds
+
+    # 11. test case when tx payload format indicator set to 0 and rx to 1
+    And I clear message storage
+    And I set MQTT publish 'payload format indicator' flag to false
+    And I set the 'payload format indicator' flag in expected received messages to true
+    When I subscribe "subscriber" to "payload_format_indicator_false_true" with qos 0
+    When I publish from "publisher" to "payload_format_indicator_false_true" with qos 0 and message "Payload format indicators false/true"
+    And message "Payload format indicators false/true" is not received on "subscriber" from "payload_format_indicator_false_true" topic within 5 seconds
+
+    # 12. test case when tx payload format indicator set to 1 and rx is unset
+    And I clear message storage
+    And I set MQTT publish 'payload format indicator' flag to true
+    And I set the 'payload format indicator' flag in expected received messages to null
+    When I subscribe "subscriber" to "payload_format_indicator_true_null" with qos 0
+    When I publish from "publisher" to "payload_format_indicator_true_null" with qos 0 and message "Payload format indicators true/null"
+    And message "Payload format indicators true/null" received on "subscriber" from "payload_format_indicator_true_null" topic within 5 seconds
+
+    # 13. test case when tx payload format indicator set to 0 and rx is unset
+    And I clear message storage
+    And I set MQTT publish 'payload format indicator' flag to false
+    And I set the 'payload format indicator' flag in expected received messages to null
+    When I subscribe "subscriber" to "payload_format_indicator_false_null" with qos 0
+    When I publish from "publisher" to "payload_format_indicator_false_null" with qos 0 and message "Payload format indicators false/null"
+    And message "Payload format indicators false/null" received on "subscriber" from "payload_format_indicator_false_null" topic within 5 seconds
 
     And I disconnect device "subscriber" with reason code 0
     And I disconnect device "publisher" with reason code 0


### PR DESCRIPTION
**Issue #, if available:**
Set payload format indicator

**Description of changes:**
- Add new steps to set tx and expected rx payload format indicator
- Add test cases for payload format indicator handling
- Join all MQTT v5 features test case to GGMQ-1-T102
- Add ability to filter messages by value of payload format indicator
- Fix bug in paho-java client when payload format indicator field of intermediate message is not handled
- Add unit tests for new filter feature
- Add @SkipOnWindows tag to scenarios

**Why is this change necessary:**
Require to test payload format indicator MQTT v5.0 feature


**How was this change tested:**
- 5 unit tests for have been added to control
- new test cases in GGMQ-1-T102 scenario outline has been added for 3 clients

**Test results:**
first run
```
[INFO ] 2023-06-26 18:13:59.483 [main] StepTrackingReporting - Passed: 'GGMQ-1-T102-v5-sdk-java: As a customer, I can use publish retain flag and subscribe retain handling as expected'
[INFO ] 2023-06-26 18:13:59.483 [main] StepTrackingReporting - Passed: 'GGMQ-1-T102-v5-mosquitto-c: As a customer, I can use publish retain flag and subscribe retain handling as expected'
[ERROR] 2023-06-26 18:13:59.483 [main] StepTrackingReporting - Failed: 'GGMQ-1-T102-v5-paho-java: As a customer, I can use publish retain flag and subscribe retain handling as expected': Failed at 'message "Payl
oad format indicators true/true" received on "subscriber" from "payload_format_indicator_true_true" topic within 5 seconds'
```
second run (single scenario)
```
[INFO ] 2023-06-26 19:35:10.341 [main] StepTrackingReporting - Passed: 'GGMQ-1-T102-v5-paho-java: As a customer, I can use publish retain flag and subscribe retain handling as expected'
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
