### PR TITLE
feat(uat): add T20 scenario and new connection step

### DIFF
--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
@@ -380,7 +380,7 @@ public class MqttConnectionImpl implements MqttConnection {
         Integer reasonCode = reasonCodes == null ? null : reasonCodes[0];
 
         List<Mqtt5Properties> ackUserProperties =
-                getAckUserProperties(token.getResponseProperties().getUserProperties(), "ConAck");
+                getAckUserProperties(token.getResponseProperties().getUserProperties(), "ConnAck");
 
         String responseInformation = token.getResponseProperties().getResponseInfo();
         if (responseInformation != null) {

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -783,7 +783,7 @@ public class MqttControlSteps {
     }
 
     /**
-     * Creates MQTT failed connection.
+     * Try to create MQTT connection to broker and ensure connection has been failed.
      *
      * @param clientDeviceId the id of the device (thing name) as defined by user in scenario
      * @param componentId  the componentId of MQTT client

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -93,7 +93,6 @@ public class MqttControlSteps {
     private static final int DEFAULT_CONTROL_GRPC_PORT = 0;
     private static final String MQTT_CONTROL_PORT_KEY = "mqttControlPort";
 
-    private static final Integer DEFAULT_CLIENT_CUSTOM_CONNECTION_PORT = null;
     private static final int MIN_QOS = 0;
     private static final int MAX_QOS = 2;
 
@@ -146,9 +145,6 @@ public class MqttControlSteps {
     private final EventStorageImpl eventStorage;
 
     private final GreengrassV2Client greengrassClient;
-
-    /** Actual value of port in MQTT connection. */
-    private static Integer customConnectionPort = DEFAULT_CLIENT_CUSTOM_CONNECTION_PORT;
 
     /** Actual value of timeout in seconds used in all MQTT opetations. */
     private int mqttTimeoutSec = DEFAULT_MQTT_TIMEOUT_SEC;
@@ -317,26 +313,6 @@ public class MqttControlSteps {
         }
 
         return Boolean.valueOf(value);
-    }
-
-    /**
-     * Sets MQTT custom connection port.
-     *
-     * @param port MQTT connection port
-     */
-    @And("I set MQTT connection port to {int}")
-    public void setMqttConnectionPort(int port) {
-        customConnectionPort = port;
-        log.info("MQTT connection port set to {}", customConnectionPort);
-    }
-
-    /**
-     * Resets MQTT custom connection port.
-     */
-    @And("I reset MQTT connection port")
-    public void resetMqttConnectionPort() {
-        customConnectionPort = DEFAULT_CLIENT_CUSTOM_CONNECTION_PORT;
-        log.info("MQTT connection port reset to default");
     }
 
     /**
@@ -783,7 +759,7 @@ public class MqttControlSteps {
         for (final MqttBrokerConnectionInfo broker : bc) {
             final List<String> caList = broker.getCaList();
             final String host = broker.getHost();
-            final Integer port = customConnectionPort == null ? broker.getPort() : customConnectionPort;
+            final Integer port = broker.getPort();
             log.info("Creating MQTT connection with broker {} to address {}:{} as Thing {} on {} using MQTT {}",
                      brokerId, host, port, clientDeviceThingName, componentId, mqttVersion);
             MqttConnectRequest request = buildMqttConnectRequest(

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -797,7 +797,8 @@ public class MqttControlSteps {
     public void canNotConnect(String clientDeviceId, String componentId, String brokerId, String mqttVersion) {
         try {
             connect(clientDeviceId, componentId, brokerId, mqttVersion);
-        } catch (RuntimeException ignored) {
+        } catch (RuntimeException e) {
+            log.info("Connection was failed with message '{}'", e.getMessage());
         }
     }
 

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -93,6 +93,7 @@ public class MqttControlSteps {
     private static final int DEFAULT_CONTROL_GRPC_PORT = 0;
     private static final String MQTT_CONTROL_PORT_KEY = "mqttControlPort";
 
+    private static final Integer DEFAULT_CLIENT_CUSTOM_CONNECTION_PORT = null;
     private static final int MIN_QOS = 0;
     private static final int MAX_QOS = 2;
 
@@ -145,6 +146,9 @@ public class MqttControlSteps {
     private final EventStorageImpl eventStorage;
 
     private final GreengrassV2Client greengrassClient;
+
+    /** Actual value of port in MQTT connection. */
+    private static Integer customConnectionPort = DEFAULT_CLIENT_CUSTOM_CONNECTION_PORT;
 
     /** Actual value of timeout in seconds used in all MQTT opetations. */
     private int mqttTimeoutSec = DEFAULT_MQTT_TIMEOUT_SEC;
@@ -313,6 +317,26 @@ public class MqttControlSteps {
         }
 
         return Boolean.valueOf(value);
+    }
+
+    /**
+     * Sets MQTT custom connection port.
+     *
+     * @param port MQTT connection port
+     */
+    @And("I set MQTT connection port to {int}")
+    public void setMqttConnectionPort(int port) {
+        customConnectionPort = port;
+        log.info("MQTT connection port set to {}", customConnectionPort);
+    }
+
+    /**
+     * Resets MQTT custom connection port.
+     */
+    @And("I reset MQTT connection port")
+    public void resetMqttConnectionPort() {
+        customConnectionPort = DEFAULT_CLIENT_CUSTOM_CONNECTION_PORT;
+        log.info("MQTT connection port reset to default");
     }
 
     /**
@@ -759,7 +783,7 @@ public class MqttControlSteps {
         for (final MqttBrokerConnectionInfo broker : bc) {
             final List<String> caList = broker.getCaList();
             final String host = broker.getHost();
-            final Integer port = broker.getPort();
+            final Integer port = customConnectionPort == null ? broker.getPort() : customConnectionPort;
             log.info("Creating MQTT connection with broker {} to address {}:{} as Thing {} on {} using MQTT {}",
                      brokerId, host, port, clientDeviceThingName, componentId, mqttVersion);
             MqttConnectRequest request = buildMqttConnectRequest(
@@ -1165,25 +1189,6 @@ public class MqttControlSteps {
                 endpoint, IOT_CORE_MQTT_PORT, Collections.singletonList(ca));
         brokers.put(brokerId, Collections.singletonList(broker));
         log.info("Added IoT Core broker as {} with endpoint {}:{}", brokerId, endpoint, IOT_CORE_MQTT_PORT);
-    }
-
-
-    /**
-     * Set up IoT core broker port.
-     *
-     * @param brokerId broker name in tests
-     * @param port broker port in tests
-     */
-    @And("I force to set broker {string} with port {int}")
-    public void setBrokerPort(String brokerId, int port) {
-        List<MqttBrokerConnectionInfo> connectionInfos = brokers.get(brokerId);
-        if (connectionInfos == null || connectionInfos.isEmpty()) {
-            throw new RuntimeException("Broker is not found");
-        }
-        for (MqttBrokerConnectionInfo info : connectionInfos) {
-                info.setPort(port);
-        }
-        log.info("Port of broker {} force changed to {}", brokerId, port);
     }
 
     /**

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -1177,6 +1177,9 @@ public class MqttControlSteps {
     @And("I force to set broker {string} with port {int}")
     public void setBrokerPort(String brokerId, int port) {
         List<MqttBrokerConnectionInfo> connectionInfos = brokers.get(brokerId);
+        if (connectionInfos == null || connectionInfos.isEmpty()) {
+            throw new RuntimeException("Broker is not found");
+        }
         for (MqttBrokerConnectionInfo info : connectionInfos) {
                 info.setPort(port);
         }

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -783,7 +783,7 @@ public class MqttControlSteps {
     }
 
     /**
-     * Creates MQTT connection.
+     * Creates MQTT failed connection.
      *
      * @param clientDeviceId the id of the device (thing name) as defined by user in scenario
      * @param componentId  the componentId of MQTT client

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -1174,22 +1174,13 @@ public class MqttControlSteps {
      * @param brokerId broker name in tests
      * @param port broker port in tests
      */
