### PR TITLE
feat(uat): windows build python paho client

### DIFF
--- a/uat/custom-components/client-python-paho/scripts/build.sh
+++ b/uat/custom-components/client-python-paho/scripts/build.sh
@@ -17,7 +17,7 @@ pip3 install -r requirements.txt
 python3 -m grpc_tools.protoc -I../../../proto --python_out=../src/grpc_client_server/grpc_generated --pyi_out=../src/grpc_client_server/grpc_generated --grpc_python_out=../src/grpc_client_server/grpc_generated ../../../proto/mqtt_client_control.proto
 python3 fix_generated.py
 pyinstaller client-python-paho.spec
-mv dist/client-python-paho ../
+mv dist/client-python-paho ../client-python-paho.exe
 rm -r dist
 rm -r build
 cd $STARTDIR

--- a/uat/testing-features/pom.xml
+++ b/uat/testing-features/pom.xml
@@ -27,7 +27,7 @@
             </activation>
             <properties>
                 <mosquitto.agent.artifact>mosquitto-test-client.amd64.tar.gz</mosquitto.agent.artifact>
-                <paho.python.agent.artifact>client-python-paho</paho.python.agent.artifact>
+                <paho.python.agent.artifact>client-python-paho.exe</paho.python.agent.artifact>
             </properties>
         </profile>
         <profile>

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -87,7 +87,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                    | subscribe-status-q1 |
       | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml     | GRANTED_QOS_0       |
 
-    @mqtt3 @paho-python @SkipOnWindows
+    @mqtt3 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  | subscribe-status-q1 |
       | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | GRANTED_QOS_1       |
@@ -107,7 +107,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                    | subscribe-status-q1 |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml     | GRANTED_QOS_1       |
 
-    @mqtt5 @paho-python @SkipOnWindows
+    @mqtt5 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  | subscribe-status-q1 |
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | GRANTED_QOS_1       |
@@ -243,7 +243,7 @@ Feature: GGMQ-1
       | mqtt-v | name     | agent                                        | recipe                    | iot_data_1-publish | subscribe-status-q1 |
       | v3     | sdk-java | aws.greengrass.client.Mqtt5JavaSdkClient     | client_java_sdk.yaml      | 0                  | GRANTED_QOS_0       |
 
-    @mqtt3 @paho-python @SkipOnWindows
+    @mqtt3 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  | iot_data_1-publish | subscribe-status-q1 |
       | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | 0                  | GRANTED_QOS_1       |
@@ -253,7 +253,7 @@ Feature: GGMQ-1
       | mqtt-v | name     | agent                                        | recipe                    | iot_data_1-publish | subscribe-status-q1 |
       | v5     | sdk-java | aws.greengrass.client.Mqtt5JavaSdkClient     | client_java_sdk.yaml      | 135                | GRANTED_QOS_1       |
 
-    @mqtt5 @paho-python @SkipOnWindows
+    @mqtt5 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  | iot_data_1-publish | subscribe-status-q1 |
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | 0                  | GRANTED_QOS_1       |
@@ -402,7 +402,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
-    @mqtt3 @paho-python @SkipOnWindows
+    @mqtt3 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
@@ -422,7 +422,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
-    @mqtt5 @paho-python @SkipOnWindows
+    @mqtt5 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
@@ -548,7 +548,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
-    @mqtt3 @paho-python @SkipOnWindows
+    @mqtt3 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
@@ -568,7 +568,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
-    @mqtt5 @paho-python @SkipOnWindows
+    @mqtt5 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
@@ -748,7 +748,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                    | subscribe-status-na | subscribe-status-good | publish-status-nms |
       | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml     | GRANTED_QOS_0       | GRANTED_QOS_0         | 0                  |
 
-    @mqtt3 @paho-python @SkipOnWindows
+    @mqtt3 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
       | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | UNSPECIFIED_ERROR   | GRANTED_QOS_1         | 0                  |
@@ -768,7 +768,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                     | recipe                    | subscribe-status-na | subscribe-status-good | publish-status-nms |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient | client_java_paho.yaml     | NOT_AUTHORIZED      | GRANTED_QOS_1         | 16                 |
 
-    @mqtt5 @paho-python @SkipOnWindows
+    @mqtt5 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  | subscribe-status-na | subscribe-status-good | publish-status-nms |
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | NOT_AUTHORIZED      | GRANTED_QOS_1         | 0                  |
@@ -897,7 +897,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
-    @mqtt3 @paho-python @SkipOnWindows
+    @mqtt3 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
@@ -917,7 +917,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
-    @mqtt5 @paho-python @SkipOnWindows
+    @mqtt5 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
@@ -1045,7 +1045,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
-    @mqtt3 @paho-python @SkipOnWindows
+    @mqtt3 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
@@ -1065,7 +1065,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
-    @mqtt5 @paho-python @SkipOnWindows
+    @mqtt5 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
@@ -1202,7 +1202,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
-    @mqtt3 @paho-python @SkipOnWindows
+    @mqtt3 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
@@ -1222,7 +1222,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
-    @mqtt5 @paho-python @SkipOnWindows
+    @mqtt5 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
@@ -1313,7 +1313,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
-    @mqtt3 @paho-python @SkipOnWindows
+    @mqtt3 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
@@ -1835,7 +1835,7 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  | publish-status-nms |
       | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   | 16                 |
 
