### PR TITLE
feat(uat): add steps for tx and rx content type and extend t102

### DIFF
--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/addon/EventFilter.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/addon/EventFilter.java
@@ -203,7 +203,7 @@ public final class EventFilter {
          *
          * @param contentType the content type of MQTT message
          */
-        public Builder withContentType(@NonNull String contentType) {
+        public Builder withContentType(String contentType) {
             this.contentType = contentType;
             return this;
         }

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/addon/EventFilter.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/addon/EventFilter.java
@@ -27,6 +27,7 @@ public final class EventFilter {
     private final String connectionName;
     private final String topic;
     private final String topicFilter;
+    private final String contentType;
     private final byte[] content;
     private final Boolean retain;
     private final List<Mqtt5Properties> userProperties;
@@ -43,6 +44,7 @@ public final class EventFilter {
         this.connectionName = builder.connectionName;
         this.topic = builder.topic;
         this.topicFilter = builder.topicFilter;
+        this.contentType = builder.contentType;
         this.content = builder.content;
         this.retain = builder.retain;
         this.userProperties = builder.userProperties;
@@ -62,6 +64,7 @@ public final class EventFilter {
         private String connectionName;
         private String topic;
         private String topicFilter;
+        private String contentType;
         private byte[] content;
         private Boolean retain;
         private List<Mqtt5Properties> userProperties;
@@ -191,6 +194,17 @@ public final class EventFilter {
          */
         public Builder withContent(@NonNull byte[] content) {
             this.content = content;
+            return this;
+        }
+
+        /**
+         * Sets content field of filter.
+         * Applicable only for MQTT message events
+         *
+         * @param contentType the content type of MQTT message
+         */
+        public Builder withContentType(@NonNull String contentType) {
+            this.contentType = contentType;
             return this;
         }
 

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/addon/MqttMessageEvent.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/addon/MqttMessageEvent.java
@@ -82,6 +82,11 @@ public class MqttMessageEvent extends EventImpl {
             return false;
         }
 
+        matched = isContentTypeMatched(filter.getContentType());
+        if (!matched) {
+            return false;
+        }
+
         matched = isPayloadFormatIndicatorMatched(filter.getPayloadFormatIndicator());
         if (!matched) {
             return false;
@@ -132,6 +137,10 @@ public class MqttMessageEvent extends EventImpl {
 
     private boolean isUserPropertiesMatched(List<Mqtt5Properties> userProperties) {
         return userProperties == null || userProperties.equals(message.getPropertiesList());
+    }
+
+    private boolean isContentTypeMatched(String contentType) {
+        return contentType == null || contentType.equals(message.getContentType());
     }
 
     private boolean isPayloadFormatIndicatorMatched(Boolean payloadFormatIndicator) {

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -104,6 +104,7 @@ public class MqttControlSteps {
 
     // publish default properties
     private static final boolean DEFAULT_PUBLISH_RETAIN = false;
+    private static final String DEFAULT_CONTENT_TYPE = null;
     private static final Boolean DEFAULT_PUBLISH_PAYLOAD_FORMAT_INDICATOR = null;
 
     // subscribe efault properties
@@ -147,6 +148,12 @@ public class MqttControlSteps {
 
     /** Actual value of publish payload format indicator. */
     private Boolean publishPayloadFormatIndicator = DEFAULT_PUBLISH_PAYLOAD_FORMAT_INDICATOR;
+
+    /** Actual value of content type to transmit. */
+    private String txContentType = DEFAULT_CONTENT_TYPE;
+
+    /** Actual value of content type to receive. */
+    private String rxContentType = DEFAULT_CONTENT_TYPE;
 
     /** Actual expected value of retain flag in received messages. */
     private Boolean receivedRetain = DEFAULT_RECEIVED_RETAIN;
@@ -385,6 +392,48 @@ public class MqttControlSteps {
     public void setMqttTimeoutSec(int mqttTimeoutSec) {
         this.mqttTimeoutSec = mqttTimeoutSec;
         log.info("MQTT timeout set to {} second(s)", mqttTimeoutSec);
+    }
+
+    /**
+     * Sets MQTT content type to transmit.
+     *
+     * @param contentType MQTT content type to transmit
+     */
+    @And("I set MQTT 'content type' to {string} to transmit")
+    public void setMqttTxContentType(String contentType) {
+        this.txContentType = contentType;
+        log.info("MQTT content type set to {} to transmit", contentType);
+    }
+
+    /**
+     * Sets MQTT content type to receive.
+     *
+     * @param contentType MQTT content type to receive
+     */
+    @And("I set MQTT 'content type' to {string} to receive")
+    public void setMqttRxContentType(String contentType) {
+        this.rxContentType = contentType;
+        log.info("MQTT content type set to {} to receive", contentType);
+    }
+
+    /**
+     * Clear MQTT content type to transmit.
+     */
+    @And("I clear MQTT 'content type' to transmit")
+    @SuppressWarnings("PMD.NullAssignment")
+    public void clearMqttTxContentType() {
+        this.txContentType = null;
+        log.info("MQTT content type reset to transmit");
+    }
+
+    /**
+     * Clear MQTT content type to receive.
+     */
+    @And("I clear MQTT 'content type' to receive")
+    @SuppressWarnings("PMD.NullAssignment")
+    public void clearMqttRxContentType() {
+        this.rxContentType = null;
+        log.info("MQTT content type reset to receive");
     }
 
     /**
@@ -678,6 +727,7 @@ public class MqttControlSteps {
                                         .withType(Event.Type.EVENT_TYPE_MQTT_MESSAGE)
                                         .withConnectionControl(connectionControl)
                                         .withTopic(topic)
+                                        .withContentType(rxContentType)
                                         .withContent(message)
                                         .withRetain(receivedRetain)
                                         .withUserProperties(rxUserProperties)
@@ -1047,6 +1097,10 @@ public class MqttControlSteps {
 
         if (payloadFormatIndicator != null) {
             builder.setPayloadFormatIndicator(payloadFormatIndicator);
+        }
+
+        if (txContentType != null) {
+            builder.setContentType(txContentType);
         }
 
         return builder.build();

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -399,7 +399,7 @@ public class MqttControlSteps {
      *
      * @param contentType MQTT content type to transmit
      */
-    @And("I set MQTT 'content type' to {string} to transmit")
+    @And("I set MQTT publish 'content type' to {string}")
     public void setMqttTxContentType(String contentType) {
         this.txContentType = contentType;
         log.info("MQTT content type set to {} to transmit", contentType);
@@ -410,29 +410,27 @@ public class MqttControlSteps {
      *
      * @param contentType MQTT content type to receive
      */
-    @And("I set MQTT 'content type' to {string} to receive")
+    @And("I set MQTT 'content type' in expected received messages to {string}")
     public void setMqttRxContentType(String contentType) {
         this.rxContentType = contentType;
         log.info("MQTT content type set to {} to receive", contentType);
     }
 
     /**
-     * Clear MQTT content type to transmit.
+     * Reset MQTT content type to transmit.
      */
-    @And("I clear MQTT 'content type' to transmit")
-    @SuppressWarnings("PMD.NullAssignment")
-    public void clearMqttTxContentType() {
-        this.txContentType = null;
+    @And("I reset MQTT publish 'content type'")
+    public void resetMqttTxContentType() {
+        this.txContentType = DEFAULT_CONTENT_TYPE;
         log.info("MQTT content type reset to transmit");
     }
 
     /**
-     * Clear MQTT content type to receive.
+     * Reset MQTT content type to receive.
      */
-    @And("I clear MQTT 'content type' to receive")
-    @SuppressWarnings("PMD.NullAssignment")
-    public void clearMqttRxContentType() {
-        this.rxContentType = null;
+    @And("I reset MQTT 'content type' in expected received messages")
+    public void resetMqttRxContentType() {
+        this.rxContentType = DEFAULT_CONTENT_TYPE;
         log.info("MQTT content type reset to receive");
     }
 

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1433,7 +1433,7 @@ Feature: GGMQ-1
     And I set MQTT 'content type' to "text/plain; charset=utf-8" to receive
     When I subscribe "subscriber" to "content_type_null_not_null" with qos 0
     When I publish from "publisher" to "content_type_null_not_null" with qos 0 and message "Content types null/not null"
-    And message "Tx content type is null" is not received on "subscriber" from "content_type_null_not_null" topic within 5 seconds
+    And message "Content types null/not null" is not received on "subscriber" from "content_type_null_not_null" topic within 5 seconds
 
     And I clear message storage
 
@@ -1442,7 +1442,7 @@ Feature: GGMQ-1
     And I clear MQTT 'content type' to receive
     When I subscribe "subscriber" to "content_type_not_null_null" with qos 0
     When I publish from "publisher" to "content_type_not_null_null" with qos 0 and message "Content types not null/null"
-    And message "Tx content type is null" received on "subscriber" from "content_type_not_null_null" topic within 5 seconds
+    And message "Content types not null/null" received on "subscriber" from "content_type_not_null_null" topic within 5 seconds
 
     And I disconnect device "subscriber" with reason code 0
     And I disconnect device "publisher" with reason code 0

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1411,8 +1411,8 @@ Feature: GGMQ-1
     And I clear message storage
 
     # 23. test case when tx content type set the same value as rx
-    And I set MQTT 'content type' to "text/plain; charset=utf-8" to transmit
-    And I set MQTT 'content type' to "text/plain; charset=utf-8" to receive
+    And I set MQTT publish 'content type' to "text/plain; charset=utf-8"
+    And I set MQTT 'content type' in expected received messages to "text/plain; charset=utf-8"
     When I subscribe "subscriber" to "content_types_the_same" with qos 0
     When I publish from "publisher" to "content_types_the_same" with qos 0 and message "Content types not null/not null"
     And message "Content types not null/not null" received on "subscriber" from "content_types_the_same" topic within 5 seconds
@@ -1420,8 +1420,8 @@ Feature: GGMQ-1
     And I clear message storage
 
     # 24. test case when tx content type set another value then rx
-    And I set MQTT 'content type' to "another content type value" to transmit
-    And I set MQTT 'content type' to "text/plain; charset=utf-8" to receive
+    And I set MQTT publish 'content type' to "another content type value"
+    And I set MQTT 'content type' in expected received messages to "text/plain; charset=utf-8"
     When I subscribe "subscriber" to "content_type_not_the_same" with qos 0
     When I publish from "publisher" to "content_type_not_the_same" with qos 0 and message "Different values of content types"
     And message "Different values of content type" is not received on "subscriber" from "content_type_not_the_same" topic within 5 seconds
@@ -1429,8 +1429,8 @@ Feature: GGMQ-1
     And I clear message storage
 
     # 25. test case when tx content type is null
-    And I clear MQTT 'content type' to transmit
-    And I set MQTT 'content type' to "text/plain; charset=utf-8" to receive
+    And I reset MQTT publish 'content type'
+    And I set MQTT 'content type' in expected received messages to "text/plain; charset=utf-8"
     When I subscribe "subscriber" to "content_type_null_not_null" with qos 0
     When I publish from "publisher" to "content_type_null_not_null" with qos 0 and message "Content types null/not null"
     And message "Content types null/not null" is not received on "subscriber" from "content_type_null_not_null" topic within 5 seconds
@@ -1438,8 +1438,8 @@ Feature: GGMQ-1
     And I clear message storage
 
     # 26. test case when rx content type is null
-    And I set MQTT 'content type' to "text/plain; charset=utf-8" to transmit
-    And I clear MQTT 'content type' to receive
+    And I set MQTT publish 'content type' to "text/plain; charset=utf-8"
+    And I reset MQTT 'content type' in expected received messages
     When I subscribe "subscriber" to "content_type_not_null_null" with qos 0
     When I publish from "publisher" to "content_type_not_null_null" with qos 0 and message "Content types not null/null"
     And message "Content types not null/null" received on "subscriber" from "content_type_not_null_null" topic within 5 seconds


### PR DESCRIPTION
**Issue #, if available:**
add tx/rx content type and extend t102 with content type

**Description of changes:**
- Add content type steps
- Extend t102 with content type
- Rename t101
- Rename t102

**Why is this change necessary:**
Testing  MQTT v5.0 content type feature

**How was this change tested:**
Scenarios run manually and on CI

**Test results:**
```
Given my device is registered as a Thing....................................passed
And my device is running Greengrass.........................................passed
When I create a Greengrass deployment with components.......................passed
And I create client device "publisher"......................................passed
And I create client device "subscriber".....................................passed
When I associate "subscriber" with ggc......................................passed
When I associate "publisher" with ggc.......................................passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:.passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.client.Mqtt5JavaPahoClient configuration to:.passed
And I deploy the Greengrass deployment configuration........................passed
Then the Greengrass deployment is COMPLETED on the device after 5 minutes...passed
And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes.passed
Then I discover core device broker as "localMqttBroker1" from "publisher" in OTF.passed
Then I discover core device broker as "localMqttBroker2" from "subscriber" in OTF.passed
And I connect device "publisher" on aws.greengrass.client.Mqtt5JavaPahoClient to "localMqttBroker1" using mqtt "v5".passed
And I connect device "subscriber" on aws.greengrass.client.Mqtt5JavaPahoClient to "localMqttBroker2" using mqtt "v5".passed
And I set MQTT publish 'retain' flag to true................................passed
And I set MQTT subscribe 'retain handling' property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION".passed
When I publish from "publisher" to "receive_last_retain_message" with qos 0 and message "First retained message".passed
When I publish from "publisher" to "receive_last_retain_message" with qos 0 and message "Second retained message".passed
When I subscribe "subscriber" to "receive_last_retain_message" with qos 0...passed
And message "First retained message" is not received on "subscriber" from "receive_last_retain_message" topic within 5 seconds.passed
And message "Second retained message" received on "subscriber" from "receive_last_retain_message" topic within 5 seconds.passed
And I clear message storage.................................................passed
And I set MQTT publish 'retain' flag to true................................passed
And I set MQTT subscribe 'retain handling' property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION".passed
When I publish from "publisher" to "receive_only_retain_message_on_subscribe" with qos 0 and message "First message with retain".passed
And I set MQTT publish 'retain' flag to false...............................passed
When I publish from "publisher" to "receive_only_retain_message_on_subscribe" with qos 0 and message "Second message without retain".passed
When I subscribe "subscriber" to "receive_only_retain_message_on_subscribe" with qos 0.passed
And message "Second message without retain" is not received on "subscriber" from "receive_only_retain_message_on_subscribe" topic within 5 seconds.passed
And message "First message with retain" received on "subscriber" from "receive_only_retain_message_on_subscribe" topic within 5 seconds.passed
And I clear message storage.................................................passed
And I set MQTT publish 'retain' flag to true................................passed
And I set MQTT subscribe 'retain handling' property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION".passed
When I publish from "publisher" to "subscribe_twice_with_send_at_subscription" with qos 0 and message "Single message in case3".passed
When I subscribe "subscriber" to "subscribe_twice_with_send_at_subscription" with qos 0.passed
And message "Single message in case3" received on "subscriber" from "subscribe_twice_with_send_at_subscription" topic within 5 seconds.passed
And I clear message storage.................................................passed
When I subscribe "subscriber" to "subscribe_twice_with_send_at_subscription" with qos 0.passed
And message "Single message in case3" received on "subscriber" from "subscribe_twice_with_send_at_subscription" topic within 5 seconds.passed
And I clear message storage.................................................passed
And I set MQTT publish 'retain' flag to true................................passed
And I set MQTT subscribe 'retain handling' property to "MQTT5_RETAIN_SEND_AT_NEW_SUBSCRIPTION".passed
When I publish from "publisher" to "send_at_new_subscription" with qos 1 and message "Single retained message in case4" and expect status 16.passed
When I subscribe "subscriber" to "send_at_new_subscription" with qos 0......passed
And message "Single retained message in case4" received on "subscriber" from "send_at_new_subscription" topic within 5 seconds.passed
And I clear message storage.................................................passed
When I subscribe "subscriber" to "send_at_new_subscription" with qos 0......passed
And message "Single retained message in case4" is not received on "subscriber" from "send_at_new_subscription" topic within 5 seconds.passed
And I clear message storage.................................................passed
And I clear message storage.................................................passed
And I set MQTT publish 'retain' flag to true................................passed
And I set MQTT subscribe 'retain handling' property to "MQTT5_RETAIN_DO_NOT_SEND_AT_SUBSCRIPTION".passed
When I publish from "publisher" to "do_not_send_at_subscription" with qos 0 and message "Single retained message in case5".passed
When I subscribe "subscriber" to "do_not_send_at_subscription" with qos 0...passed
And message "Single retained message in case5" is not received on "subscriber" from "do_not_send_at_subscription" topic within 5 seconds.passed
And I clear message storage.................................................passed
And I set MQTT publish 'retain' flag to false...............................passed
And I set MQTT subscribe 'retain handling' property to "MQTT5_RETAIN_SEND_AT_SUBSCRIPTION".passed
When I publish from "publisher" to "t102_case6" with qos 0 and message "Single not retained message in case6".passed
When I subscribe "subscriber" to "t102_case6" with qos 0....................passed
And message "Single not retained message in case6" is not received on "subscriber" from "t102_case6" topic within 5 seconds.passed
And I clear message storage.................................................passed
And I set MQTT publish 'retain' flag to false...............................passed
And I set MQTT subscribe 'retain handling' property to "MQTT5_RETAIN_SEND_AT_NEW_SUBSCRIPTION".passed
When I publish from "publisher" to "t102_case7" with qos 0 and message "Single not retained message in case7".passed
When I subscribe "subscriber" to "t102_case7" with qos 0....................passed
And message "Single not retained message in case7" is not received on "subscriber" from "t102_case7" topic within 5 seconds.passed
And I clear message storage.................................................passed
And I set MQTT publish 'retain' flag to false...............................passed
And I set MQTT subscribe 'retain handling' property to "MQTT5_RETAIN_DO_NOT_SEND_AT_SUBSCRIPTION".passed
When I publish from "publisher" to "t102_case8" with qos 0 and message "Single not retained message in case8".passed
When I subscribe "subscriber" to "t102_case8" with qos 0....................passed
And message "Single not retained message in case8" is not received on "subscriber" from "t102_case8" topic within 5 seconds.passed
And I clear message storage.................................................passed
And I set MQTT subscribe 'retain as published' flag to false................passed
When I subscribe "subscriber" to "iot_data_0" with qos 0....................passed
And I set MQTT publish 'retain' flag to false...............................passed
And I set the 'retain' flag in expected received messages to false..........passed
When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world1".passed
And message "Hello world1" received on "subscriber" from "iot_data_0" topic within 5 seconds.passed
And I set MQTT publish 'retain' flag to true................................passed
When I publish from "publisher" to "iot_data_0" with qos 0 and message "Hello world2".passed
And message "Hello world2" received on "subscriber" from "iot_data_0" topic within 5 seconds.passed
And I set MQTT subscribe 'retain as published' flag to true.................passed
When I subscribe "subscriber" to "iot_data_1" with qos 0....................passed
And I set MQTT publish 'retain' flag to false...............................passed
And I set the 'retain' flag in expected received messages to false..........passed
When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world3".passed
And message "Hello world3" received on "subscriber" from "iot_data_1" topic within 5 seconds.passed
And I set MQTT publish 'retain' flag to true................................passed
And I set the 'retain' flag in expected received messages to true...........passed
When I publish from "publisher" to "iot_data_1" with qos 0 and message "Hello world4".passed
And message "Hello world4" received on "subscriber" from "iot_data_1" topic within 5 seconds.passed
And I add MQTT 'user property' with key "type" and value "json" to transmit.passed
And I add MQTT 'user property' with key "region" and value "Asia" to transmit.passed
And I add MQTT 'user property' with key "type" and value "json" to receive..passed
And I add MQTT 'user property' with key "region" and value "Asia" to receive.passed
When I subscribe "subscriber" to "iot_data_2" with qos 0....................passed
When I publish from "publisher" to "iot_data_2" with qos 0 and message "Expected userProperties are received".passed
And message "Expected userProperties are received" received on "subscriber" from "iot_data_2" topic within 5 seconds.passed
And I clear message storage.................................................passed
And I clear MQTT 'user properties' to transmit..............................passed
And I clear MQTT 'user properties' to receive...............................passed
And I add MQTT 'user property' with key "agent-control" and value "control" to receive.passed
And I add MQTT 'user property' with key "timezone" and value "GMT6" to receive.passed
When I subscribe "subscriber" to "iot_data_2" with qos 0....................passed
When I publish from "publisher" to "iot_data_2" with qos 0 and message "Expected userProperties are not received".passed
And message "Expected userProperties are not received" is not received on "subscriber" from "iot_data_2" topic within 5 seconds.passed
And I clear message storage.................................................passed
And I clear MQTT 'user properties' to transmit..............................passed
And I clear MQTT 'user properties' to receive...............................passed
And I add MQTT 'user property' with key "agent-control" and value "control" to transmit.passed
And I add MQTT 'user property' with key "timezone" and value "GMT6" to transmit.passed
When I subscribe "subscriber" to "iot_data_3" with qos 0....................passed
When I publish from "publisher" to "iot_data_3" with qos 0 and message "Ignore userProperties".passed
And message "Ignore userProperties" received on "subscriber" from "iot_data_3" topic within 5 seconds.passed
And I clear message storage.................................................passed
And I clear MQTT 'user properties' to transmit..............................passed
And I clear MQTT 'user properties' to receive...............................passed
When I subscribe "subscriber" to "iot_data_4" with qos 0....................passed
When I publish from "publisher" to "iot_data_4" with qos 0 and message "Without userProperties".passed
And message "Without userProperties" received on "subscriber" from "iot_data_4" topic within 5 seconds.passed
And I clear message storage.................................................passed
And I clear message storage.................................................passed
And I set MQTT publish 'payload format indicator' flag to false.............passed
And I set the 'payload format indicator' flag in expected received messages to false.passed
When I subscribe "subscriber" to "payload_format_indicator_false_false" with qos 0.passed
When I publish from "publisher" to "payload_format_indicator_false_false" with qos 0 and message "Payload format indicators false/false".passed
And message "Payload format indicators false/false" received on "subscriber" from "payload_format_indicator_false_false" topic within 5 seconds.passed
And I clear message storage.................................................passed
And I set MQTT publish 'payload format indicator' flag to true..............passed
And I set the 'payload format indicator' flag in expected received messages to true.passed
When I subscribe "subscriber" to "payload_format_indicator_true_true" with qos 0.passed
When I publish from "publisher" to "payload_format_indicator_true_true" with qos 0 and message "Payload format indicators true/true".passed
And message "Payload format indicators true/true" received on "subscriber" from "payload_format_indicator_true_true" topic within 5 seconds.passed
And I clear message storage.................................................passed
And I set MQTT publish 'payload format indicator' flag to true..............passed
And I set the 'payload format indicator' flag in expected received messages to false.passed
When I subscribe "subscriber" to "payload_format_indicator_true_false" with qos 0.passed
When I publish from "publisher" to "payload_format_indicator_true_false" with qos 0 and message "Payload format indicators true/false".passed
And message "Payload format indicators true/false" is not received on "subscriber" from "payload_format_indicator_true_false" topic within 5 seconds.passed
And I clear message storage.................................................passed
And I set MQTT publish 'payload format indicator' flag to false.............passed
And I set the 'payload format indicator' flag in expected received messages to true.passed
When I subscribe "subscriber" to "payload_format_indicator_false_true" with qos 0.passed
When I publish from "publisher" to "payload_format_indicator_false_true" with qos 0 and message "Payload format indicators false/true".passed
And message "Payload format indicators false/true" is not received on "subscriber" from "payload_format_indicator_false_true" topic within 5 seconds.passed
And I clear message storage.................................................passed
And I set MQTT publish 'payload format indicator' flag to true..............passed
And I set the 'payload format indicator' flag in expected received messages to null.passed
When I subscribe "subscriber" to "payload_format_indicator_true_null" with qos 0.passed
When I publish from "publisher" to "payload_format_indicator_true_null" with qos 0 and message "Payload format indicators true/null".passed
And message "Payload format indicators true/null" received on "subscriber" from "payload_format_indicator_true_null" topic within 5 seconds.passed
And I clear message storage.................................................passed
And I set MQTT publish 'payload format indicator' flag to false.............passed
And I set the 'payload format indicator' flag in expected received messages to null.passed
When I subscribe "subscriber" to "payload_format_indicator_false_null" with qos 0.passed
When I publish from "publisher" to "payload_format_indicator_false_null" with qos 0 and message "Payload format indicators false/null".passed
And message "Payload format indicators false/null" received on "subscriber" from "payload_format_indicator_false_null" topic within 5 seconds.passed
And I clear message storage.................................................passed
And I set MQTT subscribe 'no local' flag to true............................passed
When I subscribe "subscriber" to "no_local_test" with qos 0.................passed
When I publish from "subscriber" to "no_local_true" with qos 0 and message "First message no local true test".passed
Then message "First message no local true test" is not received on "subscriber" from "no_local_true" topic within 5 seconds.passed
And I clear message storage.................................................passed
And I set MQTT subscribe 'no local' flag to false...........................passed
When I subscribe "subscriber" to "no_local_false" with qos 0................passed
When I publish from "subscriber" to "no_local_false" with qos 0 and message "First message no local false test".passed
Then message "First message no local false test" received on "subscriber" from "no_local_false" topic within 5 seconds.passed
And I clear message storage.................................................passed
And I set MQTT 'content type' to "text/plain; charset=utf-8" to transmit....passed
And I set MQTT 'content type' to "text/plain; charset=utf-8" to receive.....passed
When I subscribe "subscriber" to "content_types_the_same" with qos 0........passed
When I publish from "publisher" to "content_types_the_same" with qos 0 and message "Content types not null/not null".passed
And message "Content types not null/not null" received on "subscriber" from "content_types_the_same" topic within 5 seconds.passed
And I clear message storage.................................................passed
And I set MQTT 'content type' to "another content type value" to transmit...passed
And I set MQTT 'content type' to "text/plain; charset=utf-8" to receive.....passed
When I subscribe "subscriber" to "content_type_not_the_same" with qos 0.....passed
When I publish from "publisher" to "content_type_not_the_same" with qos 0 and message "Different values of content types".passed
And message "Different values of content type" is not received on "subscriber" from "content_type_not_the_same" topic within 5 seconds.passed
And I clear message storage.................................................passed
And I clear MQTT 'content type' to transmit.................................passed
And I set MQTT 'content type' to "text/plain; charset=utf-8" to receive.....passed
When I subscribe "subscriber" to "content_type_null_not_null" with qos 0....passed
When I publish from "publisher" to "content_type_null_not_null" with qos 0 and message "Content types null/not null".passed
And message "Content types null/not null" is not received on "subscriber" from "content_type_null_not_null" topic within 5 seconds.passed
And I clear message storage.................................................passed
And I set MQTT 'content type' to "text/plain; charset=utf-8" to transmit....passed
And I clear MQTT 'content type' to receive..................................passed
When I subscribe "subscriber" to "content_type_not_null_null" with qos 0....passed
When I publish from "publisher" to "content_type_not_null_null" with qos 0 and message "Content types not null/null".passed
And message "Content types not null/null" received on "subscriber" from "content_type_not_null_null" topic within 5 seconds.passed
And I disconnect device "subscriber" with reason code 0.....................passed
And I disconnect device "publisher" with reason code 0......................passed
```


**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

