### PR TITLE
feat(uat): fix connect bug on windows for python paho client

### DIFF
--- a/uat/custom-components/client-python-paho/src/main.py
+++ b/uat/custom-components/client-python-paho/src/main.py
@@ -146,5 +146,7 @@ class Main:
 
 if __name__ == "__main__":
     main_object = Main()
+    if sys.version_info >= (3, 8) and sys.platform.lower().startswith("win"):
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     rc = asyncio.run(main_object.main())
     sys.exit(rc)

--- a/uat/custom-components/client-python-paho/src/mqtt_lib/mqtt_lib.py
+++ b/uat/custom-components/client-python-paho/src/mqtt_lib/mqtt_lib.py
@@ -51,8 +51,8 @@ class MQTTLib:
         Returns id of connection
         """
         while True:
-            connection_id = self.__connection_id_next
             self.__connection_id_next += 1
+            connection_id = self.__connection_id_next
 
             if connection_id not in self.__connections:
                 self.__connections[connection_id] = mqtt_connection


### PR DESCRIPTION
**Issue #, if available:**
Fix "Paho Python Client cannot connect on Windows" bug.

**Description of changes:**
- "Paho Python Client cannot connect on Windows" bug was fixed
- Start connection id was changed from 0 to 1 in Paho Python Client to be consistent with the other clients

**Why is this change necessary:**
Bug is present on Windows for Python version >= 3.8

**How was this change tested:**
Run T1 scenario locally on Windows to make sure that the client successfully connect to broker and pass the test

**Test results:**
```
[INFO ] 2023-07-27 11:59:55.391 [main] feature - Finished step: 'I create a Greengrass deployment with components' with status PASSED
[INFO ] 2023-07-27 11:59:56.545 [main] EngineControlImpl - MQTT client control gRPC server started, listening on 53256
[INFO ] 2023-07-27 11:59:56.929 [main] MqttControlSteps - MQTT clients control started gRPC service on port 53256 addresses [192.168.35.1, 192.168.56.1, 192.168.100.10, 172.19.208.1]
[INFO ] 2023-07-27 11:59:57.056 [main] AbstractAWSResourceLifecycle - Created IotPolicy in IotLifecycle
[INFO ] 2023-07-27 11:59:57.787 [main] AbstractAWSResourceLifecycle - Created IotCertificate in IotLifecycle
[INFO ] 2023-07-27 11:59:57.791 [main] AbstractAWSResourceLifecycle - Created IotThing in IotLifecycle
[INFO ] 2023-07-27 11:59:57.791 [main] feature - Finished step: 'I create client device "clientDeviceTest"' with status PASSED
[INFO ] 2023-07-27 11:59:57.922 [main] feature - Finished step: 'I associate "clientDeviceTest" with ggc' with status PASSED
[INFO ] 2023-07-27 11:59:57.929 [main] feature - Finished step: 'I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:' with status PASSED
[INFO ] 2023-07-27 11:59:57.930 [main] feature - Finished step: 'I update my Greengrass deployment configuration, setting the component aws.greengrass.client.Mqtt5PythonPahoClient configuration to:' with status PASSED
[INFO ] 2023-07-27 11:59:58.324 [main] AbstractAWSResourceLifecycle - Created GreengrassDeployment in GreengrassV2Lifecycle
[INFO ] 2023-07-27 11:59:58.324 [main] DeploymentSteps - Created Greengrass deployment: 1e0b3e30-550f-4195-acb4-34880d14c86e
[INFO ] 2023-07-27 11:59:58.325 [main] feature - Finished step: 'I deploy the Greengrass deployment configuration' with status PASSED
[INFO ] 2023-07-27 12:01:15.108 [grpc-default-executor-1] GRPCDiscoveryServer - RegisterAgent: agentId aws.greengrass.client.Mqtt5PythonPahoClient
[INFO ] 2023-07-27 12:01:15.139 [grpc-default-executor-1] GRPCDiscoveryServer - DiscoveryClient: agentId aws.greengrass.client.Mqtt5PythonPahoClient address 192.168.35.1 port 53324
[INFO ] 2023-07-27 12:01:15.141 [grpc-default-executor-1] EngineControlImpl - Created new agent control for aws.greengrass.client.Mqtt5PythonPahoClient on 192.168.35.1:53324
[INFO ] 2023-07-27 12:01:15.219 [grpc-default-executor-1] MqttControlSteps - Agent aws.greengrass.client.Mqtt5PythonPahoClient is connected
[INFO ] 2023-07-27 12:01:32.017 [main] feature - Finished step: 'the Greengrass deployment is COMPLETED on the device after 5 minutes' with status PASSED
[INFO ] 2023-07-27 12:01:34.752 [main] feature - Finished step: 'the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes' with status PASSED
[INFO ] 2023-07-27 12:01:35.756 [main] MqttControlSteps - Discovered data for broker default_broker:
[INFO ] 2023-07-27 12:01:35.757 [main] MqttControlSteps - groupId greengrassV2-coreDevice-gg-142f5d82a230c33299ef-ggc-thing with 1 CA
[INFO ] 2023-07-27 12:01:35.758 [main] MqttControlSteps - Core with thing Arn arn:aws:iot:eu-central-1:285891398846:thing/gg-142f5d82a230c33299ef-ggc-thing
[INFO ] 2023-07-27 12:01:35.759 [main] MqttControlSteps - Connectivity info: id 192.168.35.1 host 192.168.35.1 port 8883
[INFO ] 2023-07-27 12:01:35.759 [main] MqttControlSteps - Connectivity info: id 192.168.56.1 host 192.168.56.1 port 8883
[INFO ] 2023-07-27 12:01:35.760 [main] MqttControlSteps - Connectivity info: id 192.168.100.10 host 192.168.100.10 port 8883
[INFO ] 2023-07-27 12:01:35.760 [main] MqttControlSteps - Connectivity info: id 172.19.208.1 host 172.19.208.1 port 8883
[INFO ] 2023-07-27 12:01:35.764 [main] feature - Finished step: 'I discover core device broker as "default_broker" from "clientDeviceTest" in OTF' with status PASSED
[INFO ] 2023-07-27 12:01:35.766 [main] MqttControlSteps - Creating MQTT connection with broker default_broker to address 192.168.35.1:8883 as Thing gg-142f5d82a230c33299ef-clientDeviceTest on aws.greengrass.client.Mqtt5PythonPahoClient using MQTT v5
[INFO ] 2023-07-27 12:01:37.110 [main] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
reasonCode: 0
retainAvailable: true
maximumPacketSize: 268435455
wildcardSubscriptionsAvailable: true
subscriptionIdentifiersAvailable: true
sharedSubscriptionsAvailable: true
topicAliasMaximum: 65535
'
[INFO ] 2023-07-27 12:01:37.167 [main] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-07-27 12:01:37.168 [main] MqttControlSteps - Connection with broker default_broker established to address 192.168.35.1:8883 as Thing gg-142f5d82a230c33299ef-clientDeviceTest on aws.greengrass.client.Mqtt5PythonPahoClient
[INFO ] 2023-07-27 12:01:37.168 [main] feature - Finished step: 'I connect device "clientDeviceTest" on aws.greengrass.client.Mqtt5PythonPahoClient to "default_broker" using mqtt "v5"' with status PASSED
[INFO ] 2023-07-27 12:01:37.170 [main] MqttControlSteps - Create MQTT subscription for Thing gg-142f5d82a230c33299ef-clientDeviceTest to topics filter iot_data_0 with QoS 0 no local false retain handling MQTT5_RETAIN_SEND_AT_SUBSCRIPTION
[INFO ] 2023-07-27 12:01:37.170 [main] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-07-27 12:01:37.179 [main] MqttControlSteps - MQTT subscription has on topics filter iot_data_0 been created with reason code 0
[INFO ] 2023-07-27 12:01:37.179 [main] feature - Finished step: 'I subscribe "clientDeviceTest" to "iot_data_0" with qos 0 and expect status "GRANTED_QOS_0"' with status PASSED
[INFO ] 2023-07-27 12:01:37.179 [main] MqttControlSteps - Create MQTT subscription for Thing gg-142f5d82a230c33299ef-clientDeviceTest to topics filter iot_data_1 with QoS 1 no local false retain handling MQTT5_RETAIN_SEND_AT_SUBSCRIPTION
[INFO ] 2023-07-27 12:01:37.179 [main] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-07-27 12:01:37.186 [main] MqttControlSteps - MQTT subscription has on topics filter iot_data_1 been created with reason code 1
[INFO ] 2023-07-27 12:01:37.186 [main] feature - Finished step: 'I subscribe "clientDeviceTest" to "iot_data_1" with qos 1 and expect status "GRANTED_QOS_1"' with status PASSED
[INFO ] 2023-07-27 12:01:37.187 [main] MqttControlSteps - Publishing MQTT message 'Test message0' as Thing gg-142f5d82a230c33299ef-clientDeviceTest to topic iot_data_0 with QoS 0 retain false payload format indicator null message expire interval null response topic null correlation data null
[INFO ] 2023-07-27 12:01:37.190 [main] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic iot_data_0
[INFO ] 2023-07-27 12:01:37.195 [main] MqttControlSteps - MQTT message 'Test message0' has been succesfully published
[INFO ] 2023-07-27 12:01:37.195 [main] feature - Finished step: 'I publish from "clientDeviceTest" to "iot_data_0" with qos 0 and message "Test message0"' with status PASSED
[INFO ] 2023-07-27 12:01:37.195 [main] MqttControlSteps - Awaiting for MQTT message 'Test message0' with retain null payload format indicator null message expiry interval null response topic null correlation data null on topic 'iot_data_0' on Thing 'gg-142f5d82a230c33299ef-clientDeviceTest' for 10 seconds
[INFO ] 2023-07-27 12:01:37.197 [grpc-default-executor-1] GRPCDiscoveryServer - OnReceiveMessage: agentId aws.greengrass.client.Mqtt5PythonPahoClient connectionId 1 topic iot_data_0 QoS 0
[INFO ] 2023-07-27 12:01:37.197 [main] feature - Finished step: 'message "Test message0" received on "clientDeviceTest" from "iot_data_0" topic within 10 seconds' with status PASSED
[INFO ] 2023-07-27 12:01:37.198 [main] MqttControlSteps - Publishing MQTT message 'Test message1' as Thing gg-142f5d82a230c33299ef-clientDeviceTest to topic iot_data_1 with QoS 1 retain false payload format indicator null message expire interval null response topic null correlation data null
[INFO ] 2023-07-27 12:01:37.198 [main] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic iot_data_1
[INFO ] 2023-07-27 12:01:37.197 [grpc-default-executor-1] MqttControlSteps - Message received on connection with name gg-142f5d82a230c33299ef-clientDeviceTest: topic: "iot_data_0"
payload: "Test message0"

[INFO ] 2023-07-27 12:01:37.212 [grpc-default-executor-1] GRPCDiscoveryServer - OnReceiveMessage: agentId aws.greengrass.client.Mqtt5PythonPahoClient connectionId 1 topic iot_data_1 QoS 1
[INFO ] 2023-07-27 12:01:37.213 [grpc-default-executor-1] MqttControlSteps - Message received on connection with name gg-142f5d82a230c33299ef-clientDeviceTest: topic: "iot_data_1"
payload: "Test message1"
qos: MQTT_QOS_1

[INFO ] 2023-07-27 12:01:37.216 [main] MqttControlSteps - MQTT message 'Test message1' has been succesfully published
[INFO ] 2023-07-27 12:01:37.216 [main] feature - Finished step: 'I publish from "clientDeviceTest" to "iot_data_1" with qos 1 and message "Test message1"' with status PASSED
[INFO ] 2023-07-27 12:01:37.216 [main] MqttControlSteps - Awaiting for MQTT message 'Test message1' with retain null payload format indicator null message expiry interval null response topic null correlation data null on topic 'iot_data_1' on Thing 'gg-142f5d82a230c33299ef-clientDeviceTest' for 10 seconds
[INFO ] 2023-07-27 12:01:37.217 [main] feature - Finished step: 'message "Test message1" received on "clientDeviceTest" from "iot_data_1" topic within 10 seconds' with status PASSED
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
