### PR TITLE
fix(uat): change error processing in paho-java-client

### DIFF
--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
@@ -42,9 +42,11 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
     private static final Logger logger = LogManager.getLogger(Mqtt311ConnectionImpl.class);
     private static final String EXCEPTION_WHEN_CONNECTING = "Exception occurred during connect";
     private static final String EXCEPTION_WHEN_CONFIGURE_SSL_CA = "Exception occurred during SSL configuration";
+    private static final String EXCEPTION_WHEN_DISCONNECTING = "Exception occurred during disconnect";
     private static final int REASON_CODE_SUCCESS = 0;
 
     private final AtomicBoolean isClosing = new AtomicBoolean();
+    private final AtomicBoolean isConnected = new AtomicBoolean();
     private final IMqttAsyncClient mqttClient;
     private final GRPCClient grpcClient;
     private int connectionId = 0;
@@ -76,6 +78,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
             mqttClient.setCallback(new MqttCallbackImpl());
             token.waitForCompletion(TimeUnit.SECONDS.toMillis(connectionParams.getConnectionTimeout()));
 
+            isConnected.set(true);
             logger.atInfo().log("MQTT 3.1.1 connection {} is establisted", connectionId);
             return buildConnectResult(true, token.isComplete());
         } catch (org.eclipse.paho.client.mqttv3.MqttException e) {
@@ -89,7 +92,9 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
 
     @Override
     public MqttSubscribeReply subscribe(long timeout, @NonNull List<Subscription> subscriptions,
-                                        List<Mqtt5Properties> userProperties) {
+                                        List<Mqtt5Properties> userProperties) throws MqttException {
+        stateCheck();
+
         checkUserProperties(userProperties);
         String[] filters = new String[subscriptions.size()];
         int[] qos = new int[subscriptions.size()];
@@ -109,7 +114,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
             logger.atError().withThrowable(e).log("Exception occurred during subscribe, reason code {}",
                                                     e.getReasonCode());
 
-            builder.addAllReasonCodes(Collections.nCopies(subscriptions.size(), (int)e.getReasonCode()));
+            throw new RuntimeException(e.getMessage(), e);
         }
         return builder.build();
     }
@@ -127,7 +132,9 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
     }
 
     @Override
-    public MqttPublishReply publish(long timeout, @NonNull Message message) {
+    public MqttPublishReply publish(long timeout, @NonNull Message message) throws MqttException {
+        stateCheck();
+
         checkUserProperties(message.getUserProperties());
         checkContentType(message.getContentType());
         checkPayloadFormatIndicator(message.getPayloadFormatIndicator());
@@ -148,14 +155,16 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
             logger.atError().withThrowable(ex)
                     .log("Failed during publishing message with reasonCode {} and reasonString {}",
                             ex.getReasonCode(), ex.getMessage());
-            builder.setReasonCode(ex.getReasonCode());
+            throw new RuntimeException(ex.getMessage(), ex);
         }
         return builder.build();
     }
 
     @Override
     public MqttSubscribeReply unsubscribe(long timeout, @NonNull List<String> filters,
-                                          List<Mqtt5Properties> userProperties) {
+                                          List<Mqtt5Properties> userProperties) throws MqttException {
+        stateCheck();
+
         checkUserProperties(userProperties);
 
         MqttSubscribeReply.Builder builder = MqttSubscribeReply.newBuilder();
@@ -166,7 +175,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
         } catch (org.eclipse.paho.client.mqttv3.MqttException e) {
             logger.atError().withThrowable(e).log("Exception occurred during unsubscribe, reason code {}",
                                                     e.getReasonCode());
-            builder.addAllReasonCodes(Collections.nCopies(filters.size(), (int)e.getReasonCode()));
+            throw new RuntimeException(e.getMessage(), e);
         }
         return builder.build();
     }
@@ -210,10 +219,31 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
         return connectionOptions;
     }
 
