### PR TITLE
feat(uat): integrate python paho client to existing scenarios

### DIFF
--- a/uat/custom-components/client-python-paho/README.md
+++ b/uat/custom-components/client-python-paho/README.md
@@ -125,6 +125,7 @@ Python Paho MQTT library is limited in
 
 1. Publishing
 Receiving properties for the PUBACK is not implemented - Python Paho MQTT publish() method and on_publish() callback do not provide it.
+In Python Paho on_publish() callback does not provide reason codes for both MQTTv3 and MQTTv5, instead zero code will be returned.
 
 2. Subscribing
 Python Paho MQTT does not provide the API to set the Subscription ID in SUBSCRIBE request.

--- a/uat/testing-features/pom.xml
+++ b/uat/testing-features/pom.xml
@@ -27,6 +27,7 @@
             </activation>
             <properties>
                 <mosquitto.agent.artifact>mosquitto-test-client.amd64.tar.gz</mosquitto.agent.artifact>
+                <paho.python.agent.artifact>client-python-paho</paho.python.agent.artifact>
             </properties>
         </profile>
         <profile>
@@ -39,6 +40,7 @@
             <properties>
                 <!-- TODO: replace to actual windows artifact -->
                 <mosquitto.agent.artifact>README.md</mosquitto.agent.artifact>
+                <paho.python.agent.artifact>client-python-paho.exe</paho.python.agent.artifact>
             </properties>
         </profile>
     </profiles>
@@ -225,6 +227,9 @@
                                 <copy
                                         file="${project.basedir}/../custom-components/client-mosquitto-c/${mosquitto.agent.artifact}"
                                         tofile="${project.basedir}/target/classes/local-store/artifacts/${mosquitto.agent.artifact}"/>
+                                <copy
+                                        file="${project.basedir}/../custom-components/client-python-paho/${paho.python.agent.artifact}"
+                                        tofile="${project.basedir}/target/classes/local-store/artifacts/${paho.python.agent.artifact}"/>
                             </target>
                         </configuration>
                     </execution>

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -88,6 +88,11 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q1 |
       | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   | GRANTED_QOS_0       |
 
+    @mqtt3 @paho-python @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  | subscribe-status-q1 |
+      | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | GRANTED_QOS_1       |
+
     @mqtt5 @sdk-java
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q1 |
@@ -102,6 +107,11 @@ Feature: GGMQ-1
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q1 |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   | GRANTED_QOS_1       |
+
+    @mqtt5 @paho-python @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  | subscribe-status-q1 |
+      | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | GRANTED_QOS_1       |
 
   @GGMQ-1-T2
   Scenario Outline: GGMQ-1-T2-<mqtt-v>-<name>: GGAD can publish to an MQTT topic at QoS 0 and QoS 1 based on CDA configuration
@@ -233,11 +243,20 @@ Feature: GGMQ-1
       | mqtt-v | name     | agent                                        | recipe                  | iot_data_1-publish | subscribe-status-q1 |
       | v3     | sdk-java | aws.greengrass.client.Mqtt5JavaSdkClient     | client_java_sdk.yaml    | 0                  | GRANTED_QOS_0       |
 
+    @mqtt3 @paho-python @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  | iot_data_1-publish | subscribe-status-q1 |
+      | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | 0                  | GRANTED_QOS_1       |
+
     @mqtt5 @sdk-java
     Examples:
       | mqtt-v | name     | agent                                        | recipe                  | iot_data_1-publish | subscribe-status-q1 |
       | v5     | sdk-java | aws.greengrass.client.Mqtt5JavaSdkClient     | client_java_sdk.yaml    | 135                | GRANTED_QOS_1       |
 
+    @mqtt5 @paho-python @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  | iot_data_1-publish | subscribe-status-q1 |
+      | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | 0                  | GRANTED_QOS_1       |
 
   @GGMQ-1-T8
   Scenario Outline: GGMQ-1-T8-<mqtt-v>-<name>: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic
@@ -384,6 +403,11 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  |
       | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
 
+    @mqtt3 @paho-python @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
+
     @mqtt5 @sdk-java
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
@@ -398,6 +422,11 @@ Feature: GGMQ-1
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
+
+    @mqtt5 @paho-python @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
 
   @GGMQ-1-T9
   Scenario Outline: GGMQ-1-T9-<mqtt-v>-<name>: As a customer,I can configure local MQTT messages to be forwarded to an IoT Core MQTT topic
