### PR TITLE
fix(uat): add connection state check to mosquitto client

### DIFF
--- a/uat/README.md
+++ b/uat/README.md
@@ -125,7 +125,7 @@ Dtest.log.path - path where you would like the test results to be stored.
 ### Tags
 -Dtags can be extended if you would like to test exact scenarios or exclude some scenarios:
 
-@GGMQ - to start all GGMQ test scenarios run 
+@GGMQ - to start all GGMQ test scenarios run.\
 Example:
 ```bash
 sudo -E java -Dggc.archive=greengrass-nucleus-latest.zip -Dtest.log.path=logs -Dtags="@GGMQ" -jar testing-features/target/client-devices-auth-testing-features.jar
@@ -133,25 +133,25 @@ sudo -E java -Dggc.archive=greengrass-nucleus-latest.zip -Dtest.log.path=logs -D
 
 To choose running of specific tests using the following tags:
 
-@sdk-java, @mosquitto-c, @paho-java, @paho-python - to choose client to run test scenarios
+@sdk-java, @mosquitto-c, @paho-java, @paho-python - to choose client to run test scenarios.\
 Example:
 ```bash
 sudo -E java -Dggc.archive=greengrass-nucleus-latest.zip -Dtest.log.path=logs -Dtags="@GGMQ and @sdk-java" -jar testing-features/target/client-devices-auth-testing-features.jar
 ```
 
-@mqtt3, @mqtt5 - to choose protocol version for test scenarios
+@mqtt3, @mqtt5 - to choose protocol version for test scenarios.\
 Example:
 ```bash
 sudo -E java -Dggc.archive=greengrass-nucleus-latest.zip -Dtest.log.path=logs -Dtags="@GGMQ and @mqtt5" -jar testing-features/target/client-devices-auth-testing-features.jar
 ```
 
-@GGMQ-1-T(scenario number) - to specify scenario number that should be run
+@GGMQ-1-T(scenario number) - to specify scenario number that should be run.\
 Example: 
 ```bash
 sudo -E java -Dggc.archive=greengrass-nucleus-latest.zip -Dtest.log.path=logs -Dtags="@GGMQ-1-T1" -jar testing-features/target/client-devices-auth-testing-features.jar
 ```
 
-@SkipOnWindows - to skip clients or tests that are not supported by Windows
+@SkipOnWindows - to skip clients or tests that are not supported by Windows.\
 Example:
 ```
 java -Dggc.archive=greengrass-nucleus-latest.zip -Dtest.log.path=logs -Dtags="@GGMQ and not @SkipOnWindows" -jar testing-features/target/client-devices-auth-testing-features.jar