-    private void disconnectAndClose(long timeout) throws org.eclipse.paho.client.mqttv3.MqttException {
+    private void disconnectAndClose(long timeout) throws org.eclipse.paho.client.mqttv3.MqttException, MqttException {
         try {
-            mqttClient.disconnectForcibly(timeout);
+            final long deadline = System.nanoTime() + timeout * 1_000_000_000;
+
+            if (isConnected.compareAndSet(true, false)) {
+                mqttClient.disconnectForcibly(timeout);
+            } else {
+                logger.atWarn().log("DISCONNECT was not sent on the dead connection");
+            }
+
+            long remaining = deadline - System.nanoTime();
+            if (remaining < MIN_SHUTDOWN_NS) {
+                remaining = MIN_SHUTDOWN_NS;
+            }
+
+            executorService.shutdown();
+            if (!executorService.awaitTermination(remaining, TimeUnit.NANOSECONDS)) {
+                executorService.shutdownNow();
+            }
+
             logger.atInfo().log("MQTT 3.1.1 connection {} has been disconnected", connectionId);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.atError().withThrowable(e).log(EXCEPTION_WHEN_DISCONNECTING);
+            throw new MqttException(EXCEPTION_WHEN_DISCONNECTING, e);
         } finally {
             mqttClient.close();
         }
@@ -273,6 +303,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
         @SuppressWarnings("PMD.AvoidCatchingGenericException")
         @Override
         public void connectionLost(Throwable throwable) {
+            isConnected.set(false);
             // only unsolicited disconnect
             if (isClosing.get()) {
                 logger.atWarn().log("DISCONNECT event ignored due to shutdown initiated");
@@ -320,6 +351,21 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
 
             logger.atInfo().log("Received MQTT message: connectionId {} topic '{}' QoS {} retain {}",
                     connectionId, topic, mqttMessage.getQos(), mqttMessage.isRetained());
+        }
+    }
+
+    /**
+     * Checks connection state.
+     *
+     * @throws MqttException when connection state is not allow opertation
+     */
+    private void stateCheck() throws MqttException {
+        if (!isConnected.get()) {
+            throw new MqttException("MQTT client is not in connected state");
+        }
+
+        if (isClosing.get()) {
+            throw new MqttException("MQTT connection is closing");
         }
     }
 }

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
@@ -114,7 +114,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
             logger.atError().withThrowable(e).log("Exception occurred during subscribe, reason code {}",
                                                     e.getReasonCode());
 
-            throw new RuntimeException(e.getMessage(), e);
+            throw new MqttException("Could not subscribe", e);
         }
         return builder.build();
     }
@@ -155,7 +155,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
             logger.atError().withThrowable(ex)
                     .log("Failed during publishing message with reasonCode {} and reasonString {}",
                             ex.getReasonCode(), ex.getMessage());
-            throw new RuntimeException(ex.getMessage(), ex);
+            throw new MqttException("Could not publish", ex);
         }
         return builder.build();
     }
@@ -175,7 +175,7 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
         } catch (org.eclipse.paho.client.mqttv3.MqttException e) {
             logger.atError().withThrowable(e).log("Exception occurred during unsubscribe, reason code {}",
                                                     e.getReasonCode());
-            throw new RuntimeException(e.getMessage(), e);
+            throw new MqttException("Could not unsubscribe", e);
         }
         return builder.build();
     }

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/MqttConnection.java
@@ -151,9 +151,10 @@ public interface MqttConnection {
      * @param subscriptions list of subscriptions
      * @param userProperties  list of user's properties MQTT v5.0
      * @return useful information from SUBACK packet
+     * @throws MqttException on errors
      */
     MqttSubscribeReply subscribe(long timeout, @NonNull List<Subscription> subscriptions,
-                                 List<Mqtt5Properties> userProperties);
+                                 List<Mqtt5Properties> userProperties) throws MqttException;
 
     /**
      * Closes MQTT connection.
@@ -171,8 +172,9 @@ public interface MqttConnection {
      * @param timeout publish operation timeout in seconds
      * @param message message to publish
      * @return useful information from PUBACK packet or null of no PUBACK has been received (as for QoS 0)
+     * @throws MqttException on errors
      */