-    @And("I force to set IoT Core broker as {string} with port {int}")
+    @And("I force to set broker {string} with port {int}")
     public void setBrokerPort(String brokerId, int port) {
-        final String endpoint = resources.lifecycle(IotLifecycle.class)
-                                         .dataEndpoint();
-        final String ca = registrationContext.rootCA();
         List<MqttBrokerConnectionInfo> connectionInfos = brokers.get(brokerId);
-        if (connectionInfos != null && !connectionInfos.isEmpty()) {
-            for (MqttBrokerConnectionInfo info : connectionInfos) {
+        for (MqttBrokerConnectionInfo info : connectionInfos) {
                 info.setPort(port);
-            }
-        } else {
-            MqttBrokerConnectionInfo broker = new MqttBrokerConnectionInfo(
-                    endpoint, port, Collections.singletonList(ca));
-            brokers.put(brokerId, Collections.singletonList(broker));
         }
-        log.info("Added IoT Core broker as {} with endpoint {}:{}", brokerId, endpoint, port);
+        log.info("Port of broker {} force changed to {}", brokerId, port);
     }
 
     /**

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1125,19 +1125,33 @@ Feature: GGMQ-1
 
     And I discover core device broker as "default_broker" from "clientDeviceTest" in OTF
     And I connect device "clientDeviceTest" on <agent> to "default_broker" using mqtt "<mqtt-v>"
+    And I disconnect device "clientDeviceTest" with reason code 0
 
     When I create a Greengrass deployment with components
       | aws.greengrass.clientdevices.Auth        | LATEST |
       | aws.greengrass.clientdevices.mqtt.EMQX   | LATEST |
       | aws.greengrass.clientdevices.IPDetector  | LATEST |
       | <agent>                                  | LATEST |
+    And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.IPDetector configuration to:
+    """
+{
+    "MERGE":{
+        "defaultPort":"11111"
+    }
+}
+    """
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 299 seconds
-
     And I discover core device broker as "default_broker" from "clientDeviceTest" in OTF
-    And I force to set broker "default_broker" with port 9443
+    And I set MQTT connection port to 9999
     Then I wait 60 seconds
     And I can not connect device "clientDeviceTest" on <agent> to "default_broker" using mqtt "<mqtt-v>"
+
+    And I discover core device broker as "default_broker" from "clientDeviceTest" in OTF
+    And I set MQTT connection port to 11111
+    Then I wait 60 seconds
+    And I connect device "clientDeviceTest" on <agent> to "default_broker" using mqtt "<mqtt-v>"
+    And I disconnect device "clientDeviceTest" with reason code 0
 
     @mqtt3 @sdk-java
     Examples:

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1135,7 +1135,7 @@ Feature: GGMQ-1
     Then the Greengrass deployment is COMPLETED on the device after 299 seconds
 
     And I discover core device broker as "default_broker" from "clientDeviceTest" in OTF
-    And I set IoT Core broker as "default_broker" with port 9443
+    And I force to set IoT Core broker as "default_broker" with port 9443
     Then I wait 60 seconds
     And I can not connect device "clientDeviceTest" on <agent> to "default_broker" using mqtt "<mqtt-v>"
 

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1140,6 +1140,21 @@ Feature: GGMQ-1
     }
 }
     """
+    And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.mqtt.EMQX configuration to:
+    """
+{
+    "MERGE":{
+        "emqx": {
+        "listener.ssl.external": "11111",
+        "listener.ssl.external.max_connections": "1024000",
+        "listener.ssl.external.max_conn_rate": "500",
+        "listener.ssl.external.rate_limit": "50KB,5s",
+        "listener.ssl.external.handshake_timeout": "15s",
+        "log.level": "warning"
+      }
+    }
+}
+    """
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 299 seconds
     And I discover core device broker as "default_broker" from "clientDeviceTest" in OTF

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1131,25 +1131,12 @@ Feature: GGMQ-1
       | aws.greengrass.clientdevices.mqtt.EMQX   | LATEST |
       | aws.greengrass.clientdevices.IPDetector  | LATEST |
       | <agent>                                  | LATEST |
-    And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.mqtt.EMQX configuration to:
-    """
-{
-    "MERGE":{
-        "emqx": {
-        "listener.ssl.external": "9443",
-        "listener.ssl.external.max_connections": "1024000",
-        "listener.ssl.external.max_conn_rate": "500",
-        "listener.ssl.external.rate_limit": "50KB,5s",
-        "listener.ssl.external.handshake_timeout": "15s",
-        "log.level": "warning"
-      }
-    }
-}
-    """
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 299 seconds
 
     And I discover core device broker as "default_broker" from "clientDeviceTest" in OTF
+    And I set IoT Core broker as "default_broker" with port 9443
+    Then I wait 60 seconds
     And I can not connect device "clientDeviceTest" on <agent> to "default_broker" using mqtt "<mqtt-v>"
 
     @mqtt3 @sdk-java

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1135,7 +1135,7 @@ Feature: GGMQ-1
     Then the Greengrass deployment is COMPLETED on the device after 299 seconds
 
     And I discover core device broker as "default_broker" from "clientDeviceTest" in OTF
-    And I force to set IoT Core broker as "default_broker" with port 9443
+    And I force to set broker "default_broker" with port 9443
     Then I wait 60 seconds
     And I can not connect device "clientDeviceTest" on <agent> to "default_broker" using mqtt "<mqtt-v>"
 

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1125,12 +1125,7 @@ Feature: GGMQ-1
 {
     "MERGE":{
         "emqx": {
-        "listener.ssl.external": "9000",
-        "listener.ssl.external.max_connections": "1024000",
-        "listener.ssl.external.max_conn_rate": "500",
-        "listener.ssl.external.rate_limit": "50KB,5s",
-        "listener.ssl.external.handshake_timeout": "15s",
-        "log.level": "warning"
+        "listener.ssl.external": "9000"
       }
     }
 }
@@ -1173,12 +1168,7 @@ Feature: GGMQ-1
 {
     "MERGE":{
         "emqx": {
-        "listener.ssl.external": "9001",
-        "listener.ssl.external.max_connections": "1024000",
-        "listener.ssl.external.max_conn_rate": "500",
-        "listener.ssl.external.rate_limit": "50KB,5s",
-        "listener.ssl.external.handshake_timeout": "15s",
-        "log.level": "warning"
+        "listener.ssl.external": "9001"
       }
     }
 }

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1130,6 +1130,14 @@ Feature: GGMQ-1
     }
 }
     """
+    And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.IPDetector configuration to:
+    """
+{
+    "MERGE":{
+        "defaultPort":"9000"
+    }
+}
+    """
 
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 5 minutes

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1125,8 +1125,8 @@ Feature: GGMQ-1
 {
     "MERGE":{
         "emqx": {
-        "listener.ssl.external": "9000"
-      }
+            "listener.ssl.external": "9000"
+        }
     }
 }
     """
@@ -1176,8 +1176,8 @@ Feature: GGMQ-1
 {
     "MERGE":{
         "emqx": {
-        "listener.ssl.external": "9001"
-      }
+            "listener.ssl.external": "9001"
+        }
     }
 }
     """
@@ -1189,33 +1189,43 @@ Feature: GGMQ-1
 
     @mqtt3 @sdk-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q1 |
-      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    | GRANTED_QOS_0       |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient    | client_java_sdk.yaml    |
 
-    @mqtt3 @mosquitto-c
+    @mqtt3 @mosquitto-c @SkipOnWindows
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q1 |
-      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | GRANTED_QOS_1       |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
 
     @mqtt3 @paho-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q1 |
-      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   | GRANTED_QOS_0       |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
+
+    @mqtt3 @paho-python @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
 
     @mqtt5 @sdk-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q1 |
-      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient  | client_java_sdk.yaml    | GRANTED_QOS_1       |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient    | client_java_sdk.yaml    |
 
-    @mqtt5 @mosquitto-c
+    @mqtt5 @mosquitto-c @SkipOnWindows
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q1 |
-      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient | client_mosquitto_c.yaml | GRANTED_QOS_1       |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
 
     @mqtt5 @paho-java
     Examples:
-      | mqtt-v | name        | agent                                     | recipe                  | subscribe-status-q1 |
-      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml   | GRANTED_QOS_1       |
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
+
+    @mqtt5 @paho-python @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
 
 
   @GGMQ-1-T101


### PR DESCRIPTION
**Issue #, if available:**
added t20 scenario and added new connection step

**Description of changes:**
- Add T20 scenario 
- Add new failed connection step

**Why is this change necessary:**
to implement Mqtt 5.0 features

**How was this change tested:**
Scenarios run manually and on CI

**Test results:**
```
Given my device is registered as a Thing....................................passed
And my device is running Greengrass.........................................passed
When I create a Greengrass deployment with components.......................passed
And I create client device "clientDeviceTest"...............................passed
When I associate "clientDeviceTest" with ggc................................passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:.passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.client.Mqtt5JavaSdkClient configuration to:.passed
And I deploy the Greengrass deployment configuration........................passed
Then the Greengrass deployment is COMPLETED on the device after 5 minutes...passed
And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes.passed
And I discover core device broker as "default_broker" from "clientDeviceTest" in OTF.passed
And I connect device "clientDeviceTest" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker" using mqtt "v5".passed
When I create a Greengrass deployment with components.......................passed
And I deploy the Greengrass deployment configuration........................passed
Then the Greengrass deployment is COMPLETED on the device after 299 seconds.passed
And I discover core device broker as "default_broker" from "clientDeviceTest" in OTF.passed
And I force to set broker "default_broker" with port 9443...................passed
Then I wait 60 seconds......................................................passed
And I can not connect device "clientDeviceTest" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker" using mqtt "v5".passed
```


**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

