### PR TITLE
feat(uat): add test cases to T102 for request/response features

### DIFF
--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -90,7 +90,10 @@ public interface MqttConnection {
         /** No local subscription. */
         private boolean noLocal;
 
+        /** Retain as published flag. */
         private boolean retainAsPublished;
+
+        /** Retain handling option. */
         private int retainHandling;
     }
 
@@ -129,8 +132,6 @@ public interface MqttConnection {
 
         /** Optional message expiry interval. */
         private Integer messageExpiryInterval;
-
-        // TODO: add user's properties and so one
     }
 
     /**

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -89,7 +89,7 @@ class GRPCControlServer {
             shutdownReason = request.getReason();
 
             // log an event
-            logger.atInfo().log("shutdownAgent: reason {}", shutdownReason);
+            logger.atInfo().log("shutdownAgent: reason '{}'", shutdownReason);
 
             Empty reply = Empty.newBuilder().build();
             responseObserver.onNext(reply);
@@ -281,7 +281,7 @@ class GRPCControlServer {
             }
 
             boolean isRetain = message.getRetain();
-            logger.atInfo().log("Publish: connectionId {} topic {} QoS {} retain {}",
+            logger.atInfo().log("Publish: connectionId {} topic '{}' QoS {} retain {}",
                     connectionId, topic, qos, isRetain);
 
             MqttConnection.Message.MessageBuilder internalMessage = MqttConnection.Message.builder()
@@ -316,7 +316,7 @@ class GRPCControlServer {
 
             MqttPublishReply publishReply = connection.publish(timeout, internalMessage.build());
                 if (publishReply != null) {
-                    logger.atInfo().log("Publish response: connectionId {} reason code {} reason string {}",
+                    logger.atInfo().log("Publish response: connectionId {} reason code {} reason string '{}'",
                             connectionId, publishReply.getReasonCode(), publishReply.getReasonString());
                 }
             responseObserver.onNext(publishReply);
@@ -430,8 +430,8 @@ class GRPCControlServer {
                 boolean retainAsPublished = subscription.getRetainAsPublished();
                 MqttConnection.Subscription tmp = new MqttConnection.Subscription(filter, qos, noLocal,
                         retainAsPublished, retainHandling);
-                logger.atInfo().log("Subscription: filter {} QoS {} noLocal {} retainAsPublished {} retainHandling {}",
-                        filter, qos, noLocal, retainAsPublished, retainHandling);
+                logger.atInfo().log("Subscription: filter '{}' QoS {} noLocal {} retainAsPublished {} "
+                                 + "retainHandling {}", filter, qos, noLocal, retainAsPublished, retainHandling);
                 outSubscriptions.add(tmp);
                 index++;
             }
@@ -447,7 +447,7 @@ class GRPCControlServer {
             List<Mqtt5Properties> userProperties = request.getPropertiesList();
             MqttSubscribeReply subscribeReply = connection.subscribe(timeout, outSubscriptions, userProperties);
             if (subscribeReply != null) {
-                logger.atInfo().log("Subscribe response: connectionId {} reason codes {} reason string {}",
+                logger.atInfo().log("Subscribe response: connectionId {} reason codes {} reason string '{}'",
                         connectionId, subscribeReply.getReasonCodesList(), subscribeReply.getReasonString());
             }
             responseObserver.onNext(subscribeReply);
@@ -490,7 +490,7 @@ class GRPCControlServer {
             MqttSubscribeReply unsubscribeReply = connection.unsubscribe(timeout, filters, userProperties);
 
             if (unsubscribeReply != null) {
-                logger.atInfo().log("Unsubscribe response: connectionId {} reason codes {} reason string {}",
+                logger.atInfo().log("Unsubscribe response: connectionId {} reason codes {} reason string '{}'",
                         connectionId, unsubscribeReply.getReasonCodesList(), unsubscribeReply.getReasonString());
             }
             responseObserver.onNext(unsubscribeReply);

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/addon/EventFilter.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/addon/EventFilter.java
@@ -278,7 +278,12 @@ public final class EventFilter {
          *
          * @param correlationData the correlation data of the message or null
          */
