### PR TITLE
feat(uat): add test cases for 'no local' feature

### DIFF
--- a/.github/workflows/otf.yml
+++ b/.github/workflows/otf.yml
@@ -6,6 +6,7 @@ name: OTF UATS
 
 on:
   workflow_dispatch:
+
   pull_request:
     branches:
       - uat-dev

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
@@ -215,6 +215,7 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
     }
 
 
+    @SuppressWarnings("PMD.CollapsibleIfStatements")
     private void unregisterAllAgent() {
         agents.forEach((agentId, agentControl) -> {
             if (agents.remove(agentId, agentControl)) {

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -99,7 +99,7 @@ public class MqttControlSteps {
     private static final int DEFAULT_MQTT_KEEP_ALIVE = 60;
 
     // connect default properties
-    private static final boolean DEFAULT_CONNECT_CLEAR_SESSION = true;
+    private static final boolean DEFAULT_CONNECT_CLEAR_SESSION = true;  // TODO: use also variable and step to set it
     private static final int IOT_CORE_MQTT_PORT = 8883;
 
     // publish default properties

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1468,19 +1468,53 @@ Feature: GGMQ-1
     And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
     And I connect device "subscriber" on <agent> to "localMqttBroker2" using mqtt "<mqtt-v>"
 
-    # 1. payload format indicator set to 0
-    When I subscribe "subscriber" to "iot_data_0" with qos 0
+    # 7. test case when both tx/rx payload format indicators are set to 0
+    And I clear message storage
     And I set MQTT publish 'payload format indicator' flag to false
-    When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world1"
     And I set the 'payload format indicator' flag in expected received messages to false
-    And message "Hello world1" received on "subscriber" from "iot_data_0" topic within 5 seconds
+    When I subscribe "subscriber" to "payload_format_indicator_false_false" with qos 0
+    When I publish from "publisher" to "payload_format_indicator_false_false" with qos 0 and message "Payload format indicators false/false"
+    And message "Payload format indicators false/false" received on "subscriber" from "payload_format_indicator_false_false" topic within 5 seconds
 
-    # 2. payload format indicator set to 1
-    When I subscribe "subscriber" to "iot_data_1" with qos 0
+    # 8. test case when both tx/rx payload format indicators set to 1
+    And I clear message storage
     And I set MQTT publish 'payload format indicator' flag to true
-    When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world2"
     And I set the 'payload format indicator' flag in expected received messages to true
-    And message "Hello world2" received on "subscriber" from "iot_data_1" topic within 5 seconds
+    When I subscribe "subscriber" to "payload_format_indicator_true_true" with qos 0
+    When I publish from "publisher" to "payload_format_indicator_true_true" with qos 0 and message "Payload format indicators true/true"
+    And message "Payload format indicators true/true" received on "subscriber" from "payload_format_indicator_true_true" topic within 5 seconds
+
+    # 10. test case when tx payload format indicator set to 1 and rx to 0
+    And I clear message storage
+    And I set MQTT publish 'payload format indicator' flag to true
+    And I set the 'payload format indicator' flag in expected received messages to false
+    When I subscribe "subscriber" to "payload_format_indicator_true_false" with qos 0
+    When I publish from "publisher" to "payload_format_indicator_true_false" with qos 0 and message "Payload format indicators true/false"
+    And message "Payload format indicators true/false" is not received on "subscriber" from "payload_format_indicator_true_false" topic within 5 seconds
+
+    # 11. test case when tx payload format indicator set to 0 and rx to 1
+    And I clear message storage
+    And I set MQTT publish 'payload format indicator' flag to false
+    And I set the 'payload format indicator' flag in expected received messages to true
+    When I subscribe "subscriber" to "payload_format_indicator_false_true" with qos 0
+    When I publish from "publisher" to "payload_format_indicator_false_true" with qos 0 and message "Payload format indicators false/true"
+    And message "Payload format indicators false/true" is not received on "subscriber" from "payload_format_indicator_false_true" topic within 5 seconds
+
+    # 12. test case when tx payload format indicator set to 1 and rx is unset
+    And I clear message storage
+    And I set MQTT publish 'payload format indicator' flag to true
+    And I set the 'payload format indicator' flag in expected received messages to null
+    When I subscribe "subscriber" to "payload_format_indicator_true_null" with qos 0
+    When I publish from "publisher" to "payload_format_indicator_true_null" with qos 0 and message "Payload format indicators true/null"
+    And message "Payload format indicators true/null" received on "subscriber" from "payload_format_indicator_true_null" topic within 5 seconds
+
+    # 13. test case when tx payload format indicator set to 0 and rx is unset
+    And I clear message storage
+    And I set MQTT publish 'payload format indicator' flag to false
+    And I set the 'payload format indicator' flag in expected received messages to null
+    When I subscribe "subscriber" to "payload_format_indicator_false_null" with qos 0
+    When I publish from "publisher" to "payload_format_indicator_false_null" with qos 0 and message "Payload format indicators false/null"
+    And message "Payload format indicators false/null" received on "subscriber" from "payload_format_indicator_false_null" topic within 5 seconds
 
     And I disconnect device "subscriber" with reason code 0
     And I disconnect device "publisher" with reason code 0

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1396,11 +1396,8 @@ Feature: GGMQ-1
     And I set MQTT subscribe 'no local' flag to true
     When I subscribe "subscriber" to "no_local_test" with qos 0
 
-    When I publish from "subscriber" to "no_local_false" with qos 0 and message "First message no local true test"
-    Then message "First message no local true test" is not received on "subscriber" from "no_local_false" topic within 5 seconds
-
-    When I publish from "publisher" to "no_local_false" with qos 0 and message "Second message no local true test"
-    Then message "Second message no local true test" received on "subscriber" from "no_local_false" topic within 5 seconds
+    When I publish from "subscriber" to "no_local_true" with qos 0 and message "First message no local true test"
+    Then message "First message no local true test" is not received on "subscriber" from "no_local_true" topic within 5 seconds
 
     And I clear message storage
 

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1408,6 +1408,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
 
+  # TODO: when paho-java is ready to handle payload format indicator join all T1xx scenarios together
   @GGMQ-1-T104
   Scenario Outline: GGMQ-1-T104-<mqtt-v>-<name>: As a customer, I can send and receive MQTT v5.0 messages with 'payload format indicator'
     When I create a Greengrass deployment with components
@@ -1484,7 +1485,11 @@ Feature: GGMQ-1
     And I disconnect device "subscriber" with reason code 0
     And I disconnect device "publisher" with reason code 0
 
-    # TODO: add more agents here when 'payload format indicator' feature will be added to it
+    @mqtt5 @sdk-java
+    Examples:
+      | mqtt-v | name        | agent                                     | recipe                  |
+      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    |
+
     @mqtt5 @mosquitto-c
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |


### PR DESCRIPTION
**Issue #, if available:**
Set/unset non local publishing

**Description of changes:**
- Update GGMQ-1-T102 by adding test cases for subscribe 'non local' feature

**Why is this change necessary:**
'no local' feature should be tested

**How was this change tested:**
By running scenarios on CodeBuild

**Test results:**
```
[INFO ] 2023-06-26 22:00:13.320 [main] StepTrackingReporting - Passed: 'GGMQ-1-T102-v5-sdk-java: As a customer, I can use publish retain flag and subscribe retain handling as expected'
[INFO ] 2023-06-26 22:00:13.321 [main] StepTrackingReporting - Passed: 'GGMQ-1-T102-v5-mosquitto-c: As a customer, I can use publish retain flag and subscribe retain handling as expected'
[INFO ] 2023-06-26 22:00:13.321 [main] StepTrackingReporting - Passed: 'GGMQ-1-T102-v5-paho-java: As a customer, I can use publish retain flag and subscribe retain handling as expected'
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
