### PR TITLE
feat(uat): implement ggmq scenario based on GGAD-1-T24

### DIFF
--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1409,9 +1409,9 @@ Feature: GGMQ-1
     And I connect device "publisher" on <agent> to "default_broker" using mqtt "<mqtt-v>"
     And I connect device "subscriber" on <agent> to "default_broker" using mqtt "<mqtt-v>"
 
-    When I subscribe "subscriber" to "iot_data_0" with qos 1 and expect status "<subscribe-status-q1>"
+    When I subscribe "subscriber" to "iot_data_0" with qos 1
     When I publish from "publisher" to "iot_data_0" with qos 1 and message "Test message0" and expect status 0
-    And message "Test message0" received on "subscriber" from "iot_data_0" topic within 10 seconds
+    And message "Test message0" received on "subscriber" from "iot_data_0" topic within 5 seconds
 
     # Reset CDA configuration
     And I update my local deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:
@@ -1420,7 +1420,7 @@ Feature: GGMQ-1
    "RESET":[""]
 }
     """
-    Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
+    Then the local Greengrass deployment is SUCCEEDED on the device within 120 seconds
 
     Then I wait 65 seconds
     When I publish from "publisher" to "iot_data_0" with qos 1 and message "Test message1" and expect status <publish-status-na>
@@ -1456,52 +1456,52 @@ Feature: GGMQ-1
     }
 }
     """
-    Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
+    Then the local Greengrass deployment is SUCCEEDED on the device within 120 seconds
 
     Then I wait 65 seconds
 
     When I publish from "publisher" to "iot_data_0" with qos 1 and message "Config update works" and expect status 0
-    And message "Config update works" received on "subscriber" from "iot_data_0" topic within 10 seconds
+    And message "Config update works" received on "subscriber" from "iot_data_0" topic within 5 seconds
 
     @mqtt3 @sdk-java
     Examples:
-      | mqtt-v | name        | agent                                       | recipe                  | publish-status-na | subscribe-status-q1 |
-      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient    | client_java_sdk.yaml    | 0                 | GRANTED_QOS_0       |
+      | mqtt-v | name        | agent                                       | recipe                  | publish-status-na |
+      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient    | client_java_sdk.yaml    | 0                 |
 
     @mqtt3 @mosquitto-c @SkipOnWindows
     Examples:
-      | mqtt-v | name        | agent                                       | recipe                  | publish-status-na | subscribe-status-q1 |
-      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml | 0                 | GRANTED_QOS_1       |
+      | mqtt-v | name        | agent                                       | recipe                  | publish-status-na |
+      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml | 0                 |
 
     @mqtt3 @paho-java
     Examples:
-      | mqtt-v | name        | agent                                       | recipe                  | publish-status-na | subscribe-status-q1 |
-      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   | 0                 | GRANTED_QOS_0       |
+      | mqtt-v | name        | agent                                       | recipe                  | publish-status-na |
+      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   | 0                 |
 
     @mqtt3 @paho-python @SkipOnWindows
     Examples:
-      | mqtt-v | name        | agent                                       | recipe                  | publish-status-na | subscribe-status-q1 |
-      | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | 0                 | GRANTED_QOS_1       |
+      | mqtt-v | name        | agent                                       | recipe                  | publish-status-na |
+      | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | 0                 |
 
     @mqtt5 @sdk-java
     Examples:
-      | mqtt-v | name        | agent                                       | recipe                  | publish-status-na | subscribe-status-q1 |
-      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient    | client_java_sdk.yaml    | 135               | GRANTED_QOS_1       |
+      | mqtt-v | name        | agent                                       | recipe                  | publish-status-na |
+      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient    | client_java_sdk.yaml    | 135               |
 
     @mqtt5 @mosquitto-c @SkipOnWindows
     Examples:
-      | mqtt-v | name        | agent                                       | recipe                  | publish-status-na | subscribe-status-q1 |
-      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml | 135               | GRANTED_QOS_1       |
+      | mqtt-v | name        | agent                                       | recipe                  | publish-status-na |
+      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml | 135               |
 
     @mqtt5 @paho-java
     Examples:
