### PR TITLE
docs(uat): update uat/README.md

### DIFF
--- a/uat/README.md
+++ b/uat/README.md
@@ -128,3 +128,9 @@ Dtest.log.path - path where you would like the test results to be stored.
 ```bash
 java -Dggc.archive=greengrass-nucleus-latest.zip -Dtest.log.path=logs -Dtags="@GGMQ-1-T1 and @sdk-java and @mqtt3" -jar testing-features/target/client-devices-auth-testing-features.jar
 ```
+
+
+## Limitations
+MQTT clients based on IoT Device SDK for Java v2, mosquitto C, Paho Java, Paho Python do no provide API to get information from PUBREC/PUBREL/PUBCOMP packages used when messages published with QoS 2.
+
+Not all features of MQTT v5.0 has been implemented in clients and supported by gRPC proto and the control as was requested, it is not a bugs it a design requirement.

--- a/uat/README.md
+++ b/uat/README.md
@@ -129,8 +129,11 @@ Dtest.log.path - path where you would like the test results to be stored.
 java -Dggc.archive=greengrass-nucleus-latest.zip -Dtest.log.path=logs -Dtags="@GGMQ-1-T1 and @sdk-java and @mqtt3" -jar testing-features/target/client-devices-auth-testing-features.jar
 ```
 
+### Run scenarios on CodeBuild
+Because scenario usually requires upload/download artifacts to S3, create and delete roles, policies, do greengrass discoverty and so one please ensure codeBuild instance have enough AWS permissions to do that.
+For more information please read [Create a CodeBuild service role](https://docs.aws.amazon.com/codebuild/latest/userguide/setting-up.html#setting-up-service-role)
 
 ## Limitations
 MQTT clients based on IoT Device SDK for Java v2, mosquitto C, Paho Java, Paho Python do no provide API to get information from PUBREC/PUBREL/PUBCOMP packages used when messages published with QoS 2.
 
-Not all features of MQTT v5.0 has been implemented in clients and supported by gRPC proto and the control as was requested, it is not a bugs it a design requirement.
+Not all features of MQTT v5.0 has been implemented in clients and supported by gRPC proto and the control as was requested, it is not bugs it is a design requirement.


### PR DESCRIPTION
**Issue #, if available:**
PUBREC/PUBREL/PUBCOMP and support for QoS2

Discovery failed on code build

**Description of changes:**
- Update README.md of uat by adding "Limitations" section
- Update README.md of uat by adding  "Run scenarios on CodeBuild" section

**Why is this change necessary:**
We can't implement some MQTT v5.0 features and should note about that.

**How was this change tested:**
Documentation update, will review by QA

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
