### PR TITLE
fix(uat): bypass send DISCONNECT on dead connection in SDK client

### DIFF
--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
@@ -212,11 +212,11 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
 
         checkUserProperties(userProperties);
 
-        if (!isClosing.getAndSet(true)) {
+        if (isClosing.compareAndSet(false, true)) {
             try {
                 final long deadline = System.nanoTime() + timeout * 1_000_000_000;
 
-                if (isConnected.get()) {
+                if (isConnected.compareAndSet(true, false)) {
                     CompletableFuture<Void> disconnnectFuture = connection.disconnect();
                     disconnnectFuture.get(timeout, TimeUnit.SECONDS);
                 } else {

--- a/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-sdk/src/main/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImpl.java
@@ -211,12 +211,17 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
     public void disconnect(long timeout, int reasonCode, List<Mqtt5Properties> userProperties) throws MqttException {
 
         checkUserProperties(userProperties);
+
         if (!isClosing.getAndSet(true)) {
-            CompletableFuture<Void> disconnnectFuture = connection.disconnect();
             try {
                 final long deadline = System.nanoTime() + timeout * 1_000_000_000;
 
-                disconnnectFuture.get(timeout, TimeUnit.SECONDS);
+                if (isConnected.get()) {
+                    CompletableFuture<Void> disconnnectFuture = connection.disconnect();
+                    disconnnectFuture.get(timeout, TimeUnit.SECONDS);
+                } else {
+                    logger.atWarn().log("DISCONNECT was not sent on the dead connection");
+                }
 
                 long remaining = deadline - System.nanoTime();
                 if (remaining < MIN_SHUTDOWN_NS) {

--- a/uat/custom-components/client-java-sdk/src/test/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImplTest.java
+++ b/uat/custom-components/client-java-sdk/src/test/java/com/aws/greengrass/testing/mqtt311/client/sdkmqtt/Mqtt311ConnectionImplTest.java
@@ -135,6 +135,9 @@ class Mqtt311ConnectionImplTest {
         when(connection.disconnect()).thenReturn(connectFuture);
         connectFuture.complete(null);
 
+        // move to connected state
+        mqttConnectionImpl.connectionEvents.onConnectionResumed(true);
+
         // WHEN
         mqttConnectionImpl.disconnect(timeoutSeconds, reasonCode, null);
 
@@ -151,6 +154,9 @@ class Mqtt311ConnectionImplTest {
 
         final CompletableFuture<Void> connectFuture = new CompletableFuture<>();
         when(connection.disconnect()).thenReturn(connectFuture);
+
+        // move to connected state
+        mqttConnectionImpl.connectionEvents.onConnectionResumed(true);
 
         // WHEN, THEN
         assertThrows(MqttException.class, () -> {

--- a/uat/custom-components/client-java-sdk/src/test/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttConnectionImplTest.java
+++ b/uat/custom-components/client-java-sdk/src/test/java/com/aws/greengrass/testing/mqtt5/client/sdkmqtt/MqttConnectionImplTest.java
@@ -254,6 +254,9 @@ class MqttConnectionImplTest {
 
         mqttConnectionImpl.lifecycleEvents.onStopped(client, onStoppedReturn);
 
+        // move to connected state
+        mqttConnectionImpl.lifecycleEvents.onConnectionSuccess(client, null);
+
         // WHEN
         mqttConnectionImpl.disconnect(timeoutSeconds, reasonCode, null);
 
@@ -272,6 +275,9 @@ class MqttConnectionImplTest {
         // GIVEN
         final long timeoutSeconds = SHORT_TIMEOUT_SEC;
         final int reasonCode = 4;
+
+        // move to connected state
+        mqttConnectionImpl.lifecycleEvents.onConnectionSuccess(client, null);
 
         // WHEN
         assertThrows(MqttException.class, () -> {


### PR DESCRIPTION
**Issue #, if available:**
Different behaviors between mqtt3 and mqtt5 when shutting down closed connection

**Description of changes:**
- Bypass calling disconnect() on library client when connection is not connected
- Log warning "DISCONNECT was not sent on the dead connection" instead of disconnect() in such cases
- Update unit tests to move objects to 'connected' state
- Fix error when waiting for closed but close() is not called yet

**Why is this change necessary:**
SDK MQTT v3 client throw an exception while try to call disconnect() on connection dropped by broker.
The same time SDK MQTT v5 client pass as usual.
To avoid control confuse we need to unify client behavior despite of MQTT version.
 
**How was this change tested:**
Manually by terminate local mosquitto broker after client has been connected

MQTT v3.1.1
Control:
```
$ ./run_for_mosquitto_311.sh
[INFO ] 2023-07-21 21:44:11.158 [main] ExampleControl - Control: port 47619, with TLS, MQTT v3
[INFO ] 2023-07-21 21:44:11.386 [main] EngineControlImpl - MQTT client control gRPC server started, listening on 47619
[INFO ] 2023-07-21 21:44:25.953 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId sdk-java-agent
[INFO ] 2023-07-21 21:44:26.013 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId sdk-java-agent address 127.0.0.1 port 44581
[INFO ] 2023-07-21 21:44:26.016 [grpc-default-executor-0] EngineControlImpl - Created new agent control for sdk-java-agent on 127.0.0.1:44581
[INFO ] 2023-07-21 21:44:26.059 [grpc-default-executor-0] ExampleControl - Agent sdk-java-agent is connected
[INFO ] 2023-07-21 21:44:26.064 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id sdk-java-agent
[INFO ] 2023-07-21 21:44:29.645 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
'
[INFO ] 2023-07-21 21:44:29.646 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-07-21 21:44:29.646 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-07-21 21:44:34.022 [grpc-default-executor-0] GRPCDiscoveryServer - OnMqttDisconnect: agentId sdk-java-agent connectionId 1 disconnect '' error 'The connection was closed unexpectedly.'
[INFO ] 2023-07-21 21:44:34.023 [grpc-default-executor-0] AgentTestScenario - MQTT disconnected on agentId sdk-java-agent connectionId 1 disconnect '' error 'The connection was closed unexpectedly.'
[INFO ] 2023-07-21 21:44:34.656 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[ERROR] 2023-07-21 21:44:34.676 [pool-2-thread-1] AgentTestScenario - gRPC error code UNKNOWN: description: null
io.grpc.StatusRuntimeException: UNKNOWN
        at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:271) ~[grpc-stub-1.53.0.jar:1.53.0]
        at io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:252) ~[grpc-stub-1.53.0.jar:1.53.0]
        at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:165) ~[grpc-stub-1.53.0.jar:1.53.0]
        at com.aws.greengrass.testing.mqtt.client.MqttClientControlGrpc$MqttClientControlBlockingStub.subscribeMqtt(MqttClientControlGrpc.java:511) ~[aws-greengrass-testing-mqtt-client-control-1.0-SNAPSHOT.jar:?]
        at com.aws.greengrass.testing.mqtt.client.control.implementation.AgentControlImpl.subscribeMqtt(AgentControlImpl.java:224) ~[aws-greengrass-testing-mqtt-client-control-1.0-SNAPSHOT.jar:?]
        at com.aws.greengrass.testing.mqtt.client.control.implementation.ConnectionControlImpl.subscribeMqtt(ConnectionControlImpl.java:123) ~[aws-greengrass-testing-mqtt-client-control-1.0-SNAPSHOT.jar:?]
        at com.aws.greengrass.testing.mqtt.client.control.AgentTestScenario.testSubscribe(AgentTestScenario.java:255) ~[aws-greengrass-testing-mqtt-client-control-1.0-SNAPSHOT.jar:?]
        at com.aws.greengrass.testing.mqtt.client.control.AgentTestScenario.run(AgentTestScenario.java:183) [aws-greengrass-testing-mqtt-client-control-1.0-SNAPSHOT.jar:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:834) [?:?]
[INFO ] 2023-07-21 21:44:34.700 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-07-21 21:44:34.702 [pool-2-thread-1] AgentControlImpl - sending shutdown request
[INFO ] 2023-07-21 21:44:34.708 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-07-21 21:44:34.719 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId sdk-java-agent reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-07-21 21:44:34.719 [grpc-default-executor-0] AgentControlImpl - shutting down channel with agent id sdk-java-agent
[INFO ] 2023-07-21 21:44:34.721 [grpc-default-executor-0] AgentControlImpl - channel terminated with agent id sdk-java-agent
[INFO ] 2023-07-21 21:44:34.721 [grpc-default-executor-0] ExampleControl - Agent sdk-java-agent is disconnected
```
SDK client:
```
[INFO ] 2023-07-21 21:44:25.472 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Making gPRC client connection with 127.0.0.1:47619 as sdk-java-agent...
[INFO ] 2023-07-21 21:44:25.975 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Client connection with Control is established, local address is 127.0.0.1
[INFO ] 2023-07-21 21:44:26.008 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - GRPCControlServer created and listed on 127.0.0.1:44581
[INFO ] 2023-07-21 21:44:26.069 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Handle gRPC requests
[INFO ] 2023-07-21 21:44:26.069 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - Server awaitTermination
[INFO ] 2023-07-21 21:44:29.174 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId client broker server:8883
[INFO ] 2023-07-21 21:44:29.178 [grpc-default-executor-0] Mqtt311ConnectionImpl - Creating AwsIotMqttConnectionBuilder with TLS
[INFO ] 2023-07-21 21:44:29.528 [grpc-default-executor-0] Mqtt311ConnectionImpl - MQTT 3.1.1 connection 1 is establisted
[INFO ] 2023-07-21 21:44:29.528 [Thread-2] Mqtt311ConnectionImpl - MQTT connection 1 (re)connected, sessionPresent false
[INFO ] 2023-07-21 21:44:34.005 [Thread-2] Mqtt311ConnectionImpl - MQTT connection 1 interrupted, error code 5134: The connection was closed unexpectedly.
[INFO ] 2023-07-21 21:44:34.665 [grpc-default-executor-0] GRPCControlServer - Subscription: filter test/topic QoS 0 noLocal false retainAsPublished false retainHandling 2
[INFO ] 2023-07-21 21:44:34.665 [grpc-default-executor-0] GRPCControlServer - Subscribe: connectionId 1 subscriptionId null for 1 filters
[ERROR] 2023-07-21 21:44:34.666 [grpc-default-executor-0] GRPCControlServer - exception during subscribe
com.aws.greengrass.testing.mqtt5.client.exceptions.MqttException: MQTT client is not in connected state
        at com.aws.greengrass.testing.mqtt311.client.sdkmqtt.Mqtt311ConnectionImpl.stateCheck(Mqtt311ConnectionImpl.java:437) ~[classes/:?]
        at com.aws.greengrass.testing.mqtt311.client.sdkmqtt.Mqtt311ConnectionImpl.subscribe(Mqtt311ConnectionImpl.java:305) ~[classes/:?]
        at com.aws.greengrass.testing.mqtt5.client.grpc.GRPCControlServer$MqttClientControlImpl.subscribeMqtt(GRPCControlServer.java:516) [classes/:?]
        at com.aws.greengrass.testing.mqtt.client.MqttClientControlGrpc$MethodHandlers.invoke(MqttClientControlGrpc.java:659) [classes/:?]
        at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182) [grpc-stub-1.53.0.jar:1.53.0]
        at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:355) [grpc-core-1.53.0.jar:1.53.0]
        at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:867) [grpc-core-1.53.0.jar:1.53.0]
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37) [grpc-core-1.53.0.jar:1.53.0]
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133) [grpc-core-1.53.0.jar:1.53.0]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:834) [?:?]
[INFO ] 2023-07-21 21:44:34.696 [grpc-default-executor-0] GRPCControlServer - closeMqttConnection: connectionId 1 reason 4
[WARN ] 2023-07-21 21:44:34.696 [grpc-default-executor-0] Mqtt311ConnectionImpl - DISCONNECT was not sent on the dead connection
[INFO ] 2023-07-21 21:44:34.696 [grpc-default-executor-0] Mqtt311ConnectionImpl - MQTT 3.1.1 connection 1 has been disconnected
[INFO ] 2023-07-21 21:44:34.705 [grpc-default-executor-0] GRPCControlServer - shutdownAgent: reason That's it.
[INFO ] 2023-07-21 21:44:34.714 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - Server awaitTermination done
[INFO ] 2023-07-21 21:44:34.714 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Shutdown gPRC link
[INFO ] 2023-07-21 21:44:34.725 [com.aws.greengrass.testing.mqtt5.client.Main.main()] Main - Execution done successfully

```

MQTT v5
Control:
```
[INFO ] 2023-07-21 21:43:08.767 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] ExampleControl - Control: port 47619, with TLS, MQTT v5
[INFO ] 2023-07-21 21:43:08.978 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] EngineControlImpl - MQTT client control gRPC server started, listening on 47619
[INFO ] 2023-07-21 21:43:16.231 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId sdk-java-agent
[INFO ] 2023-07-21 21:43:16.292 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId sdk-java-agent address 127.0.0.1 port 44007
[INFO ] 2023-07-21 21:43:16.295 [grpc-default-executor-0] EngineControlImpl - Created new agent control for sdk-java-agent on 127.0.0.1:44007
[INFO ] 2023-07-21 21:43:16.337 [grpc-default-executor-0] ExampleControl - Agent sdk-java-agent is connected
[INFO ] 2023-07-21 21:43:16.340 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id sdk-java-agent
[INFO ] 2023-07-21 21:43:19.359 [pool-2-thread-1] AgentTestScenario - Set CONNECT user property: region, US
[INFO ] 2023-07-21 21:43:19.360 [pool-2-thread-1] AgentTestScenario - Set CONNECT user property: type, JSON
[INFO ] 2023-07-21 21:43:19.362 [pool-2-thread-1] AgentTestScenario - Set CONNECT request response information true
[INFO ] 2023-07-21 21:43:19.913 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
reasonCode: 0
receiveMaximum: 20
'
[INFO ] 2023-07-21 21:43:19.913 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-07-21 21:43:19.914 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-07-21 21:43:23.590 [grpc-default-executor-0] GRPCDiscoveryServer - OnMqttDisconnect: agentId sdk-java-agent connectionId 1 disconnect '' error 'The connection was closed unexpectedly.'
[INFO ] 2023-07-21 21:43:23.591 [grpc-default-executor-0] AgentTestScenario - MQTT disconnected on agentId sdk-java-agent connectionId 1 disconnect '' error 'The connection was closed unexpectedly.'
[INFO ] 2023-07-21 21:43:24.921 [pool-2-thread-1] AgentTestScenario - Set SUBSCRIBE user property: region, US
[INFO ] 2023-07-21 21:43:24.921 [pool-2-thread-1] AgentTestScenario - Set SUBSCRIBE user property: type, JSON
[INFO ] 2023-07-21 21:43:24.930 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[ERROR] 2023-07-21 21:43:24.977 [pool-2-thread-1] AgentTestScenario - gRPC error code UNKNOWN: description: null
io.grpc.StatusRuntimeException: UNKNOWN
        at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:271) ~[grpc-stub-1.53.0.jar:1.53.0]
        at io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:252) ~[grpc-stub-1.53.0.jar:1.53.0]
        at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:165) ~[grpc-stub-1.53.0.jar:1.53.0]
        at com.aws.greengrass.testing.mqtt.client.MqttClientControlGrpc$MqttClientControlBlockingStub.subscribeMqtt(MqttClientControlGrpc.java:511) ~[classes/:?]
        at com.aws.greengrass.testing.mqtt.client.control.implementation.AgentControlImpl.subscribeMqtt(AgentControlImpl.java:224) ~[classes/:?]
        at com.aws.greengrass.testing.mqtt.client.control.implementation.ConnectionControlImpl.subscribeMqtt(ConnectionControlImpl.java:123) ~[classes/:?]
        at com.aws.greengrass.testing.mqtt.client.control.AgentTestScenario.testSubscribe(AgentTestScenario.java:255) ~[classes/:?]
        at com.aws.greengrass.testing.mqtt.client.control.AgentTestScenario.run(AgentTestScenario.java:183) [classes/:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:834) [?:?]
[INFO ] 2023-07-21 21:43:24.986 [pool-2-thread-1] AgentTestScenario - Set DISCONNECT user property: region, US
[INFO ] 2023-07-21 21:43:24.986 [pool-2-thread-1] AgentTestScenario - Set DISCONNECT user property: type, JSON
[INFO ] 2023-07-21 21:43:25.002 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-07-21 21:43:25.005 [pool-2-thread-1] AgentControlImpl - sending shutdown request
[INFO ] 2023-07-21 21:43:25.014 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-07-21 21:43:25.029 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId sdk-java-agent reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-07-21 21:43:25.030 [grpc-default-executor-0] AgentControlImpl - shutting down channel with agent id sdk-java-agent
[INFO ] 2023-07-21 21:43:25.032 [grpc-default-executor-0] AgentControlImpl - channel terminated with agent id sdk-java-agent
[INFO ] 2023-07-21 21:43:25.032 [grpc-default-executor-0] ExampleControl - Agent sdk-java-agent is disconnected
```

Client
```[INFO ] 2023-07-21 21:43:15.768 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Making gPRC client connection with 127.0.0.1:47619 as sdk-java-agent...
[INFO ] 2023-07-21 21:43:16.252 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Client connection with Control is established, local address is 127.0.0.1
[INFO ] 2023-07-21 21:43:16.287 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - GRPCControlServer created and listed on 127.0.0.1:44007
[INFO ] 2023-07-21 21:43:16.343 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Handle gRPC requests
[INFO ] 2023-07-21 21:43:16.343 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - Server awaitTermination
[INFO ] 2023-07-21 21:43:19.445 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId client broker server:8883
[INFO ] 2023-07-21 21:43:19.450 [grpc-default-executor-0] MqttConnectionImpl - Creating Mqtt5Client with TLS
[INFO ] 2023-07-21 21:43:19.675 [grpc-default-executor-0] MqttConnectionImpl - CONNECT Tx user property 'region':'US'
[INFO ] 2023-07-21 21:43:19.675 [grpc-default-executor-0] MqttConnectionImpl - CONNECT Tx user property 'type':'JSON'
[INFO ] 2023-07-21 21:43:19.676 [grpc-default-executor-0] MqttConnectionImpl - CONNECT Tx request response information: true
[INFO ] 2023-07-21 21:43:19.711 [Thread-2] MqttConnectionImpl - MQTT connectionId 1 connecting...
[INFO ] 2023-07-21 21:43:19.803 [Thread-2] MqttConnectionImpl - MQTT connectionId 1 connected, client id client
[INFO ] 2023-07-21 21:43:23.577 [Thread-2] MqttConnectionImpl - MQTT connectionId 1 disconnected error 'The connection was closed unexpectedly.' disconnectPacket 'null'
[INFO ] 2023-07-21 21:43:24.953 [grpc-default-executor-0] GRPCControlServer - Subscription: filter test/topic QoS 0 noLocal false retainAsPublished false retainHandling 2
[INFO ] 2023-07-21 21:43:24.953 [grpc-default-executor-0] GRPCControlServer - Subscribe: connectionId 1 subscriptionId null for 1 filters
[ERROR] 2023-07-21 21:43:24.957 [grpc-default-executor-0] GRPCControlServer - exception during subscribe
com.aws.greengrass.testing.mqtt5.client.exceptions.MqttException: MQTT client is not in connected state
        at com.aws.greengrass.testing.mqtt5.client.sdkmqtt.MqttConnectionImpl.stateCheck(MqttConnectionImpl.java:526) ~[classes/:?]
        at com.aws.greengrass.testing.mqtt5.client.sdkmqtt.MqttConnectionImpl.subscribe(MqttConnectionImpl.java:392) ~[classes/:?]
        at com.aws.greengrass.testing.mqtt5.client.grpc.GRPCControlServer$MqttClientControlImpl.subscribeMqtt(GRPCControlServer.java:516) [classes/:?]
        at com.aws.greengrass.testing.mqtt.client.MqttClientControlGrpc$MethodHandlers.invoke(MqttClientControlGrpc.java:659) [classes/:?]
        at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182) [grpc-stub-1.53.0.jar:1.53.0]
        at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:355) [grpc-core-1.53.0.jar:1.53.0]
        at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:867) [grpc-core-1.53.0.jar:1.53.0]
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37) [grpc-core-1.53.0.jar:1.53.0]
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133) [grpc-core-1.53.0.jar:1.53.0]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:834) [?:?]
[INFO ] 2023-07-21 21:43:24.996 [grpc-default-executor-0] GRPCControlServer - closeMqttConnection: connectionId 1 reason 4
[WARN ] 2023-07-21 21:43:24.997 [grpc-default-executor-0] MqttConnectionImpl - DISCONNECT was not sent on the dead connection
[INFO ] 2023-07-21 21:43:24.997 [Thread-2] MqttConnectionImpl - MQTT connectionId 1 stopped
[INFO ] 2023-07-21 21:43:25.011 [grpc-default-executor-0] GRPCControlServer - shutdownAgent: reason That's it.
[INFO ] 2023-07-21 21:43:25.025 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - Server awaitTermination done
[INFO ] 2023-07-21 21:43:25.025 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Shutdown gPRC link
[INFO ] 2023-07-21 21:43:25.036 [com.aws.greengrass.testing.mqtt5.client.Main.main()] Main - Execution done successfully
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
