### PR TITLE
feat(uat): handle message expiry interval in mosquitto client

### DIFF
--- a/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
@@ -260,11 +260,11 @@ Status GRPCControlServer::PublishMqtt(ServerContext *, const MqttPublishRequest 
         p_payload_format_indicator = &payload_format_indicator;
     }
 
-    int message_expire_interval;
-    int * p_message_expire_interval = NULL;
-    if (message.has_messageexpireinterval()) {
-        message_expire_interval = message.messageexpireinterval();
-        p_message_expire_interval = &message_expire_interval;
+    int message_expiry_interval;
+    int * p_message_expiry_interval = NULL;
+    if (message.has_messageexpiryinterval()) {
+        message_expiry_interval = message.messageexpiryinterval();
+        p_message_expiry_interval = &message_expiry_interval;
     }
 
     const MqttConnectionId & connection_id_obj = request->connectionid();
@@ -283,7 +283,7 @@ Status GRPCControlServer::PublishMqtt(ServerContext *, const MqttPublishRequest 
         ClientControl::MqttPublishReply * result = connection->publish(timeout, qos, is_retain, topic,
                                                                         message.payload(), message.properties(),
                                                                         p_content_type, p_payload_format_indicator,
-                                                                        p_message_expire_interval);
+                                                                        p_message_expiry_interval);
         if (result) {
             if (result->has_reasoncode()) {
                 reply->set_reasoncode(result->reasoncode());

--- a/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/GRPCControlServer.cpp
@@ -260,6 +260,13 @@ Status GRPCControlServer::PublishMqtt(ServerContext *, const MqttPublishRequest 
         p_payload_format_indicator = &payload_format_indicator;
     }
 
+    int message_expire_interval;
+    int * p_message_expire_interval = NULL;
+    if (message.has_messageexpireinterval()) {
+        message_expire_interval = message.messageexpireinterval();
+        p_message_expire_interval = &message_expire_interval;
+    }
+
     const MqttConnectionId & connection_id_obj = request->connectionid();
     int connection_id = connection_id_obj.connectionid();
 
@@ -275,7 +282,8 @@ Status GRPCControlServer::PublishMqtt(ServerContext *, const MqttPublishRequest 
     try {
         ClientControl::MqttPublishReply * result = connection->publish(timeout, qos, is_retain, topic,
                                                                         message.payload(), message.properties(),
-                                                                        p_content_type, p_payload_format_indicator);
+                                                                        p_content_type, p_payload_format_indicator,
+                                                                        p_message_expire_interval);
         if (result) {
             if (result->has_reasoncode()) {
                 reply->set_reasoncode(result->reasoncode());

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.cpp
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.cpp
@@ -459,7 +459,7 @@ ClientControl::MqttPublishReply * MqttConnection::publish(unsigned timeout, int 
                                             const std::string & payload,
                                             const RepeatedPtrField<ClientControl::Mqtt5Properties> & user_properties,
                                             const std::string * content_type, const bool * payload_format_indicator,
-                                            const int * message_expire_interval) {
+                                            const int * message_expiry_interval) {
     PendingRequest * request = 0;
     int message_id = 0;
     mosquitto_property * properties = NULL;
@@ -486,17 +486,17 @@ ClientControl::MqttPublishReply * MqttConnection::publish(unsigned timeout, int 
             }
         }
 
-        if (message_expire_interval) {
+        if (message_expiry_interval) {
             if (m_v5) {
-                rc = mosquitto_property_add_int32(&properties, MQTT_PROP_MESSAGE_EXPIRY_INTERVAL, *message_expire_interval);
+                rc = mosquitto_property_add_int32(&properties, MQTT_PROP_MESSAGE_EXPIRY_INTERVAL, *message_expiry_interval);
                 if (rc == MOSQ_ERR_SUCCESS) {
-                    logd("Copied TX message expire interval %d\n", *message_expire_interval);
+                    logd("Copied TX message expiry interval %d\n", *message_expiry_interval);
                 } else {
                     loge("mosquitto_property_add_int32 failed with code %d: %s\n", rc, mosquitto_strerror(rc));
-                    throw MqttException("couldn't set message expire interval", rc);
+                    throw MqttException("couldn't set message expiry interval", rc);
                 }
             } else {
-                logw("Message expire interval is ignored for MQTT v3.1.1 connection\n");
+                logw("Message expiry interval is ignored for MQTT v3.1.1 connection\n");
             }
         }
 
@@ -844,8 +844,8 @@ ClientControl::Mqtt5Message * MqttConnection::convertToMqtt5Message(const struct
                 break;
             case MQTT_PROP_MESSAGE_EXPIRY_INTERVAL:
                 mosquitto_property_read_int32(prop, id, &value32, false);
-                msg->set_messageexpireinterval(value32);
-                logd("Copied RX message expire interval %d\n", value32);
+                msg->set_messageexpiryinterval(value32);
+                logd("Copied RX message expiry interval %d\n", value32);
                 break;
             default:
                 logw("Unhandled PUBLISH property with id %d\n", id);

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
@@ -114,7 +114,7 @@ public:
      * @param user_properties the user properties of the PUBLISH request
      * @param content_type the optional content type
      * @param payload_format_indicator the pointer to optional value of 'payload format indicator' of the message
-     * @param message_expire_interval the pointer to optinal value of 'message expired interval'
+     * @param message_expiry_interval the pointer to optinal value of 'message expiry interval'
      * @return pointer to allocated gRPC MqttPublishReply
      * @throw MqttException on errors
      */
@@ -122,7 +122,7 @@ public:
                                                 const std::string & payload,
                                                 const RepeatedPtrField<ClientControl::Mqtt5Properties> & user_properties,
                                                 const std::string * content_type, const bool * payload_format_indicator,
-                                                const int * message_expire_interval);
+                                                const int * message_expiry_interval);
 
     /**
      * Disconnect from the broker.

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
@@ -114,13 +114,15 @@ public:
      * @param user_properties the user properties of the PUBLISH request
      * @param content_type the optional content type
      * @param payload_format_indicator the pointer to optional value of 'payload format indicator' of the message
+     * @param message_expire_interval the pointer to optinal value of 'message expired interval'
      * @return pointer to allocated gRPC MqttPublishReply
      * @throw MqttException on errors
      */
     ClientControl::MqttPublishReply * publish(unsigned timeout, int qos, bool is_retain, const std::string & topic,
                                                 const std::string & payload,
                                                 const RepeatedPtrField<ClientControl::Mqtt5Properties> & user_properties,
-                                                const std::string * content_type, bool * payload_format_indicator);
+                                                const std::string * content_type, const bool * payload_format_indicator,
+                                                const int * message_expire_interval);
 
     /**
      * Disconnect from the broker.

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
@@ -77,6 +77,7 @@ class AgentTestScenario implements Runnable {
     private static final boolean PUBLISH_RETAIN = false;
     private static final String PUBLISH_CONTENT_TYPE = "text/plain; charset=utf-8";
     private static final Boolean PUBLISH_PAYLOAD_FORMAT_INDICATOR = true;
+    private static final Integer PUBLISH_MESSAGE_EXPIRE_INTERVAL = 3600;
 
     private static final Integer SUBSCRIPTION_ID = null;                        // NOTE: do not set for IoT Core !!!
     private static final String SUBSCRIBE_FILTER = "test/topic";
@@ -117,6 +118,10 @@ class AgentTestScenario implements Runnable {
 
             if (message.hasPayloadFormatIndicator()) {
                 logger.atInfo().log("Message has payload format indicator {}", message.getPayloadFormatIndicator());
+            }
+
+            if (message.hasMessageExpireInterval()) {
+                logger.atInfo().log("Message has message expire interval {}", message.getMessageExpireInterval());
             }
 
             eventStorage.addEvent(new MqttMessageEvent(connectionControl, message));
@@ -245,14 +250,16 @@ class AgentTestScenario implements Runnable {
 
     private void testPublish(ConnectionControl connectionControl) {
         Mqtt5Message msg = createPublishMessage(PUBLISH_QOS, PUBLISH_RETAIN, PUBLISH_TOPIC, PUBLISH_TEXT.getBytes(),
-                                                PUBLISH_CONTENT_TYPE, PUBLISH_PAYLOAD_FORMAT_INDICATOR);
+                                                PUBLISH_CONTENT_TYPE, PUBLISH_PAYLOAD_FORMAT_INDICATOR,
+                                                PUBLISH_MESSAGE_EXPIRE_INTERVAL);
         MqttPublishReply reply = connectionControl.publishMqtt(msg);
         logger.atInfo().log("Published connectionId {} reason code {} reason string '{}'",
                                 connectionControl.getConnectionId(), reply.getReasonCode(), reply.getReasonString());
     }
 
     private Mqtt5Message createPublishMessage(MqttQoS qos, boolean retain, String topic, byte[] data,
-                                                String contentType, Boolean payloadFormatIndicator) {
+                                                String contentType, Boolean payloadFormatIndicator,
+                                                Integer messageExpireInterval) {
         Mqtt5Message.Builder builder = Mqtt5Message.newBuilder()
                             .setTopic(topic)
                             .setPayload(ByteString.copyFrom(data))
@@ -265,8 +272,13 @@ class AgentTestScenario implements Runnable {
             if (contentType != null) {
                 builder.setContentType(contentType);
             }
+
             if (payloadFormatIndicator != null) {
                 builder.setPayloadFormatIndicator(payloadFormatIndicator);
+            }
+
+            if (messageExpireInterval != null) {
+                builder.setMessageExpireInterval(messageExpireInterval);
             }
         }
 

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
@@ -77,7 +77,7 @@ class AgentTestScenario implements Runnable {
     private static final boolean PUBLISH_RETAIN = false;
     private static final String PUBLISH_CONTENT_TYPE = "text/plain; charset=utf-8";
     private static final Boolean PUBLISH_PAYLOAD_FORMAT_INDICATOR = true;
-    private static final Integer PUBLISH_MESSAGE_EXPIRE_INTERVAL = 3600;
+    private static final Integer PUBLISH_MESSAGE_EXPIRY_INTERVAL = 3600;
 
     private static final Integer SUBSCRIPTION_ID = null;                        // NOTE: do not set for IoT Core !!!
     private static final String SUBSCRIBE_FILTER = "test/topic";
@@ -113,8 +113,8 @@ class AgentTestScenario implements Runnable {
                 logger.atInfo().log("Message has payload format indicator {}", message.getPayloadFormatIndicator());
             }
 
-            if (message.hasMessageExpireInterval()) {
-                logger.atInfo().log("Message has message expire interval {}", message.getMessageExpireInterval());
+            if (message.hasMessageExpiryInterval()) {
+                logger.atInfo().log("Message has message expiry interval {}", message.getMessageExpiryInterval());
             }
 
             for (Mqtt5Properties property : message.getPropertiesList()) {
@@ -253,7 +253,7 @@ class AgentTestScenario implements Runnable {
     private void testPublish(ConnectionControl connectionControl) {
         Mqtt5Message msg = createPublishMessage(PUBLISH_QOS, PUBLISH_RETAIN, PUBLISH_TOPIC, PUBLISH_TEXT.getBytes(),
                                                 PUBLISH_CONTENT_TYPE, PUBLISH_PAYLOAD_FORMAT_INDICATOR,
-                                                PUBLISH_MESSAGE_EXPIRE_INTERVAL);
+                                                PUBLISH_MESSAGE_EXPIRY_INTERVAL);
         MqttPublishReply reply = connectionControl.publishMqtt(msg);
         logger.atInfo().log("Published connectionId {} reason code {} reason string '{}'",
                                 connectionControl.getConnectionId(), reply.getReasonCode(), reply.getReasonString());
@@ -261,7 +261,7 @@ class AgentTestScenario implements Runnable {
 
     private Mqtt5Message createPublishMessage(MqttQoS qos, boolean retain, String topic, byte[] data,
                                                 String contentType, Boolean payloadFormatIndicator,
-                                                Integer messageExpireInterval) {
+                                                Integer messageExpiryInterval) {
         Mqtt5Message.Builder builder = Mqtt5Message.newBuilder()
                             .setTopic(topic)
                             .setPayload(ByteString.copyFrom(data))
@@ -274,9 +274,9 @@ class AgentTestScenario implements Runnable {
                 logger.atInfo().log("Set property payload format indicator {}", payloadFormatIndicator);
             }
 
-            if (messageExpireInterval != null) {
-                builder.setMessageExpireInterval(messageExpireInterval);
-                logger.atInfo().log("Set property message expire interval {}", messageExpireInterval);
+            if (messageExpiryInterval != null) {
+                builder.setMessageExpiryInterval(messageExpiryInterval);
+                logger.atInfo().log("Set property message expiry interval {}", messageExpiryInterval);
             }
 
             builder.addAllProperties(createMqtt5Properties("Publish"));

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/AgentTestScenario.java
@@ -107,6 +107,16 @@ class AgentTestScenario implements Runnable {
                                 message.getTopic(),
                                 message.getQos().getNumber(),
                                 message.getPayload());
+
+            // order is the same as in MQTTT v5.0 spec of PUBLISH message
+            if (message.hasPayloadFormatIndicator()) {
+                logger.atInfo().log("Message has payload format indicator {}", message.getPayloadFormatIndicator());
+            }
+
+            if (message.hasMessageExpireInterval()) {
+                logger.atInfo().log("Message has message expire interval {}", message.getMessageExpireInterval());
+            }
+
             for (Mqtt5Properties property : message.getPropertiesList()) {
                 logger.atInfo().log("Message has user property key {} value {}", property.getKey(),
                                         property.getValue());
@@ -114,14 +124,6 @@ class AgentTestScenario implements Runnable {
 
             if (message.hasContentType()) {
                 logger.atInfo().log("Message has content type '{}'", message.getContentType());
-            }
-
-            if (message.hasPayloadFormatIndicator()) {
-                logger.atInfo().log("Message has payload format indicator {}", message.getPayloadFormatIndicator());
-            }
-
-            if (message.hasMessageExpireInterval()) {
-                logger.atInfo().log("Message has message expire interval {}", message.getMessageExpireInterval());
             }
 
             eventStorage.addEvent(new MqttMessageEvent(connectionControl, message));
@@ -267,18 +269,21 @@ class AgentTestScenario implements Runnable {
                             .setRetain(retain);
 
         if (mqtt50) {
-            builder.addAllProperties(createMqtt5Properties("Publish"));
-
-            if (contentType != null) {
-                builder.setContentType(contentType);
-            }
-
             if (payloadFormatIndicator != null) {
                 builder.setPayloadFormatIndicator(payloadFormatIndicator);
+                logger.atInfo().log("Set property payload format indicator {}", payloadFormatIndicator);
             }
 
             if (messageExpireInterval != null) {
                 builder.setMessageExpireInterval(messageExpireInterval);
+                logger.atInfo().log("Set property message expire interval {}", messageExpireInterval);
+            }
+
+            builder.addAllProperties(createMqtt5Properties("Publish"));
+
+            if (contentType != null) {
+                builder.setContentType(contentType);
+                logger.atInfo().log("Set property content type {}", contentType);
             }
         }
 
@@ -290,7 +295,7 @@ class AgentTestScenario implements Runnable {
         properties.add(Mqtt5Properties.newBuilder().setKey("region").setValue("US").build());
         properties.add(Mqtt5Properties.newBuilder().setKey("type").setValue("JSON").build());
         properties.forEach(p -> logger.atInfo()
-                .log("{} MQTT userProperties: {}, {}", commandName, p.getKey(), p.getValue()));
+                .log("{} Set user property: {}, {}", commandName, p.getKey(), p.getValue()));
         return properties;
     }
 

--- a/uat/proto/mqtt_client_control.proto
+++ b/uat/proto/mqtt_client_control.proto
@@ -37,7 +37,7 @@ message Mqtt5Message {
     repeated Mqtt5Properties properties = 5;
     optional string contentType = 6;
     optional bool payloadFormatIndicator = 7;
-    optional int32 messageExpireInterval = 8;
+    optional int32 messageExpiryInterval = 8;
 };
 
 // End of common part

--- a/uat/proto/mqtt_client_control.proto
+++ b/uat/proto/mqtt_client_control.proto
@@ -37,6 +37,7 @@ message Mqtt5Message {
     repeated Mqtt5Properties properties = 5;
     optional string contentType = 6;
     optional bool payloadFormatIndicator = 7;
+    optional int32 messageExpireInterval = 8;
 };
 
 // End of common part


### PR DESCRIPTION
**Issue #, if available:**
Set/unset message expiry interval

**Description of changes:**
- Update protocol by adding optional field messageExpiryInterval to Mqtt5Message
- Update mosquitto client to handle message expiry interval in PUBLISH message in both directions
- Update control application to send message expiry interval and log it from received messages
- Tune logging in mosquitto client and control

**Why is this change necessary:**
New MQTT v5.0 feature message expiry interval should be handled

**How was this change tested:**
Currently manually by running Control as application with hard-coded scenario.
Later by adding new cucumber scenario.

**Test results:**
Control:
```
[INFO ] 2023-06-30 15:27:50.490 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] ExampleControl - Control: port 47619, with TLS, MQTT v5
[INFO ] 2023-06-30 15:27:50.710 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] EngineControlImpl - MQTT client control gRPC server started, listening on 47619
[INFO ] 2023-06-30 15:28:35.532 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId mosquitto_agent
[INFO ] 2023-06-30 15:28:35.550 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId mosquitto_agent address 127.0.0.1 port 35423
[INFO ] 2023-06-30 15:28:35.553 [grpc-default-executor-0] EngineControlImpl - Created new agent control for mosquitto_agent on 127.0.0.1:35423
[INFO ] 2023-06-30 15:28:35.604 [grpc-default-executor-0] ExampleControl - Agent mosquitto_agent is connected
[INFO ] 2023-06-30 15:28:35.608 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id mosquitto_agent
[INFO ] 2023-06-30 15:28:38.628 [pool-2-thread-1] AgentTestScenario - Connect Set user property: region, US
[INFO ] 2023-06-30 15:28:38.628 [pool-2-thread-1] AgentTestScenario - Connect Set user property: type, JSON
[INFO ] 2023-06-30 15:28:38.995 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
reasonCode: 0
receiveMaximum: 100
maximumQoS: 1
retainAvailable: true
maximumPacketSize: 149504
wildcardSubscriptionsAvailable: true
subscriptionIdentifiersAvailable: false
sharedSubscriptionsAvailable: true
serverKeepAlive: 60
topicAliasMaximum: 8
'
[INFO ] 2023-06-30 15:28:38.995 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-06-30 15:28:38.995 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-06-30 15:28:44.002 [pool-2-thread-1] AgentTestScenario - Subscribe Set user property: region, US
[INFO ] 2023-06-30 15:28:44.002 [pool-2-thread-1] AgentTestScenario - Subscribe Set user property: type, JSON
[INFO ] 2023-06-30 15:28:44.010 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-06-30 15:28:44.083 [pool-2-thread-1] AgentTestScenario - Subscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-06-30 15:28:49.089 [pool-2-thread-1] AgentTestScenario - Set property payload format indicator true
[INFO ] 2023-06-30 15:28:49.089 [pool-2-thread-1] AgentTestScenario - Set property message expiry interval 3600
[INFO ] 2023-06-30 15:28:49.089 [pool-2-thread-1] AgentTestScenario - Publish Set user property: region, US
[INFO ] 2023-06-30 15:28:49.089 [pool-2-thread-1] AgentTestScenario - Publish Set user property: type, JSON
[INFO ] 2023-06-30 15:28:49.089 [pool-2-thread-1] AgentTestScenario - Set property content type text/plain; charset=utf-8
[INFO ] 2023-06-30 15:28:49.091 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic test/topic
[INFO ] 2023-06-30 15:28:49.146 [grpc-default-executor-0] GRPCDiscoveryServer - OnReceiveMessage: agentId mosquitto_agent connectionId 1 topic test/topic QoS 0
[INFO ] 2023-06-30 15:28:49.148 [grpc-default-executor-0] AgentTestScenario - Message received on agentId mosquitto_agent connectionId 1 topic test/topic QoS 0 content <ByteString@130638d1 size=12 contents="Hello World!">
[INFO ] 2023-06-30 15:28:49.148 [grpc-default-executor-0] AgentTestScenario - Message has payload format indicator true
[INFO ] 2023-06-30 15:28:49.149 [grpc-default-executor-0] AgentTestScenario - Message has message expiry interval 3599
[INFO ] 2023-06-30 15:28:49.149 [grpc-default-executor-0] AgentTestScenario - Message has user property key region value US
[INFO ] 2023-06-30 15:28:49.149 [grpc-default-executor-0] AgentTestScenario - Message has user property key type value JSON
[INFO ] 2023-06-30 15:28:49.149 [grpc-default-executor-0] AgentTestScenario - Message has content type 'text/plain; charset=utf-8'
[INFO ] 2023-06-30 15:28:49.158 [pool-2-thread-1] AgentTestScenario - Published connectionId 1 reason code 0 reason string ''
[INFO ] 2023-06-30 15:28:54.159 [pool-2-thread-1] AgentTestScenario - Unsubscribe Set user property: region, US
[INFO ] 2023-06-30 15:28:54.159 [pool-2-thread-1] AgentTestScenario - Unsubscribe Set user property: type, JSON
[INFO ] 2023-06-30 15:28:54.161 [pool-2-thread-1] AgentControlImpl - UnsubscribeMqtt: unsubscribe on connectionId 1
[INFO ] 2023-06-30 15:28:54.211 [pool-2-thread-1] AgentTestScenario - Unsubscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-06-30 15:29:09.212 [pool-2-thread-1] AgentTestScenario - Disconnect Set user property: region, US
[INFO ] 2023-06-30 15:29:09.213 [pool-2-thread-1] AgentTestScenario - Disconnect Set user property: type, JSON
[INFO ] 2023-06-30 15:29:09.242 [grpc-default-executor-0] GRPCDiscoveryServer - OnMqttDisconnect: agentId mosquitto_agent connectionId 1 disconnect 'reasonCode: 0
' error ''
[INFO ] 2023-06-30 15:29:09.243 [grpc-default-executor-0] AgentTestScenario - MQTT disconnected on agentId mosquitto_agent connectionId 1 disconnect 'reasonCode: 0
' error ''
[INFO ] 2023-06-30 15:29:09.249 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-06-30 15:29:09.256 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-06-30 15:29:09.262 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId mosquitto_agent reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-06-30 15:29:09.264 [grpc-default-executor-0] ExampleControl - Agent mosquitto_agent is disconnected
```

Mosquitto client:
```
$ build/src/mosquitto-test-client mosquitto_agent 
[DEBUG]: Initialize gRPC library
[DEBUG]: Making gPRC link with 127.0.0.1:47619 as agent_id 'mosquitto_agent'
[DEBUG]: Sending RegisterAgent request with agent_id mosquitto_agent
[DEBUG]: Local address is 127.0.0.1
[DEBUG]: GRPCControlServer created and listed on 127.0.0.1:35423
[DEBUG]: Sending DiscoveryAgent request agent_id 'mosquitto_agent' host:port 127.0.0.1:35423
[DEBUG]: gPRC link established with 127.0.0.1:47619 as agent_id 'mosquitto_agent'
[DEBUG]: Initialize Mosquitto MQTT library
[DEBUG]: Mosquitto library version 2.0.15
[DEBUG]: Handle gRPC requests
[DEBUG]: CreateMqttConnection client_id 'GGMQ-test-device2' broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[DEBUG]: Creating Mosquitto MQTT v5 connection for a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[DEBUG]: Copied TX user property region:US
[DEBUG]: Copied TX user property type:JSON
[DEBUG]: Establishing Mosquitto MQTT v5 connection to a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883 in 10 seconds
[DEBUG]: Use provided TLS credentials
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending CONNECT
[DEBUG]: mosquitto: Client GGMQ-test-device2 received CONNACK (0)
[DEBUG]: onConnect rc 0 flags 0 props 0x7f8708010780
[DEBUG]: Establishing MQTT connection to a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883 completed with reason code 0
[DEBUG]: Connection registered with id 1
[DEBUG]: Subscription: filter test/topic QoS 0 noLocal 0 retainAsPublished 0 retainHandling 2
[DEBUG]: SubscribeMqtt connection_id 1
[DEBUG]: Copied TX user property region:US
[DEBUG]: Copied TX user property type:JSON
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending SUBSCRIBE (Mid: 1, Topic: test/topic, QoS: 0, Options: 0x20)
[DEBUG]: mosquitto: Client GGMQ-test-device2 received SUBACK
[DEBUG]: onSubscribe mid 1 qos_count 1 granted_qos 0x7f8708014040 props (nil)
[DEBUG]: Subscribed on filters 'test/topic,' QoS 0 no local 0 retain as published 0 retain handing 2 with message id 1
[DEBUG]: Copied RX reason code 0
[DEBUG]: PublishMqtt connection_id 1 topic test/topic retain 0
[DEBUG]: Copied TX payload format indicator 1
[DEBUG]: Copied TX message expiry interval 3600
[DEBUG]: Copied TX user property region:US
[DEBUG]: Copied TX user property type:JSON
[DEBUG]: Copied TX content type "text/plain; charset=utf-8"
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending PUBLISH (d0, q1, r0, m2, 'test/topic', ... (12 bytes))
[DEBUG]: mosquitto: Client GGMQ-test-device2 received PUBLISH (d0, q0, r0, m0, 'test/topic', ... (12 bytes))
[DEBUG]: onMessage message 0x7f8708015908 props 0x7f8708011f00
[DEBUG]: Copied RX payload format indicator 1
[DEBUG]: Copied RX message expiry interval 3599
[DEBUG]: Copied RX content type "text/plain; charset=utf-8"
[DEBUG]: Copied RX user property region:US
[DEBUG]: Copied RX user property type:JSON
[DEBUG]: Sending OnReceiveMessage request agent_id 'mosquitto_agent' connection_id 1
[DEBUG]: mosquitto: Client GGMQ-test-device2 received PUBACK (Mid: 2, RC:0)
[DEBUG]: onPublish mid 2 rc 0 props (nil)
[DEBUG]: Published on topic 'test/topic' QoS 1 retain 0 with rc 0 message id 2
[DEBUG]: UnsubscribeMqtt connection_id 1
[DEBUG]: Copied TX user property region:US
[DEBUG]: Copied TX user property type:JSON
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending UNSUBSCRIBE (Mid: 3, Topic: test/topic)
[DEBUG]: mosquitto: Client GGMQ-test-device2 received UNSUBACK
[DEBUG]: onUnsubscribe mid 3 props (nil)
[DEBUG]: Unsubscribed from filters 'test/topic,' with message id 3
[DEBUG]: Copied RX reason code 0
[DEBUG]: CloseMqttConnection connection_id 1 reason 4
[DEBUG]: Disconnect Mosquitto MQTT connection with reason code 4
[DEBUG]: Copied TX user property region:US
[DEBUG]: Copied TX user property type:JSON
[DEBUG]: mosquitto: Client GGMQ-test-device2 sending DISCONNECT
[DEBUG]: onDisconnect rc 0 props (nil)
[DEBUG]: Sending OnMqttDisconnect request agent_id 'mosquitto_agent' connection_id 1 error '(null)'
[DEBUG]: Destroy Mosquitto MQTT connection
[DEBUG]: ShutdownAgent with reason 'That's it.'
[DEBUG]: Shutdown gPRC link
[DEBUG]: Sending UnregisterAgent request agent_id 'mosquitto_agent' reason 'Agent shutdown by OTF request 'That's it.''
[DEBUG]: Shutdown MQTT library
[DEBUG]: Shutdown gRPC library
[DEBUG]: Execution done
```


**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
