### PR TITLE
feat(uat): add message expiry interval for java-paho-client

### DIFF
--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
@@ -127,6 +127,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
         checkUserProperties(message.getUserProperties());
         checkContentType(message.getContentType());
         checkPayloadFormatIndicator(message.getPayloadFormatIndicator());
+        checkMessageExpiryInterval(message.getMessageExpiryInterval());
 
         MqttMessage mqttMessage = new MqttMessage();
         mqttMessage.setQos(message.getQos());
@@ -229,6 +230,12 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
     private void checkPayloadFormatIndicator(Boolean payloadFormatIndicator) {
         if (payloadFormatIndicator != null) {
             logger.warn("MQTT V3.1.1 doesn't support 'payload format indicator'");
+        }
+    }
+
+    private void checkMessageExpiryInterval(Integer messageExpiryInterval) {
+        if (messageExpiryInterval != null) {
+            logger.warn("MQTT V3.1.1 doesn't support 'message expiry interval'");
         }
     }
 }

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -121,6 +121,9 @@ public interface MqttConnection {
         /** Optional payload format indicator. */
         private Boolean payloadFormatIndicator;
 
+        /** Optional message expiry interval. */
+        private Integer messageExpiryInterval;
+
         // TODO: add user's properties and so one
     }
 

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -298,8 +298,8 @@ class GRPCControlServer {
                 internalMessage.payloadFormatIndicator(message.getPayloadFormatIndicator());
             }
 