+        @SuppressWarnings("PMD.NullAssignment")
         public Builder withCorrelationData(String correlationData) {
+            if (correlationData == null) {
+                this.correlationData = null;
+                return this;
+            }
             return withCorrelationData(correlationData.getBytes(StandardCharsets.UTF_8));
         }
 

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/addon/EventFilter.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/addon/EventFilter.java
@@ -33,6 +33,8 @@ public final class EventFilter {
     private final List<Mqtt5Properties> userProperties;
     private final Boolean payloadFormatIndicator;
     private final Integer messageExpiryInterval;
+    private final String responseTopic;
+    private final byte[] correlationData;
 
     EventFilter(Builder builder) {
         super();
@@ -51,6 +53,8 @@ public final class EventFilter {
         this.userProperties = builder.userProperties;
         this.payloadFormatIndicator = builder.payloadFormatIndicator;
         this.messageExpiryInterval = builder.messageExpiryInterval;
+        this.responseTopic = builder.responseTopic;
+        this.correlationData = builder.correlationData;
     }
 
     /**
@@ -72,6 +76,8 @@ public final class EventFilter {
         private List<Mqtt5Properties> userProperties;
         private Boolean payloadFormatIndicator;
         private Integer messageExpiryInterval;
+        private String responseTopic;
+        private byte[] correlationData;
 
         /**
          * Sets type of event.
@@ -252,6 +258,38 @@ public final class EventFilter {
          */
         public Builder withMessageExpiryInterval(Integer messageExpiryInterval) {
             this.messageExpiryInterval = messageExpiryInterval;
+            return this;
+        }
+
+        /**
+         * Sets message response topic.
+         * Applicable only for MQTT message events
+         *
+         * @param responseTopic the response topic of the message or null
+         */
+        public Builder withResponseTopic(String responseTopic) {
+            this.responseTopic = responseTopic;
+            return this;
+        }
+
+        /**
+         * Sets message correlation fata.
+         * Applicable only for MQTT message events
+         *
+         * @param correlationData the correlation data of the message or null
+         */
+        public Builder withCorrelationData(String correlationData) {
+            return withCorrelationData(correlationData.getBytes(StandardCharsets.UTF_8));
+        }
+
+        /**
+         * Sets message correlation fata.
+         * Applicable only for MQTT message events
+         *
+         * @param correlationData the correlation data of the message or null
+         */
+        public Builder withCorrelationData(byte[] correlationData) {
+            this.correlationData = correlationData;
             return this;
         }
 

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/addon/MqttMessageEvent.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/addon/MqttMessageEvent.java
@@ -43,12 +43,9 @@ public class MqttMessageEvent extends EventImpl {
         return connectionControl.getConnectionName();
     }
 
+    @SuppressWarnings("PMD.CognitiveComplexity")
     @Override
     public boolean isMatched(@NonNull EventFilter filter) {
-        return isMatchedPart1(filter) && isMatchedPart2(filter);
-    }
-
-    private boolean isMatchedPart1(@NonNull EventFilter filter) {
         // check type and timestamp
         boolean matched = super.isMatched(filter);
         if (!matched) {
@@ -76,11 +73,7 @@ public class MqttMessageEvent extends EventImpl {
             }
         }
 
-        return true;
-    }
-
-    private boolean isMatchedPart2(@NonNull EventFilter filter) {
-        boolean matched = isRetainMatched(filter.getRetain());
+        matched = isRetainMatched(filter.getRetain());
         if (!matched) {
             return false;
         }
@@ -115,7 +108,7 @@ public class MqttMessageEvent extends EventImpl {
             return false;
         }
 
-        // TODO: check QoS ?
+        // TODO: check QoS ? it can be differ on transmit and receive sides
 
         // check content
         return comparePayload(filter.getContent());

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/addon/MqttMessageEvent.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/addon/MqttMessageEvent.java
@@ -45,10 +45,10 @@ public class MqttMessageEvent extends EventImpl {
 
     @Override
     public boolean isMatched(@NonNull EventFilter filter) {
-        return isMatched1(filter) && isMatched2(filter);
+        return isMatchedPart1(filter) && isMatchedPart2(filter);
     }
 
-    private boolean isMatched1(@NonNull EventFilter filter) {
+    private boolean isMatchedPart1(@NonNull EventFilter filter) {
         // check type and timestamp
         boolean matched = super.isMatched(filter);
         if (!matched) {
@@ -79,7 +79,7 @@ public class MqttMessageEvent extends EventImpl {
         return true;
     }
 
-    private boolean isMatched2(@NonNull EventFilter filter) {
+    private boolean isMatchedPart2(@NonNull EventFilter filter) {
         boolean matched = isRetainMatched(filter.getRetain());
         if (!matched) {
             return false;

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -332,7 +332,7 @@ public class MqttControlSteps {
      *
      * @param connectCleanSession the new boolean value of clean session or null
      */
-    @And("I set 'clean session' to {booleanOrNullValue}")
+    @And("I set 'clean session' to {booleanValue}")
     public void setCleanSessions(Boolean connectCleanSession) {
         this.connectCleanSession = connectCleanSession;
         log.info("CONNECT 'clean session' set to {}", connectCleanSession);
@@ -1203,7 +1203,6 @@ public class MqttControlSteps {
                                                         int port, MqttProtoVersion version) {
         final IotThingSpec thingSpec = getClientDeviceThingSpec(clientDeviceThingName);
 
-        // TODO: use values from scenario instead of defaults for keepAlive, cleanSession
         MqttConnectRequest.Builder builder = MqttConnectRequest.newBuilder()
                                  .setClientId(clientDeviceThingName)
                                  .setHost(host)
@@ -1212,6 +1211,10 @@ public class MqttControlSteps {
                                  .setCleanSession(connectCleanSession)
                                  .setTls(buildTlsSettings(thingSpec, caList))
                                  .setProtocolVersion(version);
+
+        if (connectRequestResponseInformation != null) {
+            builder.setRequestResponseInformation(connectRequestResponseInformation);
+        }
 
         if (txUserProperties != null) {
              builder.addAllProperties(txUserProperties);

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -96,11 +96,17 @@ public class MqttControlSteps {
     private static final int MAX_QOS = 2;
 
     // TODO: use scenario supplied values instead of defaults
-    private static final int DEFAULT_MQTT_KEEP_ALIVE = 60;
+    private static final int IOT_CORE_MQTT_PORT = 8883;
 
     // connect default properties
-    private static final boolean DEFAULT_CONNECT_CLEAR_SESSION = true;  // TODO: use also variable and step to set it
-    private static final int IOT_CORE_MQTT_PORT = 8883;
+    // please keep order the same as in 3.1.2 CONNECT Variable Header of MQTT v5.0 spec
+    private static final boolean DEFAULT_CONNECT_CLEAN_SESSION = true;
+    private static final int DEFAULT_CONNECT_KEEP_ALIVE = 60;
+
+    // please keep order the same as in 3.1.2.11 CONNECT Properties of MQTT v5.0 spec
+    private static final Boolean DEFAULT_REQUEST_RESPONSE_INFORMATION = null;
+
+    // TODO: CONNACK Response Information
 
     // publish default properties
 
@@ -110,6 +116,8 @@ public class MqttControlSteps {
     // please keep order the same as in 3.3.2.3 PUBLISH Properties of MQTT v5.0 spec
     private static final Boolean DEFAULT_PUBLISH_PAYLOAD_FORMAT_INDICATOR = null;
     private static final Integer DEFAULT_MESSAGE_EXPIRY_INTERVAL = null;
+    private static final String DEFAULT_RESPONSE_TOPIC = null;
+    private static final String DEFAULT_CORRELATION_DATA = null;
     private static final String DEFAULT_CONTENT_TYPE = null;
 
     // subscribe efault properties
@@ -140,6 +148,17 @@ public class MqttControlSteps {
     /** Actual value of timeout in seconds used in all MQTT opetations. */
     private int mqttTimeoutSec = DEFAULT_MQTT_TIMEOUT_SEC;
 
+    // please keep order the same as in 3.1.2 CONNECT Variable Header of MQTT v5.0 spec
+    /** Actual value of CONNECT clean session. */
+    private boolean connectCleanSession = DEFAULT_CONNECT_CLEAN_SESSION;
+
+    /** Actual value of CONNECT keep alive. */
+    private int connectKeepAlive = DEFAULT_CONNECT_KEEP_ALIVE;
+
+    private Boolean connectRequestResponseInformation = DEFAULT_REQUEST_RESPONSE_INFORMATION;
+
+    // TODO: CONNACK response information
+
     // please keep order the same as in 3.8.3.1 Subscription Options of MQTT v5.0
     /** Actual value of subscribe no local option. */
     private boolean subscribeNoLocal = DEFAULT_SUBSCRIBE_NO_LOCAL;
@@ -166,11 +185,25 @@ public class MqttControlSteps {
     private Boolean rxPayloadFormatIndicator = DEFAULT_RECEIVED_PAYLOAD_FORMAT_INDICATOR;
 
 
-    /** Actual value of message expiry interval. */
+    /** Actual value of message expiry interval to publishing. */
     private Integer txMessageExpiryInterval = DEFAULT_MESSAGE_EXPIRY_INTERVAL;
 
     /** Actual expected value of message expiry interval in received messages. */
     private Integer rxMessageExpiryInterval = DEFAULT_MESSAGE_EXPIRY_INTERVAL;
+
+
+    /** Actual value of response topic to publishing. */
+    private String txResponseTopic = DEFAULT_RESPONSE_TOPIC;
+
+    /** Actual expected value of response topic in received messages. */
+    private String rxResponseTopic = DEFAULT_RESPONSE_TOPIC;
+
+
+    /** Actual value of correlation data to publishing. */
+    private String txCorrelationData = DEFAULT_CORRELATION_DATA;
+
+    /** Actual expected value of correlation data in received messages. */
+    private String rxCorrelationData = DEFAULT_CORRELATION_DATA;
 
 
     /** Actual list of user properties to transmit. */
@@ -294,6 +327,43 @@ public class MqttControlSteps {
 
 
     /**
+     * Sets or resets CONNECT clean session boolean value.
+     *
+     * @param connectCleanSession the new boolean value of clean session or null
+     */
+    @And("I set 'clean session' to {booleanOrNullValue}")
+    public void setCleanSessions(Boolean connectCleanSession) {
+        this.connectCleanSession = connectCleanSession;
+        log.info("CONNECT 'clean session' set to {}", connectCleanSession);
+    }
+
+
+    /**
+     * Sets CONNECT 'keep alive' value.
+     *
+     * @param connectKeepAlive the value of CONNECT 'keep alive' property
+     */
+    @And("I set CONNECT 'keep alive' to {int} second(s)")
+    public void setConnectKeepAlive(int connectKeepAlive) {
+        this.connectKeepAlive = connectKeepAlive;
+        log.info("CONNECT 'keep alive' set to {}", connectKeepAlive);
+    }
+
+
+    /**
+     * Sets or resets CONNECT 'request response information' flag.
+     *
+     * @param connectRequestResponseInformation the value of CONNECT 'request response information' flag or null
+     */
+    @And("I set 'request response information' to {booleanOrNullValue}")
+    public void setConnectRequestResponseInformation(Boolean connectRequestResponseInformation) {
+        this.connectRequestResponseInformation = connectRequestResponseInformation;
+        log.info("CONNECT 'request response information' set to {}", connectRequestResponseInformation);
+    }
+
+    // TODO: CONNACK response information
+
+    /**
      * Sets MQTT subscribe 'no local' flag.
      *
      * @param subscribeNoLocal the new values of 'no local' flag.
@@ -379,7 +449,7 @@ public class MqttControlSteps {
     @And("I set MQTT publish 'message expiry interval' to {int}")
     public void setTxMessageExpiryInterval(Integer messageExpiryInterval) {
         this.txMessageExpiryInterval = messageExpiryInterval;
-        log.info("Publish 'message expiry interval' set to {}", this.txMessageExpiryInterval);
+        log.info("Publish 'message expiry interval' set to {}", messageExpiryInterval);
     }
 
     /**
@@ -414,6 +484,97 @@ public class MqttControlSteps {
         this.rxMessageExpiryInterval = null;
         log.info("Expected 'message expiry interval' is reset");
     }
+
+    /**
+     * Sets MQTT 'response topic' value for publishing.
+     *
+     * @param responseTopic the new value of response topic for publishing
+     */
+    @And("I set MQTT publish 'response topic' to {string}")
+    public void setTxResponseTopic(String responseTopic) {
+        this.txResponseTopic = responseTopic;
+        log.info("Publish 'response topic' set to {}", responseTopic);
+    }
+
+    /**
+     * Reset MQTT 'response topic' value for publishing.
+     *
+     */
+    @SuppressWarnings("PMD.NullAssignment")
+    @And("I reset MQTT publish 'response topic'")
+    public void resetTxResponseTopic() {
+        this.txResponseTopic = null;
+        log.info("Publish 'response topic' is reset");
+    }
+
+    /**
+     * Sets value of expected MQTT 'response topic' in received messages.
+     *
+     * @param responseTopic the new expected value of 'response topic' in received messages
+     */
+    @And("I set the 'response topic' in expected received messages to {string}")
+    public void setRxResponseTopic(String responseTopic) {
+        this.rxResponseTopic = responseTopic;
+        log.info("Expected 'response topic' in received messages set to {}", responseTopic);
+    }
+
+    /**
+     * Reset expected value 'response topic' in received messages.
+     *
+     */
+    @SuppressWarnings("PMD.NullAssignment")
+    @And("I reset expected 'response topic'")
+    public void resetRxResponseTopic() {
+        this.rxResponseTopic = null;
+        log.info("Expected 'response topic' is reset");
+    }
+
+
+    /**
+     * Sets MQTT 'correlation data' value for publishing.
+     *
+     * @param correlationData the new value of correlation data for publishing
+     */
+    @And("I set MQTT publish 'correlation data' to {string}")
+    public void setTxCorrelationData(String correlationData) {
+        this.txCorrelationData = correlationData;
+        log.info("Publish 'correlation data' set to {}", correlationData);
+    }
+
+    /**
+     * Reset MQTT 'correlation data' value for publishing.
+     *
+     */
+    @SuppressWarnings("PMD.NullAssignment")
+    @And("I reset MQTT publish 'correlation data'")
+    public void resetTxCorrelationData() {
+        this.txCorrelationData = null;
+        log.info("Publish 'correlation data' is reset");
+    }
+
+
+    /**
+     * Sets value of expected MQTT 'correlation data' in received messages.
+     *
+     * @param correlationData the new expected value of 'correlation data' in received messages
+     */
+    @And("I set the 'correlation data' in expected received messages to {string}")
+    public void setRxCorrelationData(String correlationData) {
+        this.rxCorrelationData = correlationData;
+        log.info("Expected 'correlation data' in received messages set to {}", correlationData);
+    }
+
+    /**
+     * Reset expected value 'correlation data' in received messages.
+     *
+     */
+    @SuppressWarnings("PMD.NullAssignment")
+    @And("I reset expected 'correlation data'")
+    public void resetRxCorrelationData() {
+        this.rxCorrelationData = null;
+        log.info("Expected 'correlation data' is reset");
+    }
+
 
     /**
      * Sets MQTT user Properties to transmit.
@@ -496,18 +657,20 @@ public class MqttControlSteps {
     /**
      * Reset MQTT content type to transmit.
      */
+    @SuppressWarnings("PMD.NullAssignment")
     @And("I reset MQTT publish 'content type'")
     public void resetMqttTxContentType() {
-        this.txContentType = DEFAULT_CONTENT_TYPE;
+        this.txContentType = null;
         log.info("MQTT content type reset to transmit");
     }
 
     /**
      * Reset MQTT content type to receive.
      */
+    @SuppressWarnings("PMD.NullAssignment")
     @And("I reset MQTT 'content type' in expected received messages")
     public void resetMqttRxContentType() {
-        this.rxContentType = DEFAULT_CONTENT_TYPE;
+        this.rxContentType = null;
         log.info("MQTT content type reset to receive");
     }
 
@@ -766,8 +929,10 @@ public class MqttControlSteps {
 
         // do publishing
         log.info("Publishing MQTT message '{}' as Thing {} to topic {} with QoS {} retain {}"
-                        + " payload format indicator {} message expire interval {}", message, clientDeviceThingName,
-                    topic, qos, txRetain, txPayloadFormatIndicator, txMessageExpiryInterval);
+                        + " payload format indicator {} message expire interval {} response topic {} "
+                        + "correlation data {}", message, clientDeviceThingName, topic, qos, txRetain,
+                    txPayloadFormatIndicator, txMessageExpiryInterval, txResponseTopic, txCorrelationData);
+
         Mqtt5Message mqtt5Message = buildMqtt5Message(qos, topic, message);
         MqttPublishReply mqttPublishReply = connectionControl.publishMqtt(mqtt5Message);
         if (mqttPublishReply == null) {
@@ -854,14 +1019,18 @@ public class MqttControlSteps {
                                         .withUserProperties(rxUserProperties)
                                         .withPayloadFormatIndicator(rxPayloadFormatIndicator)
                                         .withMessageExpiryInterval(rxMessageExpiryInterval)
+                                        .withResponseTopic(rxResponseTopic)
+                                        .withCorrelationData(rxCorrelationData)
                                         .build();
         // convert time units
         TimeUnit timeUnit = TimeUnit.valueOf(unit.toUpperCase());
 
         // awaiting for message
         log.info("Awaiting for MQTT message '{}' with retain {} payload format indicator {} message expiry interval {} "
-                    + "on topic '{}' on Thing '{}' for {} {}", message, rxRetain, rxPayloadFormatIndicator,
-                    rxMessageExpiryInterval, topic, clientDeviceThingName, value, unit);
+                    + "response topic {} correlation data {} on topic '{}' on Thing '{}' for {} {}", message, rxRetain,
+                    rxPayloadFormatIndicator, rxMessageExpiryInterval, rxResponseTopic, rxCorrelationData, topic,
+                    clientDeviceThingName, value, unit);
+
         List<Event> events = new ArrayList<>();
         try {
             events = eventStorage.awaitEvents(eventFilter, value, timeUnit);
@@ -894,6 +1063,10 @@ public class MqttControlSteps {
     public void clearAnything() {
         clearStorage();
         setMqttTimeoutSec(DEFAULT_MQTT_TIMEOUT_SEC);
+        setCleanSessions(DEFAULT_CONNECT_CLEAN_SESSION);
+        setConnectKeepAlive(DEFAULT_CONNECT_KEEP_ALIVE);
+        setConnectRequestResponseInformation(DEFAULT_REQUEST_RESPONSE_INFORMATION);
+        // TODO: reset CONNACK ResponseInformation
 
         setTxRetain(DEFAULT_PUBLISH_RETAIN);
         setRxRetain(DEFAULT_RECEIVED_RETAIN);
@@ -903,6 +1076,12 @@ public class MqttControlSteps {
 
         setTxMessageExpiryInterval(DEFAULT_MESSAGE_EXPIRY_INTERVAL);
         setRxMessageExpiryInterval(DEFAULT_MESSAGE_EXPIRY_INTERVAL);
+
+        setTxResponseTopic(DEFAULT_RESPONSE_TOPIC);
+        setRxResponseTopic(DEFAULT_RESPONSE_TOPIC);
+
+        setTxCorrelationData(DEFAULT_CORRELATION_DATA);
+        setRxCorrelationData(DEFAULT_CORRELATION_DATA);
 
         clearTxUserProperties();
         clearRxUserProperties();
@@ -1028,8 +1207,8 @@ public class MqttControlSteps {
                                  .setClientId(clientDeviceThingName)
                                  .setHost(host)
                                  .setPort(port)
-                                 .setKeepalive(DEFAULT_MQTT_KEEP_ALIVE)
-                                 .setCleanSession(DEFAULT_CONNECT_CLEAR_SESSION)
+                                 .setKeepalive(connectKeepAlive)
+                                 .setCleanSession(connectCleanSession)
                                  .setTls(buildTlsSettings(thingSpec, caList))
                                  .setProtocolVersion(version);
 
@@ -1195,6 +1374,14 @@ public class MqttControlSteps {
 
         if (txMessageExpiryInterval != null) {
             builder.setMessageExpiryInterval(txMessageExpiryInterval);
+        }
+
+        if (txResponseTopic != null) {
+            builder.setResponseTopic(txResponseTopic);
+        }
+
+        if (txCorrelationData != null) {
+            builder.setCorrelationData(ByteString.copyFromUtf8(txCorrelationData));
         }
 
         if (txContentType != null) {

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -74,6 +74,7 @@ import javax.inject.Inject;
 
 import static software.amazon.awssdk.iot.discovery.DiscoveryClient.TLS_EXT_ALPN;
 
+@SuppressWarnings("PMD.ExcessivePublicCount")
 @Log4j2
 @ScenarioScoped
 public class MqttControlSteps {

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1603,7 +1603,7 @@ Feature: GGMQ-1
     And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
 
     When I subscribe "subscriber" to "topic_request_response_information_is_set_false" with qos 0
-    When I publish from "publisher" to "topic_request_response_information_is_set_true" with qos 0 and message "Message when request response information is false"
+    When I publish from "publisher" to "topic_request_response_information_is_set_false" with qos 0 and message "Message when request response information is false"
     And message "Message when request response information is false" received on "subscriber" from "topic_request_response_information_is_set_false" topic within 5 seconds
 
     @mqtt5 @sdk-java

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1163,7 +1163,7 @@ Feature: GGMQ-1
 
 
   @GGMQ-1-T102
-  Scenario Outline: GGMQ-1-T102-<mqtt-v>-<name>: As a customer, I can use publish retain flag,subscribe retain handling, content type using MQTT V5.0
+  Scenario Outline: GGMQ-1-T102-<mqtt-v>-<name>: As a customer, I can use new MQTT v5.0 features
     When I create a Greengrass deployment with components
       | aws.greengrass.clientdevices.Auth       | LATEST                                  |
       | aws.greengrass.clientdevices.mqtt.EMQX  | LATEST                                  |

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1554,6 +1554,58 @@ Feature: GGMQ-1
     When I subscribe "subscriber" to "message_expire_interval_1" with qos 0
     And message "Message expiry interval was 1" is not received on "subscriber" from "message_expire_interval_1" topic within 10 seconds
 
+    And I clear message storage and reset all MQTT settings to default
+
+    # I. test 'response topic' feature
+
+    # 30. test case when publish message with response topic and receive message with the same response topic
+    And I set MQTT publish 'response topic' to "response_topic"
+    And I set the 'response topic' in expected received messages to "response_topic"
+
+    When I subscribe "subscriber" to "response_topic_test_case_1" with qos 0
+    When I publish from "publisher" to "response_topic_test_case_1" with qos 0 and message "Message with response topic 1"
+    And message "Message with response topic 1" received on "subscriber" from "response_topic_test_case_1" topic within 5 seconds
+
+    And I clear message storage
+    And I reset MQTT publish 'response topic'
+    And I reset expected 'response topic'
+
+    # J. test 'correlation data' feature
+    # 31. test case when publish message with correlation data and receive message with the same correlation data
+    And I set MQTT publish 'correlation data' to "correlation_data_1"
+    And I set the 'correlation data' in expected received messages to "correlation_data_1"
+
+    When I subscribe "subscriber" to "correlation_data_test_case_1" with qos 0
+    When I publish from "publisher" to "correlation_data_test_case_1" with qos 0 and message "Message with correlation data 1"
+    And message "Message with correlation data 1" received on "subscriber" from "correlation_data_test_case_1" topic within 5 seconds
+
+    And I clear message storage
+    And I reset MQTT publish 'correlation data'
+    And I reset expected 'correlation data'
+    And I disconnect device "publisher" with reason code 0
+
+    # K. test 'request response information' feature
+
+    # 32. test case when connect with 'request response information' flag set to true
+    #  unfortunately IoT Core and EMQX brokers does not provide 'Response Information' in CONNACK so we can only test connection is OK
+    And I set 'request response information' to true
+    And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
+
+    When I subscribe "subscriber" to "topic_request_response_information_is_set_true" with qos 0
+    When I publish from "publisher" to "topic_request_response_information_is_set_true" with qos 0 and message "Message when request response information is true"
+    And message "Message when request response information is true" received on "subscriber" from "topic_request_response_information_is_set_true" topic within 5 seconds
+
+    And I clear message storage
+    And I disconnect device "publisher" with reason code 0
+
+    # 33. test case when connect with 'request response information' flag set to false
+    And I set 'request response information' to false
+    And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
+
+    When I subscribe "subscriber" to "topic_request_response_information_is_set_false" with qos 0
+    When I publish from "publisher" to "topic_request_response_information_is_set_true" with qos 0 and message "Message when request response information is false"
+    And message "Message when request response information is false" received on "subscriber" from "topic_request_response_information_is_set_false" topic within 5 seconds
+
     @mqtt5 @sdk-java
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  | publish-status-nms |

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1567,11 +1567,40 @@ Feature: GGMQ-1
     And message "Message with response topic 1" received on "subscriber" from "response_topic_test_case_1" topic within 5 seconds
 
     And I clear message storage
-    And I reset MQTT publish 'response topic'
+
+    # 31. test case when publish message with response topic set but expected response topic is not set
+    And I set MQTT publish 'response topic' to "response_topic_2"
     And I reset expected 'response topic'
 
+    When I subscribe "subscriber" to "response_topic_test_case_2" with qos 0
+    When I publish from "publisher" to "response_topic_test_case_2" with qos 0 and message "Message with response topic 2"
+    And message "Message with response topic 2" received on "subscriber" from "response_topic_test_case_2" topic within 5 seconds
+
+    And I clear message storage
+
+    # 32. test case when response topic in publish is not set but expected in received message
+    And I reset MQTT publish 'response topic'
+    And I set the 'response topic' in expected received messages to "response_topic_3"
+
+    When I subscribe "subscriber" to "response_topic_test_case_3" with qos 0
+    When I publish from "publisher" to "response_topic_test_case_3" with qos 0 and message "Message without response topic 3"
+    And message "Message without response topic 3" is not received on "subscriber" from "response_topic_test_case_3" topic within 10 seconds
+
+    And I clear message storage
+
+    # 33. test case when response topic in pulish and receive are not the same
+    And I set MQTT publish 'response topic' to "response_topic_4"
+    And I set the 'response topic' in expected received messages to "response_topic_5"
+
+    When I subscribe "subscriber" to "response_topic_test_case_4" with qos 0
+    When I publish from "publisher" to "response_topic_test_case_4" with qos 0 and message "Message with response topic 4"
+    And message "Message with response topic 4" is not received on "subscriber" from "response_topic_test_case_4" topic within 10 seconds
+
+    And I clear message storage and reset all MQTT settings to default
+
     # J. test 'correlation data' feature
-    # 31. test case when publish message with correlation data and receive message with the same correlation data
+
+    # 34. test case when publish message with correlation data and receive message with the same correlation data
     And I set MQTT publish 'correlation data' to "correlation_data_1"
     And I set the 'correlation data' in expected received messages to "correlation_data_1"
 
@@ -1579,14 +1608,42 @@ Feature: GGMQ-1
     When I publish from "publisher" to "correlation_data_test_case_1" with qos 0 and message "Message with correlation data 1"
     And message "Message with correlation data 1" received on "subscriber" from "correlation_data_test_case_1" topic within 5 seconds
 
+    # 35. test case when publish message with correlation data but without expected correlation data
+    And I set MQTT publish 'correlation data' to "correlation_data_2"
+    And "I reset expected 'correlation data'"
+
+    When I subscribe "subscriber" to "correlation_data_test_case_2" with qos 0
+    When I publish from "publisher" to "correlation_data_test_case_2" with qos 0 and message "Message with correlation data 2"
+    And message "Message with correlation data 2" received on "subscriber" from "correlation_data_test_case_2" topic within 5 seconds
+
     And I clear message storage
+
+    # 36. test case when correlation data in publish is not set but expected in received message
     And I reset MQTT publish 'correlation data'
-    And I reset expected 'correlation data'
+    And I set the 'correlation data' in expected received messages to "correlation_data_3"
+
+    When I subscribe "subscriber" to "correlation_data_test_case_3" with qos 0
+    When I publish from "publisher" to "correlation_data_test_case_3" with qos 0 and message "Message without correlation data 3"
+    And message "Message without correlation data 3" is not received on "subscriber" from "correlation_data_test_case_3" topic within 10 seconds
+
+    And I clear message storage
+
+    # 37. test case when correlation data in pulish and receive are not the same
+    And I set MQTT publish 'correlation data' to "correlation_data_4"
+    And I set the 'correlation data' in expected received messages to "correlation_data_5"
+
+    When I subscribe "subscriber" to "correlation_data_test_case_4" with qos 0
+    When I publish from "publisher" to "correlation_data_test_case_4" with qos 0 and message "Message with correlation data 4"
+    And message "Message with correlation data 4" is not received on "subscriber" from "correlation_data_test_case_4" topic within 10 seconds
+
+    And I clear message storage and reset all MQTT settings to default
+
+    # request response information is a CONNECT packet property
     And I disconnect device "publisher" with reason code 0
 
     # K. test 'request response information' feature
 
-    # 32. test case when connect with 'request response information' flag set to true
+    # 38. test case when connect with 'request response information' flag set to true
     #  unfortunately IoT Core and EMQX brokers does not provide 'Response Information' in CONNACK so we can only test connection is OK
     And I set 'request response information' to true
     And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
@@ -1598,7 +1655,7 @@ Feature: GGMQ-1
     And I clear message storage
     And I disconnect device "publisher" with reason code 0
 
-    # 33. test case when connect with 'request response information' flag set to false
+    # 39. test case when connect with 'request response information' flag set to false
     And I set 'request response information' to false
     And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
 


### PR DESCRIPTION
**Issue #, if available:**
Add test cases to T102 for request/response features

**Description of changes:**
- Add steps to set/reset clean session, keep alive, request response information, response topic tx/rx, correlation data tx/rx
- Add test cases for reponse topic, correlation data and request response information to T102 scenario outline
- Add response topic and correlation data to EventFilter
- Fix unhandled exception and tune logging in paho java client

**Why is this change necessary:**
Automatically test steps, clients and local broker with some new MQTT v5.0 features

**How was this change tested:**
Automatically run scenarios on CodeBuild 

**Test results:**
```
[INFO ] 2023-07-12 19:51:25.453 [main] StepTrackingReporting - Passed: 'GGMQ-1-T102-v5-sdk-java: As a customer, I can use new MQTT v5.0 features'
[INFO ] 2023-07-12 19:51:25.453 [main] StepTrackingReporting - Passed: 'GGMQ-1-T102-v5-mosquitto-c: As a customer, I can use new MQTT v5.0 features'
[INFO ] 2023-07-12 19:51:25.453 [main] StepTrackingReporting - Passed: 'GGMQ-1-T102-v5-paho-java: As a customer, I can use new MQTT v5.0 features'
[INFO ] 2023-07-12 19:51:25.453 [main] StepTrackingReporting - Passed: 'GGMQ-1-T102-v5-paho-python: As a customer, I can use new MQTT v5.0 features'
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