-    MqttPublishReply publish(long timeout, @NonNull Message message);
+    MqttPublishReply publish(long timeout, @NonNull Message message) throws MqttException;
 
     /**
      * Unsubscribes from topics.
@@ -181,9 +183,10 @@ public interface MqttConnection {
      * @param filters list of topic filter to unsubscribe
      * @param userProperties list of user's properties MQTT v5.0
      * @return useful information from UNSUBACK packet
+     * @throws MqttException on errors
      */
     MqttSubscribeReply unsubscribe(long timeout, @NonNull List<String> filters,
-                                   List<Mqtt5Properties> userProperties);
+                                   List<Mqtt5Properties> userProperties) throws MqttException;
 
 
     /**

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/grpc/GRPCControlServer.java
@@ -314,11 +314,19 @@ class GRPCControlServer {
                 internalMessage.contentType(message.getContentType());
             }
 
-            MqttPublishReply publishReply = connection.publish(timeout, internalMessage.build());
+            MqttPublishReply publishReply;
+            try {
+                publishReply = connection.publish(timeout, internalMessage.build());
                 if (publishReply != null) {
                     logger.atInfo().log("Publish response: connectionId {} reason code {} reason string '{}'",
                             connectionId, publishReply.getReasonCode(), publishReply.getReasonString());
                 }
+            } catch (MqttException e) {
+                logger.atError().withThrowable(e).log("exception during publish");
+                responseObserver.onError(e);
+                return;
+            }
+
             responseObserver.onNext(publishReply);
             responseObserver.onCompleted();
         }
@@ -445,11 +453,19 @@ class GRPCControlServer {
             logger.atInfo().log("Subscribe: connectionId {} for {} filters",
                     connectionId, outSubscriptions.size());
             List<Mqtt5Properties> userProperties = request.getPropertiesList();
-            MqttSubscribeReply subscribeReply = connection.subscribe(timeout, outSubscriptions, userProperties);
-            if (subscribeReply != null) {
-                logger.atInfo().log("Subscribe response: connectionId {} reason codes {} reason string '{}'",
-                        connectionId, subscribeReply.getReasonCodesList(), subscribeReply.getReasonString());
+            MqttSubscribeReply subscribeReply;
+            try {
+                subscribeReply = connection.subscribe(timeout, outSubscriptions, userProperties);
+                if (subscribeReply != null) {
+                    logger.atInfo().log("Subscribe response: connectionId {} reason codes {} reason string '{}'",
+                            connectionId, subscribeReply.getReasonCodesList(), subscribeReply.getReasonString());
+                }
+            } catch (MqttException e) {
+                logger.atError().withThrowable(e).log("exception during subscribe");
+                responseObserver.onError(e);
+                return;
             }
+
             responseObserver.onNext(subscribeReply);
             responseObserver.onCompleted();
         }
@@ -487,12 +503,19 @@ class GRPCControlServer {
             logger.atInfo().log("Unsubscribe: connectionId {} for {} filters",
                     connectionId, filters);
             List<Mqtt5Properties> userProperties = request.getPropertiesList();
-            MqttSubscribeReply unsubscribeReply = connection.unsubscribe(timeout, filters, userProperties);
-
-            if (unsubscribeReply != null) {
-                logger.atInfo().log("Unsubscribe response: connectionId {} reason codes {} reason string '{}'",
-                        connectionId, unsubscribeReply.getReasonCodesList(), unsubscribeReply.getReasonString());
+            MqttSubscribeReply unsubscribeReply;
+            try {
+                unsubscribeReply = connection.unsubscribe(timeout, filters, userProperties);
+                if (unsubscribeReply != null) {
+                    logger.atInfo().log("Unsubscribe response: connectionId {} reason codes {} reason string '{}'",
+                            connectionId, unsubscribeReply.getReasonCodesList(), unsubscribeReply.getReasonString());
+                }
+            } catch (MqttException e) {
+                logger.atError().withThrowable(e).log("exception during unsubscribe");
+                responseObserver.onError(e);
+                return;
             }
+
             responseObserver.onNext(unsubscribeReply);
             responseObserver.onCompleted();
         }

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
@@ -147,7 +147,7 @@ public class MqttConnectionImpl implements MqttConnection {
             }
         } catch (org.eclipse.paho.mqttv5.common.MqttException e) {
             logger.atError().withThrowable(e).log("Failed during subscribing");
-            throw new RuntimeException(e.getMessage(), e);
+            throw new MqttException("Could not subscribe", e);
         }
         return builder.build();
     }
@@ -203,7 +203,7 @@ public class MqttConnectionImpl implements MqttConnection {
             logger.atError().withThrowable(ex)
                     .log("Failed during publishing message with reasonCode {} and reasonString {}",
                             ex.getReasonCode(), ex.getMessage());
-            throw new RuntimeException(ex.getMessage(), ex);
+            throw new MqttException("Could not publish", ex);
         }
         return builder.build();
     }
@@ -252,7 +252,7 @@ public class MqttConnectionImpl implements MqttConnection {
             }
         } catch (org.eclipse.paho.mqttv5.common.MqttException e) {
             logger.atError().withThrowable(e).log("Failed during unsubscribe");
-            throw new RuntimeException(e.getMessage(), e);
+            throw new MqttException("Could not unsubscribe", e);
         }
         return builder.build();
     }
@@ -302,7 +302,6 @@ public class MqttConnectionImpl implements MqttConnection {
             Thread.currentThread().interrupt();
         } finally {
             client.close();
-            executorService.shutdown();
         }
     }
 


### PR DESCRIPTION
**Issue #, if available:**
fix error processing in paho-java-client

**Description of changes:**
- change error processing
- add isClosing boolean for callback

**Why is this change necessary:**
Implement scenarios

**How was this change tested:**
Start the local broker and shutdown the broker after a successful connection.

**Test results:**
```
[INFO ] 2023-07-27 21:08:36.788 [main] GRPCLinkImpl - Making gPRC client connection with 127.0.0.1:47619 as client1...
[INFO ] 2023-07-27 21:08:37.244 [main] GRPCLinkImpl - Client connection with Control is established, local address is 127.0.0.1
[INFO ] 2023-07-27 21:08:37.264 [main] GRPCControlServer - GRPCControlServer created and listed on 127.0.0.1:35873
[INFO ] 2023-07-27 21:08:37.336 [main] GRPCLinkImpl - Handle gRPC requests
[INFO ] 2023-07-27 21:08:37.337 [main] GRPCControlServer - Server awaitTermination
[INFO ] 2023-07-27 21:08:40.391 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId client1 broker server:10101
[INFO ] 2023-07-27 21:08:40.408 [grpc-default-executor-0] MqttConnectionImpl - CONNECT Tx user property 'region':'US'
[INFO ] 2023-07-27 21:08:40.409 [grpc-default-executor-0] MqttConnectionImpl - CONNECT Tx user property 'type':'JSON'
[INFO ] 2023-07-27 21:08:40.409 [grpc-default-executor-0] MqttConnectionImpl - CONNECT Tx request response information: true
[INFO ] 2023-07-27 21:08:41.831 [MQTT Rec: client1] MqttConnectionImpl - MQTT connectionId 1 disconnected error 'Connection lost' disconnectInfo 'com.aws.greengrass.testing.mqtt5.client.GRPCClient$DisconnectInfo@23a4a06d'
[INFO ] 2023-07-27 21:08:45.807 [grpc-default-executor-0] GRPCControlServer - Subscription: filter 'test/topic' QoS 0 noLocal false retainAsPublished false retainHandling 2
[INFO ] 2023-07-27 21:08:45.807 [grpc-default-executor-0] GRPCControlServer - Subscribe: connectionId 1 for 1 filters
[ERROR] 2023-07-27 21:08:45.807 [grpc-default-executor-0] GRPCControlServer - exception during subscribe
com.aws.greengrass.testing.mqtt5.client.exceptions.MqttException: MQTT client is not in connected state
	at com.aws.greengrass.testing.mqtt5.client.paho.MqttConnectionImpl.stateCheck(MqttConnectionImpl.java:626) ~[classes/:?]
	at com.aws.greengrass.testing.mqtt5.client.paho.MqttConnectionImpl.subscribe(MqttConnectionImpl.java:107) ~[classes/:?]
	at com.aws.greengrass.testing.mqtt5.client.grpc.GRPCControlServer$MqttClientControlImpl.subscribeMqtt(GRPCControlServer.java:458) [classes/:?]
	at com.aws.greengrass.testing.mqtt.client.MqttClientControlGrpc$MethodHandlers.invoke(MqttClientControlGrpc.java:659) [classes/:?]
	at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182) [grpc-stub-1.53.0.jar:1.53.0]
	at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:355) [grpc-core-1.53.0.jar:1.53.0]
	at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:867) [grpc-core-1.53.0.jar:1.53.0]
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37) [grpc-core-1.53.0.jar:1.53.0]
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133) [grpc-core-1.53.0.jar:1.53.0]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_361]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_361]
	at java.lang.Thread.run(Thread.java:750) [?:1.8.0_361]
[INFO ] 2023-07-27 21:08:45.825 [grpc-default-executor-0] GRPCControlServer - closeMqttConnection: connectionId 1 reason 4
[INFO ] 2023-07-27 21:08:45.826 [grpc-default-executor-0] MqttConnectionImpl - Disconnect MQTT userProperties: region, US
[INFO ] 2023-07-27 21:08:45.826 [grpc-default-executor-0] MqttConnectionImpl - Disconnect MQTT userProperties: type, JSON
[WARN ] 2023-07-27 21:08:45.826 [grpc-default-executor-0] MqttConnectionImpl - DISCONNECT was not sent on the dead connection
[INFO ] 2023-07-27 21:08:45.837 [grpc-default-executor-0] GRPCControlServer - shutdownAgent: reason 'That's it.'
[INFO ] 2023-07-27 21:08:45.890 [main] GRPCControlServer - Server awaitTermination done
[INFO ] 2023-07-27 21:08:45.890 [main] GRPCLinkImpl - Shutdown gPRC link
[INFO ] 2023-07-27 21:08:45.902 [main] Main - Execution done successfully
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