-    @mqtt5 @paho-python @SkipOnWindows
+    @mqtt5 @paho-python
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  | publish-status-nms |
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | 0                  |

--- a/uat/testing-features/src/main/resources/local-store/recipes/client_python_paho.yaml
+++ b/uat/testing-features/src/main/resources/local-store/recipes/client_python_paho.yaml
@@ -17,11 +17,10 @@ ComponentConfiguration:
     controlPort: 47619
 Manifests:
   - Artifacts:
-      - URI: classpath:/local-store/artifacts/client-python-paho
+      - URI: classpath:/local-store/artifacts/client-python-paho.exe
         Permission:
           Read: ALL
           Execute: OWNER
     Lifecycle:
       Run: |
-        {artifacts:path}/client-python-paho "{configuration:/agentId}" "{configuration:/controlPort}" {configuration:/controlAddresses}
-# Only linux support at this moment
+        {artifacts:path}/client-python-paho.exe "{configuration:/agentId}" "{configuration:/controlPort}" {configuration:/controlAddresses}


### PR DESCRIPTION
**Description of changes:**
-Update Python Paho client building system to make it possible running scenarios on Windows

**Why is this change necessary:**
Test all scenarios with Python Paho client on Windows

**How was this change tested:**
Run scenarios locally on Windows

**Test results:**
```
[INFO ] 2023-07-17 14:53:00.815 [main] StepTrackingReporting - Passed: 'GGMQ-1-T1-v3-paho-python: As a customer, I can connect, subscribe/publish at QoS 0 and 1 and receive using client application to MQTT topic'
[INFO ] 2023-07-17 14:53:00.815 [main] StepTrackingReporting - Passed: 'GGMQ-1-T1-v5-paho-python: As a customer, I can connect, subscribe/publish at QoS 0 and 1 and receive using client application to MQTT topic'
[INFO ] 2023-07-17 14:53:00.816 [main] StepTrackingReporting - Passed: 'GGMQ-1-T2-v3-paho-python: GGAD can publish to an MQTT topic at QoS 0 and QoS 1 based on CDA configuration'
[INFO ] 2023-07-17 14:53:00.816 [main] StepTrackingReporting - Passed: 'GGMQ-1-T2-v5-paho-python: GGAD can publish to an MQTT topic at QoS 0 and QoS 1 based on CDA configuration'
[INFO ] 2023-07-17 14:53:00.816 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v3-paho-python: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'
[INFO ] 2023-07-17 14:53:00.817 [main] StepTrackingReporting - Passed: 'GGMQ-1-T8-v5-paho-python: As a customer, I can configure local MQTT messages to be forwarded to a PubSub topic'
[INFO ] 2023-07-17 14:53:00.817 [main] StepTrackingReporting - Passed: 'GGMQ-1-T9-v3-paho-python: As a customer,I can configure local MQTT messages to be forwarded to an IoT Core MQTT topic'
[INFO ] 2023-07-17 14:53:00.817 [main] StepTrackingReporting - Passed: 'GGMQ-1-T9-v5-paho-python: As a customer,I can configure local MQTT messages to be forwarded to an IoT Core MQTT topic'
[INFO ] 2023-07-17 14:53:00.818 [main] StepTrackingReporting - Passed: 'GGMQ-1-T13-v3-paho-python: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration'
[INFO ] 2023-07-17 14:53:00.818 [main] StepTrackingReporting - Passed: 'GGMQ-1-T13-v5-paho-python: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration'
[INFO ] 2023-07-17 14:53:00.819 [main] StepTrackingReporting - Passed: 'GGMQ-1-T14-v3-paho-python: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic'
[INFO ] 2023-07-17 14:53:00.819 [main] StepTrackingReporting - Passed: 'GGMQ-1-T14-v5-paho-python: As a customer, I can configure IoT Core messages to be forwarded to local MQTT topic'
[INFO ] 2023-07-17 14:53:00.819 [main] StepTrackingReporting - Passed: 'GGMQ-1-T15-v3-paho-python: As a customer, I can configure Pubsub messages to be forwarded to local MQTT topic'
[INFO ] 2023-07-17 14:53:00.820 [main] StepTrackingReporting - Passed: 'GGMQ-1-T15-v5-paho-python: As a customer, I can configure Pubsub messages to be forwarded to local MQTT topic'
[INFO ] 2023-07-17 14:53:00.820 [main] StepTrackingReporting - Passed: 'GGMQ-1-T20-v3-paho-python: As a customer, I can associate and connect GGADs with GGC over custom port'
[INFO ] 2023-07-17 14:53:00.820 [main] StepTrackingReporting - Passed: 'GGMQ-1-T20-v5-paho-python: As a customer, I can associate and connect GGADs with GGC over custom port'
[INFO ] 2023-07-17 14:53:00.821 [main] StepTrackingReporting - Passed: 'GGMQ-1-T101-v3-paho-python: As a customer, I can use publish retain flag using MQTT V3.1.1'
[INFO ] 2023-07-17 14:53:00.821 [main] StepTrackingReporting - Passed: 'GGMQ-1-T102-v5-paho-python: As a customer, I can use new MQTT v5.0 features'
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