-      | mqtt-v | name        | agent                                       | recipe                  | publish-status-na | subscribe-status-q1 |
-      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   | 135               | GRANTED_QOS_1       |
+      | mqtt-v | name        | agent                                       | recipe                  | publish-status-na |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   | 135               |
 
     @mqtt5 @paho-python @SkipOnWindows
     Examples:
-      | mqtt-v | name        | agent                                       | recipe                  | publish-status-na | subscribe-status-q1 |
-      | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | 0                 | GRANTED_QOS_1       |
+      | mqtt-v | name        | agent                                       | recipe                  | publish-status-na |
+      | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | 0                 |
 
   @GGMQ-1-T101
   Scenario Outline: GGMQ-1-T101-<mqtt-v>-<name>: As a customer, I can use publish retain flag using MQTT V3.1.1

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1420,8 +1420,9 @@ Feature: GGMQ-1
    "RESET":[""]
 }
     """
-    Then the local Greengrass deployment is SUCCEEDED on the device after 65 seconds
+    Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
 
+    Then I wait 65 seconds
     When I publish from "publisher" to "iot_data_0" with qos 1 and message "Test message1" and expect status <publish-status-na>
     And message "Test message1" is not received on "subscriber" from "iot_data_0" topic within 10 seconds
 
@@ -1455,7 +1456,9 @@ Feature: GGMQ-1
     }
 }
     """