-            if (message.hasMessageExpireInterval()) {
-                internalMessage.messageExpiryInterval(message.getMessageExpireInterval());
+            if (message.hasMessageExpiryInterval()) {
+                internalMessage.messageExpiryInterval(message.getMessageExpiryInterval());
             }
 
             MqttPublishReply publishReply = connection.publish(timeout, internalMessage.build());

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -298,6 +298,10 @@ class GRPCControlServer {
                 internalMessage.payloadFormatIndicator(message.getPayloadFormatIndicator());
             }
 
+            if (message.hasMessageExpireInterval()) {
+                internalMessage.messageExpiryInterval(message.getMessageExpireInterval());
+            }
+
             MqttPublishReply publishReply = connection.publish(timeout, internalMessage.build());
                 if (publishReply != null) {
                     logger.atInfo().log("Publish response: connectionId {} reason code {} reason string {}",

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
@@ -150,26 +150,7 @@ public class MqttConnectionImpl implements MqttConnection {
         mqttMessage.setPayload(message.getPayload());
         mqttMessage.setRetained(message.isRetain());
 
-        MqttProperties properties = new MqttProperties();
-        if (message.getUserProperties() != null && !message.getUserProperties().isEmpty()) {
-            List<UserProperty> userProperties = convertToUserProperties(message.getUserProperties());
-            properties.setUserProperties(userProperties);
-            userProperties.forEach(p -> logger.atInfo()
-                    .log("Publish MQTT userProperties: {}, {}", p.getKey(), p.getValue()));
-        }
-
-        String contentType = message.getContentType();
-        if (contentType != null && !contentType.isEmpty()) {
-            properties.setContentType(contentType);
-            logger.atInfo().log("Publish MQTT payload content type '{}'", contentType);
-        }
-
-        Boolean payloadFormatIndicator = message.getPayloadFormatIndicator();
-        if (payloadFormatIndicator != null) {
-            properties.setPayloadFormat(payloadFormatIndicator);
-            logger.atInfo().log("Publish MQTT payload format indicator '{}'", payloadFormatIndicator);
-        }
-
+        MqttProperties properties = createPublishProperties(message);
         mqttMessage.setProperties(properties);
 
         MqttPublishReply.Builder builder = MqttPublishReply.newBuilder();
@@ -297,6 +278,37 @@ public class MqttConnectionImpl implements MqttConnection {
         return connectionOptions;
     }
 
+    private MqttProperties createPublishProperties(Message message) {
+        MqttProperties properties = new MqttProperties();
+
+        if (message.getUserProperties() != null && !message.getUserProperties().isEmpty()) {
+            List<UserProperty> userProperties = convertToUserProperties(message.getUserProperties());
+            properties.setUserProperties(userProperties);
+            userProperties.forEach(p -> logger.atInfo()
+                    .log("Publish MQTT userProperties: {}, {}", p.getKey(), p.getValue()));
+        }
+
+        String contentType = message.getContentType();
+        if (contentType != null && !contentType.isEmpty()) {
+            properties.setContentType(contentType);
+            logger.atInfo().log("Publish MQTT payload content type '{}'", contentType);
+        }
+
+        Boolean payloadFormatIndicator = message.getPayloadFormatIndicator();
+        if (payloadFormatIndicator != null) {
+            properties.setPayloadFormat(payloadFormatIndicator);
+            logger.atInfo().log("Publish MQTT payload format indicator '{}'", payloadFormatIndicator);
+        }
+
+        Integer messageExpiryInterval = message.getMessageExpiryInterval();
+        if (messageExpiryInterval != null) {
+            properties.setMessageExpiryInterval(Long.valueOf(messageExpiryInterval));
+            logger.atInfo().log("Publish MQTT expiry message interval '{}'", messageExpiryInterval);
+        }
+
+        return properties;
+    }
+
     private static ConnectResult buildConnectResult(boolean success, IMqttToken token, String error) {
         ConnAckInfo connAckInfo = convertConnAckPacket(token);
         return new ConnectResult(success, connAckInfo, error);
@@ -357,9 +369,11 @@ public class MqttConnectionImpl implements MqttConnection {
 
             String contentType = null;
             Boolean payloadFormatIndicator = null;
+            Long messageExpiryInterval = null;
             if (receivedProperties != null) {
                 contentType = receivedProperties.getContentType();
                 payloadFormatIndicator = receivedProperties.getPayloadFormat();
+                messageExpiryInterval = receivedProperties.getMessageExpiryInterval();
             }
 
             List<Mqtt5Properties> userProps = convertToMqtt5Properties(receivedProperties);
@@ -380,6 +394,9 @@ public class MqttConnectionImpl implements MqttConnection {
             }
             if (payloadFormatIndicator != null) {
                 logger.atInfo().log("Received MQTT message has payload format indicator '{}'", payloadFormatIndicator);
+            }
+            if (messageExpiryInterval != null) {
+                logger.atInfo().log("Received MQTT message has message expiry interval '{}'", messageExpiryInterval);
             }
         }
     }

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
@@ -396,7 +396,7 @@ public class MqttConnectionImpl implements MqttConnection {
                 logger.atInfo().log("Received MQTT message has payload format indicator '{}'", payloadFormatIndicator);
             }
             if (messageExpiryInterval != null) {
-                logger.atInfo().log("Received MQTT message has message expiry interval '{}'", messageExpiryInterval);
+                logger.atInfo().log("Received MQTT message has message expiry interval {}", messageExpiryInterval);
             }
         }
     }


### PR DESCRIPTION
**Issue #, if available:**
Set message expiry interval for java-paho-client 

**Description of changes:**
- Update java-paho client to handle message expiry interval in PUBLISH message in both directions
- Update java-paho to log message expiry interval from received messages

**Why is this change necessary:**
New MQTT v5.0 feature message expiry interval should be handled

**How was this change tested:**
Currently manually by running Control as application with hard-coded scenario.
Later by adding new cucumber scenario.

**Test results:**
Control:
```
[INFO ] 2023-07-01 14:53:46.812 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId best-thing-akezhan
[INFO ] 2023-07-01 14:53:46.897 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId best-thing-akezhan address 127.0.0.1 port 34333
[INFO ] 2023-07-01 14:53:46.899 [grpc-default-executor-0] EngineControlImpl - Created new agent control for best-thing-akezhan on 127.0.0.1:34333
[INFO ] 2023-07-01 14:53:46.923 [grpc-default-executor-0] ExampleControl - Agent best-thing-akezhan is connected
[INFO ] 2023-07-01 14:53:46.928 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id best-thing-akezhan
[INFO ] 2023-07-01 14:53:49.938 [pool-2-thread-1] AgentTestScenario - Connect Set user property: region, US
[INFO ] 2023-07-01 14:53:49.938 [pool-2-thread-1] AgentTestScenario - Connect Set user property: type, JSON
[INFO ] 2023-07-01 14:53:51.334 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
receiveMaximum: 100
maximumQoS: 1
retainAvailable: true
maximumPacketSize: 149504
serverKeepAlive: 60
'
[INFO ] 2023-07-01 14:53:51.334 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-07-01 14:53:51.334 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-07-01 14:53:56.338 [pool-2-thread-1] AgentTestScenario - Subscribe Set user property: region, US
[INFO ] 2023-07-01 14:53:56.339 [pool-2-thread-1] AgentTestScenario - Subscribe Set user property: type, JSON
[INFO ] 2023-07-01 14:53:56.342 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-07-01 14:53:56.506 [pool-2-thread-1] AgentTestScenario - Subscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-07-01 14:54:01.511 [pool-2-thread-1] AgentTestScenario - Set property payload format indicator true
[INFO ] 2023-07-01 14:54:01.511 [pool-2-thread-1] AgentTestScenario - Set property message expire interval 3600
[INFO ] 2023-07-01 14:54:01.511 [pool-2-thread-1] AgentTestScenario - Publish Set user property: region, US
[INFO ] 2023-07-01 14:54:01.512 [pool-2-thread-1] AgentTestScenario - Publish Set user property: type, JSON
[INFO ] 2023-07-01 14:54:01.512 [pool-2-thread-1] AgentTestScenario - Set property content type text/plain; charset=utf-8
[INFO ] 2023-07-01 14:54:01.514 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic test/topic
[INFO ] 2023-07-01 14:54:01.674 [pool-2-thread-1] AgentTestScenario - Published connectionId 1 reason code 0 reason string ''
[INFO ] 2023-07-01 14:54:01.682 [grpc-default-executor-0] GRPCDiscoveryServer - OnReceiveMessage: agentId best-thing-akezhan connectionId 1 topic test/topic QoS 0
[INFO ] 2023-07-01 14:54:01.683 [grpc-default-executor-0] AgentTestScenario - Message received on agentId best-thing-akezhan connectionId 1 topic test/topic QoS 0 content <ByteString@5e87b03c size=12 contents="Hello World!">
[INFO ] 2023-07-01 14:54:01.683 [grpc-default-executor-0] AgentTestScenario - Message has payload format indicator true
[INFO ] 2023-07-01 14:54:01.683 [grpc-default-executor-0] AgentTestScenario - Message has user property key region value US
[INFO ] 2023-07-01 14:54:01.683 [grpc-default-executor-0] AgentTestScenario - Message has user property key type value JSON
[INFO ] 2023-07-01 14:54:01.683 [grpc-default-executor-0] AgentTestScenario - Message has content type 'text/plain; charset=utf-8'
[INFO ] 2023-07-01 14:54:06.674 [pool-2-thread-1] AgentTestScenario - Unsubscribe Set user property: region, US
[INFO ] 2023-07-01 14:54:06.675 [pool-2-thread-1] AgentTestScenario - Unsubscribe Set user property: type, JSON
[INFO ] 2023-07-01 14:54:06.680 [pool-2-thread-1] AgentControlImpl - UnsubscribeMqtt: unsubscribe on connectionId 1
[INFO ] 2023-07-01 14:54:06.832 [pool-2-thread-1] AgentTestScenario - Unsubscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-07-01 14:54:21.833 [pool-2-thread-1] AgentTestScenario - Disconnect Set user property: region, US
[INFO ] 2023-07-01 14:54:21.833 [pool-2-thread-1] AgentTestScenario - Disconnect Set user property: type, JSON
[INFO ] 2023-07-01 14:54:21.965 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-07-01 14:54:21.980 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-07-01 14:54:21.999 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId best-thing-akezhan reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-07-01 14:54:22.000 [grpc-default-executor-0] ExampleControl - Agent best-thing-akezhan is disconnected
```

java-paho client:
```
[INFO ] 2023-07-01 14:53:46.363 [main] GRPCLinkImpl - Making gPRC client connection with 127.0.0.1:47619 as best-thing-akezhan...
[INFO ] 2023-07-01 14:53:46.849 [main] GRPCLinkImpl - Client connection with Control is established, local address is 127.0.0.1
[INFO ] 2023-07-01 14:53:46.891 [main] GRPCControlServer - GRPCControlServer created and listed on 127.0.0.1:34333
[INFO ] 2023-07-01 14:53:46.968 [main] GRPCLinkImpl - Handle gRPC requests
[INFO ] 2023-07-01 14:53:46.968 [main] GRPCControlServer - Server awaitTermination
[INFO ] 2023-07-01 14:53:50.000 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId best-thing-akezhan broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[INFO ] 2023-07-01 14:53:50.220 [grpc-default-executor-0] MqttConnectionImpl - Connect MQTT userProperties: region, US
[INFO ] 2023-07-01 14:53:50.220 [grpc-default-executor-0] MqttConnectionImpl - Connect MQTT userProperties: type, JSON
[INFO ] 2023-07-01 14:53:56.354 [grpc-default-executor-0] GRPCControlServer - Subscription: filter test/topic QoS 0 noLocal false retainAsPublished false retainHandling 2
[INFO ] 2023-07-01 14:53:56.354 [grpc-default-executor-0] GRPCControlServer - Subscribe: connectionId 1 for 1 filters
[INFO ] 2023-07-01 14:53:56.356 [grpc-default-executor-0] MqttConnectionImpl - Subscribe MQTT userProperties: region, US
[INFO ] 2023-07-01 14:53:56.356 [grpc-default-executor-0] MqttConnectionImpl - Subscribe MQTT userProperties: type, JSON
[INFO ] 2023-07-01 14:53:56.501 [grpc-default-executor-0] GRPCControlServer - Subscribe response: connectionId 1 reason codes [0] reason string 
[INFO ] 2023-07-01 14:54:01.524 [grpc-default-executor-0] GRPCControlServer - Publish: connectionId 1 topic test/topic QoS 1 retain false
[INFO ] 2023-07-01 14:54:01.525 [grpc-default-executor-0] MqttConnectionImpl - Publish MQTT userProperties: region, US
[INFO ] 2023-07-01 14:54:01.525 [grpc-default-executor-0] MqttConnectionImpl - Publish MQTT userProperties: type, JSON
[INFO ] 2023-07-01 14:54:01.525 [grpc-default-executor-0] MqttConnectionImpl - Publish MQTT payload content type 'text/plain; charset=utf-8'
[INFO ] 2023-07-01 14:54:01.525 [grpc-default-executor-0] MqttConnectionImpl - Publish MQTT payload format indicator 'true'
[INFO ] 2023-07-01 14:54:01.525 [grpc-default-executor-0] MqttConnectionImpl - Publish MQTT expiry message interval '3600'
[INFO ] 2023-07-01 14:54:01.669 [grpc-default-executor-0] GRPCControlServer - Publish response: connectionId 1 reason code 0 reason string 
[INFO ] 2023-07-01 14:54:01.675 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT userProperties: region, US
[INFO ] 2023-07-01 14:54:01.675 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT userProperties: type, JSON
[INFO ] 2023-07-01 14:54:01.675 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT message has content type 'text/plain; charset=utf-8'
[INFO ] 2023-07-01 14:54:01.675 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT message has payload format indicator 'true'
[INFO ] 2023-07-01 14:54:01.675 [MQTT Call: best-thing-akezhan] MqttConnectionImpl - Received MQTT message has message expiry interval '3599'
[INFO ] 2023-07-01 14:54:01.686 [pool-3-thread-1] MqttConnectionImpl - Received MQTT message: connectionId 1 topic test/topic QoS 0 retain false
[INFO ] 2023-07-01 14:54:06.686 [grpc-default-executor-0] GRPCControlServer - Unsubscribe: connectionId 1 for [test/topic] filters
[INFO ] 2023-07-01 14:54:06.686 [grpc-default-executor-0] MqttConnectionImpl - Unsubscribe MQTT userProperties: region, US
[INFO ] 2023-07-01 14:54:06.687 [grpc-default-executor-0] MqttConnectionImpl - Unsubscribe MQTT userProperties: type, JSON
[INFO ] 2023-07-01 14:54:06.829 [grpc-default-executor-0] GRPCControlServer - Unsubscribe response: connectionId 1 reason codes [0] reason string 
[INFO ] 2023-07-01 14:54:21.845 [grpc-default-executor-0] GRPCControlServer - closeMqttConnection: connectionId 1 reason 4
[INFO ] 2023-07-01 14:54:21.846 [grpc-default-executor-0] MqttConnectionImpl - Disconnect MQTT userProperties: region, US
[INFO ] 2023-07-01 14:54:21.846 [grpc-default-executor-0] MqttConnectionImpl - Disconnect MQTT userProperties: type, JSON
[INFO ] 2023-07-01 14:54:21.974 [grpc-default-executor-0] GRPCControlServer - shutdownAgent: reason That's it.
[INFO ] 2023-07-01 14:54:21.990 [main] GRPCControlServer - Server awaitTermination done
[INFO ] 2023-07-01 14:54:21.990 [main] GRPCLinkImpl - Shutdown gPRC link
[INFO ] 2023-07-01 14:54:22.004 [main] Main - Execution done successfully
```


**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