@@ -522,6 +551,11 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  |
       | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
 
+    @mqtt3 @paho-python @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
+
     @mqtt5 @sdk-java
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
@@ -536,6 +570,11 @@ Feature: GGMQ-1
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
+
+    @mqtt5 @paho-python @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
 
 
   @GGMQ-1-T13
@@ -706,11 +745,16 @@ Feature: GGMQ-1
 
     # WARNING: Paho Java MQTT v3 client in org.eclipse.paho.client.mqttv3.IMqttAsyncClient
     #  missing API to getting actual reason code of SUBACK/PUBACK/UNSUBACK, client always return reason code 0 on publish and subscribe.
-    #  It makes sdk-java client useless for T13
+    #  It makes paho-java client useless for T13
     @mqtt3 @paho-java
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
       | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   | GRANTED_QOS_0       | GRANTED_QOS_0         | 0                  |
+
+    @mqtt3 @paho-python @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
+      | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | UNSPECIFIED_ERROR   | GRANTED_QOS_1         | 0                  |
 
     @mqtt5 @sdk-java
     Examples:
@@ -727,6 +771,10 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   | NOT_AUTHORIZED      | GRANTED_QOS_1         | 16                 |
 
+    @mqtt5 @paho-python @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
+      | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | NOT_AUTHORIZED      | GRANTED_QOS_1         | 0                  |
 
   @GGMQ-1-T14
   Scenario Outline: GGMQ-1-T14-<mqtt-v>-<name>: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic
@@ -851,6 +899,11 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  |
       | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
 
+    @mqtt3 @paho-python @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
+
     @mqtt5 @sdk-java
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
@@ -865,6 +918,11 @@ Feature: GGMQ-1
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
+
+    @mqtt5 @paho-python @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
 
 
   @GGMQ-1-T15