-    Then the local Greengrass deployment is SUCCEEDED on the device after 65 seconds
+    Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
+
+    Then I wait 65 seconds
 
     When I publish from "publisher" to "iot_data_0" with qos 1 and message "Config update works" and expect status 0
     And message "Config update works" received on "subscriber" from "iot_data_0" topic within 5 seconds

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1348,6 +1348,161 @@ Feature: GGMQ-1
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
 
 
+  @GGMQ-1-T24
+  Scenario Outline: GGMQ-1-T24-<mqtt-v>-<name>: As a customer, I can reset CDA config and update it and CDA will use the new config
+    When I create a Greengrass deployment with components
+      | aws.greengrass.clientdevices.Auth        | LATEST                                  |
+      | aws.greengrass.clientdevices.mqtt.EMQX   | LATEST                                  |
+      | aws.greengrass.clientdevices.IPDetector  | LATEST                                  |
+      | aws.greengrass.Cli                       | LATEST                                  |
+      | <agent>                                  | classpath:/local-store/recipes/<recipe> |
+    And I create client device "publisher"
+    And I create client device "subscriber"
+
+    And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:
+    """
+{
+    "MERGE":{
+        "deviceGroups":{
+            "formatVersion":"2021-03-05",
+            "definitions":{
+                "MyPermissiveDeviceGroup":{
+                    "selectionRule":"thingName: ${publisher} OR thingName: ${subscriber}",
+                    "policyName":"MyPermissivePolicy"
+                }
+            },
+            "policies":{
+                "MyPermissivePolicy":{
+                    "AllowAll":{
+                        "statementDescription":"Allow client devices to perform all actions.",
+                        "operations":[
+                            "*"
+                        ],
+                        "resources":[
+                            "*"
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}
+    """
+
+    And I update my Greengrass deployment configuration, setting the component <agent> configuration to:
+    """
+{
+    "MERGE":{
+        "controlAddresses":"${mqttControlAddresses}",
+        "controlPort":"${mqttControlPort}"
+    }
+}
+    """
+    When I associate "publisher" with ggc
+    When I associate "subscriber" with ggc
+
+    And I deploy the Greengrass deployment configuration
+    Then the Greengrass deployment is COMPLETED on the device after 5 minutes
+    And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes
+
+    And I discover core device broker as "default_broker" from "publisher" in OTF
+    And I connect device "publisher" on <agent> to "default_broker" using mqtt "<mqtt-v>"
+    And I connect device "subscriber" on <agent> to "default_broker" using mqtt "<mqtt-v>"
+
+    When I subscribe "subscriber" to "iot_data_0" with qos 1 and expect status "<subscribe-status-q1>"
+    When I publish from "publisher" to "iot_data_0" with qos 1 and message "Test message0" and expect status 0
+    And message "Test message0" received on "subscriber" from "iot_data_0" topic within 10 seconds
+
+    # Reset CDA configuration
+    And I update my local deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:
+    """
+{
+   "RESET":[""]
+}
+    """
+    Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
+
+    Then I wait 65 seconds
+    When I publish from "publisher" to "iot_data_0" with qos 1 and message "Test message1" and expect status <publish-status-na>
+    And message "Test message1" is not received on "subscriber" from "iot_data_0" topic within 10 seconds
+
+    # Restore CDA configuration
+    And I update my local deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:
+    """
+{
+    "MERGE":{
+        "deviceGroups":{
+            "formatVersion":"2021-03-05",
+            "definitions":{
+                "MyPermissiveDeviceGroup":{
+                    "selectionRule":"thingName: ${publisher} OR thingName: ${subscriber}",
+                    "policyName":"MyPermissivePolicy"
+                }
+            },
+            "policies":{
+                "MyPermissivePolicy":{
+                    "AllowAll":{
+                        "statementDescription":"Allow client devices to perform all actions.",
+                        "operations":[
+                            "*"
+                        ],
+                        "resources":[
+                            "*"
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}
+    """
+    Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
+
+    Then I wait 65 seconds
+
+    When I publish from "publisher" to "iot_data_0" with qos 1 and message "Config update works" and expect status 0
+    And message "Config update works" received on "subscriber" from "iot_data_0" topic within 10 seconds
+
+    @mqtt3 @sdk-java
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  | publish-status-na | subscribe-status-q1 |
+      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient    | client_java_sdk.yaml    | 0                 | GRANTED_QOS_0       |
+
+    @mqtt3 @mosquitto-c @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  | publish-status-na | subscribe-status-q1 |
+      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml | 0                 | GRANTED_QOS_1       |
+
+    @mqtt3 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  | publish-status-na | subscribe-status-q1 |
+      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   | 0                 | GRANTED_QOS_0       |
+
+    @mqtt3 @paho-python @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  | publish-status-na | subscribe-status-q1 |
+      | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | 0                 | GRANTED_QOS_1       |
+
+    @mqtt5 @sdk-java
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  | publish-status-na | subscribe-status-q1 |
+      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient    | client_java_sdk.yaml    | 135               | GRANTED_QOS_1       |
+
+    @mqtt5 @mosquitto-c @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  | publish-status-na | subscribe-status-q1 |
+      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml | 135               | GRANTED_QOS_1       |
+
+    @mqtt5 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  | publish-status-na | subscribe-status-q1 |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   | 135               | GRANTED_QOS_1       |
+
+    @mqtt5 @paho-python @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  | publish-status-na | subscribe-status-q1 |
+      | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | 0                 | GRANTED_QOS_1       |
+
   @GGMQ-1-T101
   Scenario Outline: GGMQ-1-T101-<mqtt-v>-<name>: As a customer, I can use publish retain flag using MQTT V3.1.1
     When I create a Greengrass deployment with components

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1420,9 +1420,8 @@ Feature: GGMQ-1
    "RESET":[""]
 }
     """
-    Then the local Greengrass deployment is SUCCEEDED on the device within 120 seconds
+    Then the local Greengrass deployment is SUCCEEDED on the device after 65 seconds
 
-    Then I wait 65 seconds
     When I publish from "publisher" to "iot_data_0" with qos 1 and message "Test message1" and expect status <publish-status-na>
     And message "Test message1" is not received on "subscriber" from "iot_data_0" topic within 10 seconds
 
@@ -1456,9 +1455,7 @@ Feature: GGMQ-1
     }
 }
     """