@@ -169,14 +169,15 @@ sudo -E java -Dggc.archive=greengrass-nucleus-latest.zip -Dtest.log.path=logs -D
 Due to scenario usually requires upload/download artifacts to S3, create and delete roles, policies, do Greengrass discovery and so one please ensure CodeBuild instance has enough AWS permissions to do that.
 For more information please read [Create a CodeBuild service role](https://docs.aws.amazon.com/codebuild/latest/userguide/setting-up.html#setting-up-service-role)
 
+## Generate html-documentation from JavaDoc
+To generate html-documentation from JavaDoc, run the following command from the uat directory of the project:
+```bash
+mvn -ntp -U clean install
+mvn javadoc:javadoc
+```
+The main html-file will be located in each module by path **target/site/apidocs/index.html**
+
 ## Limitations
 MQTT clients based on IoT Device SDK for Java v2, mosquitto C, Paho Java, Paho Python do no provide API to get information from PUBREC/PUBREL/PUBCOMP packages used when messages published with QoS 2.
 
 Not all features of MQTT v5.0 have been implemented in clients and are supported by gRPC proto and the control as was requested, these are not bugs but designed by requirement.
-
-### Generate html-documentation from JavaDoc
-To generate html-documentation from JavaDoc, run the following command from the uat directory of the project:
-```bash
-mvn javadoc:javadoc
-```
-The main html-file will be located in each module by path **~/target/site/apidocs/index.html**

--- a/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
+++ b/uat/custom-components/client-mosquitto-c/src/MqttConnection.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <unordered_map>
 #include <mutex>
+#include <atomic>
 #include <google/protobuf/repeated_field.h>
 
 using google::protobuf::RepeatedPtrField;
@@ -195,6 +196,8 @@ private:
     bool m_clean_session;
     bool m_v5;
     int m_connection_id;
+    std::atomic_bool m_is_closing;
+    std::atomic_bool m_is_connected;
 
     std::string m_ca;
     std::string m_cert;


### PR DESCRIPTION
**Issue #, if available:**
MQTT Client Control does not send shutdown agent request

**Description of changes:**
- Add connection state check before publish, subscribe, unsubscribe, shutdown
- Add shutdown initiated check before shutdown
- Joined with REAME update

**Why is this change necessary:**
Currently mosquitto client throw an exception when closeMqttConnection gRPC request is called on connection already closed from broker's side.
Also behavior of gRPC requests for publish,subscribe,unsubscribe and shutdown when connection is closed by broker depends on mosquitto library which differ from other client. We need unify behavior of clients to simplify control and MQTT steps.

**How was this change tested:**
Manually by run Control as application and local mosquitto broker.
When client is connected terminate broker before first subscribe.
Observe results in client and control logs:

**Test results:**
Control:
```
[INFO ] 2023-07-28 23:57:45.102 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId mosquitto-agent
[INFO ] 2023-07-28 23:57:45.108 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId mosquitto-agent address 127.0.0.1 port 44355
[INFO ] 2023-07-28 23:57:45.109 [grpc-default-executor-0] EngineControlImpl - Created new agent control for mosquitto-agent on 127.0.0.1:44355
[INFO ] 2023-07-28 23:57:45.109 [grpc-default-executor-0] ExampleControl - Agent mosquitto-agent is connected
[INFO ] 2023-07-28 23:57:45.110 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id mosquitto-agent
[INFO ] 2023-07-28 23:57:48.111 [pool-2-thread-1] AgentTestScenario - Set CONNECT user property: region, US
[INFO ] 2023-07-28 23:57:48.111 [pool-2-thread-1] AgentTestScenario - Set CONNECT user property: type, JSON
[INFO ] 2023-07-28 23:57:48.112 [pool-2-thread-1] AgentTestScenario - Set CONNECT request response information true
[INFO ] 2023-07-28 23:57:48.197 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
reasonCode: 0
receiveMaximum: 20
topicAliasMaximum: 10
'
[INFO ] 2023-07-28 23:57:48.197 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-07-28 23:57:48.198 [pool-2-thread-1] AgentTestScenario - MQTT connection with id 1 is established
[INFO ] 2023-07-28 23:57:49.057 [grpc-default-executor-0] GRPCDiscoveryServer - OnMqttDisconnect: agentId mosquitto-agent connectionId 1 disconnect 'reasonCode: 7
' error ''
[INFO ] 2023-07-28 23:57:49.058 [grpc-default-executor-0] AgentTestScenario - MQTT disconnected on agentId mosquitto-agent connectionId 1 disconnect 'reasonCode: 7
' error ''
[INFO ] 2023-07-28 23:57:53.199 [pool-2-thread-1] AgentTestScenario - Set SUBSCRIBE user property: region, US
[INFO ] 2023-07-28 23:57:53.199 [pool-2-thread-1] AgentTestScenario - Set SUBSCRIBE user property: type, JSON
[INFO ] 2023-07-28 23:57:53.200 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[ERROR] 2023-07-28 23:57:53.210 [pool-2-thread-1] AgentTestScenario - gRPC error code INTERNAL: description: MQTT client is not connected
io.grpc.StatusRuntimeException: INTERNAL: MQTT client is not connected
        at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:271) ~[grpc-stub-1.53.0.jar:1.53.0]
        at io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:252) ~[grpc-stub-1.53.0.jar:1.53.0]
        at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:165) ~[grpc-stub-1.53.0.jar:1.53.0]
        at com.aws.greengrass.testing.mqtt.client.MqttClientControlGrpc$MqttClientControlBlockingStub.subscribeMqtt(MqttClientControlGrpc.java:511) ~[classes/:?]
        at com.aws.greengrass.testing.mqtt.client.control.implementation.AgentControlImpl.subscribeMqtt(AgentControlImpl.java:224) ~[classes/:?]
        at com.aws.greengrass.testing.mqtt.client.control.implementation.ConnectionControlImpl.subscribeMqtt(ConnectionControlImpl.java:123) ~[classes/:?]
        at com.aws.greengrass.testing.mqtt.client.control.AgentTestScenario.testSubscribe(AgentTestScenario.java:255) ~[classes/:?]
        at com.aws.greengrass.testing.mqtt.client.control.AgentTestScenario.run(AgentTestScenario.java:183) [classes/:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:834) [?:?]
[INFO ] 2023-07-28 23:57:53.217 [pool-2-thread-1] AgentTestScenario - Set DISCONNECT user property: region, US
[INFO ] 2023-07-28 23:57:53.217 [pool-2-thread-1] AgentTestScenario - Set DISCONNECT user property: type, JSON
[INFO ] 2023-07-28 23:57:53.220 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-07-28 23:57:53.220 [pool-2-thread-1] AgentControlImpl - sending shutdown request
[INFO ] 2023-07-28 23:57:53.222 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-07-28 23:57:53.225 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId mosquitto-agent reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-07-28 23:57:53.225 [grpc-default-executor-0] AgentControlImpl - shutting down channel with agent id mosquitto-agent
[INFO ] 2023-07-28 23:57:53.226 [grpc-default-executor-0] AgentControlImpl - channel terminated with agent id mosquitto-agent
[INFO ] 2023-07-28 23:57:53.226 [grpc-default-executor-0] ExampleControl - Agent mosquitto-agent is disconnected
```

Mosquitto client:
```
$ build/src/mosquitto-test-client mosquitto-agent
[DEBUG]: Initialize gRPC library
[DEBUG]: Making gPRC link with 127.0.0.1:47619 as agent_id 'mosquitto-agent'
[DEBUG]: Sending RegisterAgent request with agent_id mosquitto-agent
[DEBUG]: Local address is 127.0.0.1
[DEBUG]: GRPCControlServer created and listed on 127.0.0.1:44355
[DEBUG]: Sending DiscoveryAgent request agent_id 'mosquitto-agent' host:port 127.0.0.1:44355
[DEBUG]: gPRC link established with 127.0.0.1:47619 as agent_id 'mosquitto-agent'
[DEBUG]: Initialize Mosquitto MQTT library
[DEBUG]: Mosquitto library version 2.0.15
[DEBUG]: Handle gRPC requests
[DEBUG]: CreateMqttConnection client_id 'client' broker server:8883
[DEBUG]: Creating Mosquitto MQTT v5 connection for server:8883
[DEBUG]: Copied TX user property region:US
[DEBUG]: Copied TX user property type:JSON
[DEBUG]: Establishing Mosquitto MQTT v5 connection to server:8883 in 10 seconds
[DEBUG]: Copied TX request response information 1
[DEBUG]: Use provided TLS credentials
[DEBUG]: mosquitto: Client client sending CONNECT
[DEBUG]: mosquitto: Client client received CONNACK (0)
[DEBUG]: onConnect rc 0 flags 0 props 0x7f37f400bf10
[DEBUG]: Copied RX topic alias maximum 10
[DEBUG]: Copied RX receive maximum 20
[DEBUG]: Establishing MQTT connection to server:8883 completed with reason code 0
[DEBUG]: Connection registered with id 1
[DEBUG]: onDisconnect rc 7 props (nil)
[DEBUG]: Sending OnMqttDisconnect request agent_id 'mosquitto-agent' connection_id 1 error '(null)'
[DEBUG]: Subscription: filter test/topic QoS 0 noLocal 0 retainAsPublished 0 retainHandling 2
[DEBUG]: SubscribeMqtt connection_id 1
[ERROR]: SubscribeMqtt: exception during subscribing
[DEBUG]: CloseMqttConnection connection_id 1 reason 4
[DEBUG]: Destroy Mosquitto MQTT connection
[DEBUG]: ShutdownAgent with reason 'That's it.'
[DEBUG]: Shutdown gPRC link
[DEBUG]: Sending UnregisterAgent request agent_id 'mosquitto-agent' reason 'Agent shutdown by OTF request 'That's it.''
[DEBUG]: Shutdown MQTT library
[DEBUG]: Shutdown gRPC library
[DEBUG]: Execution done
```


**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