@@ -968,7 +1026,7 @@ Feature: GGMQ-1
     }
 }
     """
-    Then the local Greengrass deployment is SUCCEEDED on the device after 2 minutes
+    Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
 
     Then I wait 5 seconds
     Then message "Hello world" received on "subscriber" from "pubsub/topic/to/publish/on" topic within 10 seconds
@@ -991,6 +1049,11 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  |
       | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
 
+    @mqtt3 @paho-python @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
+
     @mqtt5 @sdk-java
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
@@ -1005,6 +1068,11 @@ Feature: GGMQ-1
     Examples:
       | mqtt-v | name        | agent                                     | recipe                  |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
+
+    @mqtt5 @paho-python @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
 
 
   @GGMQ-1-T101
@@ -1095,6 +1163,10 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                  |
       | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   |
 
+    @mqtt3 @paho-python @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
 
   @GGMQ-1-T102
   Scenario Outline: GGMQ-1-T102-<mqtt-v>-<name>: As a customer, I can use publish retain flag,subscribe retain handling, content type using MQTT V5.0

--- a/uat/testing-features/src/main/resources/local-store/recipes/client_python_paho.yaml
+++ b/uat/testing-features/src/main/resources/local-store/recipes/client_python_paho.yaml
@@ -8,7 +8,7 @@ RecipeFormatVersion: '2020-01-25'
 ComponentName: aws.greengrass.client.Mqtt5PythonPahoClient
 ComponentVersion: '1.0.0'
 ComponentDescription: MQTT 5.0/3.1.1 Python Client powered by Eclipse Paho
-ComponentPublisher: Amazon
+ComponentPublisher: AWS
 ComponentConfiguration:
   DefaultConfiguration:
     # agentId should be the same as ComponentName
@@ -20,7 +20,7 @@ Manifests:
       - URI: classpath:/local-store/artifacts/client-python-paho
         Permission:
           Read: ALL
-          Execute: ALL
+          Execute: OWNER
     Lifecycle:
       Run: |
         {artifacts:path}/client-python-paho "{configuration:/agentId}" "{configuration:/controlPort}" {configuration:/controlAddresses}

--- a/uat/testing-features/src/main/resources/local-store/recipes/client_python_paho.yaml
+++ b/uat/testing-features/src/main/resources/local-store/recipes/client_python_paho.yaml
@@ -1,0 +1,27 @@
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+---
+RecipeFormatVersion: '2020-01-25'
+ComponentName: aws.greengrass.client.Mqtt5PythonPahoClient
+ComponentVersion: '1.0.0'
+ComponentDescription: MQTT 5.0/3.1.1 Python Client powered by Eclipse Paho
+ComponentPublisher: Amazon
+ComponentConfiguration:
+  DefaultConfiguration:
+    # agentId should be the same as ComponentName
+    agentId: aws.greengrass.client.Mqtt5PythonPahoClient
+    controlAddresses: 127.0.0.1
+    controlPort: 47619
+Manifests:
+  - Artifacts:
+      - URI: classpath:/local-store/artifacts/client-python-paho
+        Permission:
+          Read: ALL
+          Execute: ALL
+    Lifecycle:
+      Run: |
+        {artifacts:path}/client-python-paho "{configuration:/agentId}" "{configuration:/controlPort}" {configuration:/controlAddresses}
+# Only linux support at this moment


### PR DESCRIPTION
**Description of changes:**
- Integrate Python Paho client to existing scenarios except for GGMQ-1-T102 for Linux

**Why is this change necessary:**
Test all scenarios with Python Paho client

**How was this change tested:**
Run scenarios locally

**Test results:**
```
[INFO ] 2023-07-03 19:17:00.402 [main] StepTrackingReporting - Passed: 'GGMQ-1-T1-v3-paho-python: As a customer, I can connect, subscribe/publish at QoS 0 and 1 and receive using client application to MQTT topic'
[INFO ] 2023-07-03 19:17:00.402 [main] StepTrackingReporting - Passed: 'GGMQ-1-T1-v5-paho-python: As a customer, I can connect, subscribe/publish at QoS 0 and 1 and receive using client application to MQTT topic'
[INFO ] 2023-07-03 19:17:00.402 [main] StepTrackingReporting - Passed: 'GGMQ-1-T2-v3-paho-python: GGAD can publish to an MQTT topic at QoS 0 and QoS 1 based on CDA configuration'
[INFO ] 2023-07-03 19:17:00.402 [main] StepTrackingReporting - Passed: 'GGMQ-1-T2-v5-paho-python: GGAD can publish to an MQTT topic at QoS 0 and QoS 1 based on CDA configuration'
[INFO ] 2023-07-03 19:17:00.403 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v3-paho-python: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'
[INFO ] 2023-07-03 19:17:00.403 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v5-paho-python: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'
[INFO ] 2023-07-03 19:17:00.403 [main] StepTrackingReporting - Passed: 'GGMQ-1-T9-v3-paho-python: As a customer,I can configure local MQTT messages to be forwarded to an IoT Core MQTT topic'
[INFO ] 2023-07-03 19:17:00.403 [main] StepTrackingReporting - Passed: 'GGMQ-1-T9-v5-paho-python: As a customer,I can configure local MQTT messages to be forwarded to an IoT Core MQTT topic'
[INFO ] 2023-07-03 19:17:00.403 [main] StepTrackingReporting - Passed: 'GGMQ-1-T13-v3-paho-python: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration'
[INFO ] 2023-07-03 19:17:00.403 [main] StepTrackingReporting - Passed: 'GGMQ-1-T13-v5-paho-python: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration'
[INFO ] 2023-07-03 19:17:00.403 [main] StepTrackingReporting - Passed: 'GGMQ-1-T14-v3-paho-python: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic'
[INFO ] 2023-07-03 19:17:00.403 [main] StepTrackingReporting - Passed: 'GGMQ-1-T14-v5-paho-python: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic'
[INFO ] 2023-07-03 19:17:00.403 [main] StepTrackingReporting - Passed: 'GGMQ-1-T15-v3-paho-python: As a customer, I can configure Pubsub messages to be forwarded to local MQTT topic'
[INFO ] 2023-07-03 19:17:00.403 [main] StepTrackingReporting - Passed: 'GGMQ-1-T15-v5-paho-python: As a customer, I can configure Pubsub messages to be forwarded to local MQTT topic'
[INFO ] 2023-07-03 19:17:00.403 [main] StepTrackingReporting - Passed: 'GGMQ-1-T101-v3-paho-python: As a customer, I can use publish retain flag using MQTT V3.1.1'
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