-    Then the local Greengrass deployment is SUCCEEDED on the device within 120 seconds
-
-    Then I wait 65 seconds
+    Then the local Greengrass deployment is SUCCEEDED on the device after 65 seconds
 
     When I publish from "publisher" to "iot_data_0" with qos 1 and message "Config update works" and expect status 0
     And message "Config update works" received on "subscriber" from "iot_data_0" topic within 5 seconds


### PR DESCRIPTION
**Description of changes:**
- Add T24 scenario

**Why is this change necessary:**
Implement scenarios

**How was this change tested:**
Run scenario locally

**Test results:**
```
Given my device is registered as a Thing....................................passed
And my device is running Greengrass.........................................passed
When I create a Greengrass deployment with components.......................passed
And I create client device "publisher"......................................passed
And I create client device "subscriber".....................................passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:.passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.client.Mqtt5JavaSdkClient configuration to:.passed
When I associate "publisher" with ggc.......................................passed
When I associate "subscriber" with ggc......................................passed
And I deploy the Greengrass deployment configuration........................passed
Then the Greengrass deployment is COMPLETED on the device after 5 minutes...passed
And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes.passed
And I discover core device broker as "default_broker" from "publisher" in OTF.passed
And I connect device "publisher" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker" using mqtt "v3".passed
And I connect device "subscriber" on aws.greengrass.client.Mqtt5JavaSdkClient to "default_broker" using mqtt "v3".passed
When I subscribe "subscriber" to "iot_data_0" with qos 1....................passed
When I publish from "publisher" to "iot_data_0" with qos 1 and message "Test message0" and expect status 0.passed
And message "Test message0" received on "subscriber" from "iot_data_0" topic within 5 seconds.passed
And I update my local deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:.passed
Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds.passed
Then I wait 65 seconds......................................................passed
When I publish from "publisher" to "iot_data_0" with qos 1 and message "Test message1" and expect status 0.passed
And message "Test message1" is not received on "subscriber" from "iot_data_0" topic within 10 seconds.passed
And I update my local deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:.passed
Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds.passed
Then I wait 65 seconds......................................................passed
When I publish from "publisher" to "iot_data_0" with qos 1 and message "Config update works" and expect status 0.passed
And message "Config update works" received on "subscriber" from "iot_data_0" topic within 5 seconds.passed
```
All clients:
```
[INFO ] 2023-07-20 18:14:25.209 [main] StepTrackingReporting - Passed: 'GGMQ-1-T24-v3-sdk-java: As a customer, I can reset CDA config and update it and CDA will use the new config'
[INFO ] 2023-07-20 18:14:25.209 [main] StepTrackingReporting - Passed: 'GGMQ-1-T24-v3-mosquitto-c: As a customer, I can reset CDA config and update it and CDA will use the new config'
[INFO ] 2023-07-20 18:14:25.209 [main] StepTrackingReporting - Passed: 'GGMQ-1-T24-v3-paho-java: As a customer, I can reset CDA config and update it and CDA will use the new config'
[INFO ] 2023-07-20 18:14:25.209 [main] StepTrackingReporting - Passed: 'GGMQ-1-T24-v3-paho-python: As a customer, I can reset CDA config and update it and CDA will use the new config'
[INFO ] 2023-07-20 18:14:25.209 [main] StepTrackingReporting - Passed: 'GGMQ-1-T24-v5-sdk-java: As a customer, I can reset CDA config and update it and CDA will use the new config'
[INFO ] 2023-07-20 18:14:25.209 [main] StepTrackingReporting - Passed: 'GGMQ-1-T24-v5-mosquitto-c: As a customer, I can reset CDA config and update it and CDA will use the new config'
[INFO ] 2023-07-20 18:14:25.209 [main] StepTrackingReporting - Passed: 'GGMQ-1-T24-v5-paho-java: As a customer, I can reset CDA config and update it and CDA will use the new config'
[INFO ] 2023-07-20 18:14:25.209 [main] StepTrackingReporting - Passed: 'GGMQ-1-T24-v5-paho-python: As a customer, I can reset CDA config and update it and CDA will use the new config'
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
