### PR TITLE
feat(uat): implement GGMQ scenario based on GGAD-1-T25

### DIFF
--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -798,10 +798,10 @@ public class MqttControlSteps {
         ConnectionControl connectionControl = getConnectionControl(clientDeviceThingName);
 
         // Add test id to new name
-        final String newConnectionNameWithTestId = getClientDeviceThingName(clientDeviceId);
+        final String newConnectionNameWithTestId = getClientDeviceThingName(newConnectionName);
         connectionControl.setConnectionName(newConnectionNameWithTestId);
 
-        log.info("Connection {string} was renamed to {string}",
+        log.info("Connection {} was renamed to {}",
                  clientDeviceThingName,
                  newConnectionNameWithTestId);
     }

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -786,6 +786,27 @@ public class MqttControlSteps {
     }
 
     /**
+     * Renames connection.
+     *
+     * @param clientDeviceId the id of the device (thing name) as defined by user in scenario
+     * @param newConnectionName new name of the connection
+     * @throws RuntimeException throws in fail case
+     */
+    @And("I rename connection {string} to {string}")
+    public void renameConnection(String clientDeviceId, String newConnectionName) {
+        final String clientDeviceThingName = getClientDeviceThingName(clientDeviceId);
+        ConnectionControl connectionControl = getConnectionControl(clientDeviceThingName);
+
+        // Add test id to new name
+        final String newConnectionNameWithTestId = getClientDeviceThingName(clientDeviceId);
+        connectionControl.setConnectionName(newConnectionNameWithTestId);
+
+        log.info("Connection {string} was renamed to {string}",
+                 clientDeviceThingName,
+                 newConnectionNameWithTestId);
+    }
+
+    /**
      * Try to create MQTT connection to broker and ensure connection has been failed.
      *
      * @param clientDeviceId the id of the device (thing name) as defined by user in scenario

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1829,6 +1829,8 @@ Feature: GGMQ-1
       | <agent>                                  | classpath:/local-store/recipes/<recipe> |
     And I create client device "publisher"
     And I create client device "subscriber"
+    When I associate "publisher" with ggc
+    When I associate "subscriber" with ggc
     And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:
     """
 {
@@ -1868,8 +1870,6 @@ Feature: GGMQ-1
     }
 }
     """
-    When I associate "publisher" with ggc
-    When I associate "subscriber" with ggc
 
     And I deploy the Greengrass deployment configuration
     Then the Greengrass deployment is COMPLETED on the device after 5 minutes
@@ -1881,13 +1881,13 @@ Feature: GGMQ-1
     And I connect device "subscriber" on <agent> to "localMqttBroker2" using mqtt "<mqtt-v>"
 
     When I subscribe "subscriber" to "iot_data_0" with qos 1
-    When I publish from "publisher" to "iot_data_0" with qos 1 and message "Test message" and expect status 0
+    When I publish from "publisher" to "iot_data_0" with qos 1 and message "Test message"
     And message "Test message" received on "subscriber" from "iot_data_0" topic within 5 seconds
     And I rename connection "publisher" to "publisher_old"
 
     # Reconnect publisher with the same device id
     And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
-    When I publish from "publisher" to "iot_data_0" with qos 1 and message "Connect again" and expect status 0
+    When I publish from "publisher" to "iot_data_0" with qos 1 and message "Connect again"
     And message "Connect again" received on "subscriber" from "iot_data_0" topic within 5 seconds
 
     # WARNING: Paho Java client does not work in this test because of "Untranslated MqttException - RC: 0"

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1890,8 +1890,6 @@ Feature: GGMQ-1
     When I publish from "publisher" to "iot_data_0" with qos 1 and message "Connect again"
     And message "Connect again" received on "subscriber" from "iot_data_0" topic within 5 seconds
 
-    # WARNING: Paho Java client does not work in this test because of "Untranslated MqttException - RC: 0"
-    # Add this client here after this issue will be fixed
     @mqtt3 @sdk-java
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
@@ -1901,6 +1899,11 @@ Feature: GGMQ-1
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
+
+    @mqtt3 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
     @mqtt3 @paho-python
     Examples:
@@ -1916,6 +1919,11 @@ Feature: GGMQ-1
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
+
+    @mqtt5 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
     @mqtt5 @paho-python
     Examples:

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1875,9 +1875,10 @@ Feature: GGMQ-1
     Then the Greengrass deployment is COMPLETED on the device after 5 minutes
     And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes
 
-    And I discover core device broker as "default_broker" from "publisher" in OTF
-    And I connect device "publisher" on <agent> to "default_broker" using mqtt "<mqtt-v>"
-    And I connect device "subscriber" on <agent> to "default_broker" using mqtt "<mqtt-v>"
+    Then I discover core device broker as "localMqttBroker1" from "publisher" in OTF
+    Then I discover core device broker as "localMqttBroker2" from "subscriber" in OTF
+    And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
+    And I connect device "subscriber" on <agent> to "localMqttBroker2" using mqtt "<mqtt-v>"
 
     When I subscribe "subscriber" to "iot_data_0" with qos 1
     When I publish from "publisher" to "iot_data_0" with qos 1 and message "Test message" and expect status 0
@@ -1885,7 +1886,7 @@ Feature: GGMQ-1
     And I rename connection "publisher" to "publisher_old"
 
     # Reconnect publisher with the same device id
-    And I connect device "publisher" on <agent> to "default_broker" using mqtt "<mqtt-v>"
+    And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
     When I publish from "publisher" to "iot_data_0" with qos 1 and message "Connect again" and expect status 0
     And message "Connect again" received on "subscriber" from "iot_data_0" topic within 5 seconds
 

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1887,6 +1887,7 @@ Feature: GGMQ-1
 
     # Reconnect publisher with the same device id
     And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
+    And I wait 5 seconds
     When I publish from "publisher" to "iot_data_0" with qos 1 and message "Connect again" and expect status 0
     And message "Connect again" received on "subscriber" from "iot_data_0" topic within 5 seconds
 

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1820,6 +1820,115 @@ Feature: GGMQ-1
       | mqtt-v | name        | agent                                       | recipe                  | publish-status-na |
       | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml | 0                 |
 
+  @GGMQ-1-T25
+  Scenario Outline: GGMQ-1-T25-<mqtt-v>-<name>: As a customer, I connect with same client id twice (not reconnect) and be able to publish and subscribe to messages.
+    When I create a Greengrass deployment with components
+      | aws.greengrass.clientdevices.Auth        | LATEST                                  |
+      | aws.greengrass.clientdevices.mqtt.EMQX   | LATEST                                  |
+      | aws.greengrass.clientdevices.IPDetector  | LATEST                                  |
+      | <agent>                                  | classpath:/local-store/recipes/<recipe> |
+    And I create client device "publisher"
+    And I create client device "subscriber"
+    And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:
+    """
+{
+    "MERGE":{
+        "deviceGroups":{
+            "formatVersion":"2021-03-05",
+            "definitions":{
+                "MyPermissiveDeviceGroup":{
+                    "selectionRule":"thingName: ${publisher} OR thingName: ${subscriber}",
+                    "policyName":"MyPermissivePolicy"
+                }
+            },
+            "policies":{
+                "MyPermissivePolicy":{
+                    "AllowAll":{
+                        "statementDescription":"Allow client devices to perform all actions.",
+                        "operations":[
+                            "*"
+                        ],
+                        "resources":[
+                            "*"
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}
+    """
+
+    And I update my Greengrass deployment configuration, setting the component <agent> configuration to:
+    """
+{
+    "MERGE":{
+        "controlAddresses":"${mqttControlAddresses}",
+        "controlPort":"${mqttControlPort}"
+    }
+}
+    """
+    When I associate "publisher" with ggc
+    When I associate "subscriber" with ggc
+
+    And I deploy the Greengrass deployment configuration
+    Then the Greengrass deployment is COMPLETED on the device after 5 minutes
+    And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes
+
+    And I discover core device broker as "default_broker" from "publisher" in OTF
+    And I connect device "publisher" on <agent> to "default_broker" using mqtt "<mqtt-v>"
+    And I connect device "subscriber" on <agent> to "default_broker" using mqtt "<mqtt-v>"
+
+    When I subscribe "subscriber" to "iot_data_0" with qos 1
+    When I publish from "publisher" to "iot_data_0" with qos 1 and message "Test message" and expect status 0
+    And message "Test message" received on "subscriber" from "iot_data_0" topic within 5 seconds
+    And I rename connection "publisher" to "publisher_old"
+
+    # Reconnect publisher with the same device id
+    And I connect device "publisher" on <agent> to "default_broker" using mqtt "<mqtt-v>"
+    When I publish from "publisher" to "iot_data_0" with qos 1 and message "Connect again" and expect status 0
+    And message "Connect again" received on "subscriber" from "iot_data_0" topic within 5 seconds
+
+    @mqtt3 @sdk-java
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient    | client_java_sdk.yaml    |
+
+    @mqtt3 @mosquitto-c @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
+
+    @mqtt3 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
+
+    @mqtt3 @paho-python
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v3     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
+
+    @mqtt5 @sdk-java
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | sdk-java    | aws.greengrass.client.Mqtt5JavaSdkClient    | client_java_sdk.yaml    |
+
+    @mqtt5 @mosquitto-c @SkipOnWindows
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
+
+    @mqtt5 @paho-java
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
+
+    @mqtt5 @paho-python
+    Examples:
+      | mqtt-v | name        | agent                                       | recipe                  |
+      | v5     | paho-python | aws.greengrass.client.Mqtt5PythonPahoClient | client_python_paho.yaml |
+
 
   @GGMQ-1-T27 @OffTheNetwork
   Scenario Outline: GGMQ-1-T27-<mqtt-v>-<name>: As a customer, my Greengrass-issued certificate does not rotate when mqtt reconnects

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -1887,10 +1887,11 @@ Feature: GGMQ-1
 
     # Reconnect publisher with the same device id
     And I connect device "publisher" on <agent> to "localMqttBroker1" using mqtt "<mqtt-v>"
-    And I wait 5 seconds
     When I publish from "publisher" to "iot_data_0" with qos 1 and message "Connect again" and expect status 0
     And message "Connect again" received on "subscriber" from "iot_data_0" topic within 5 seconds
 
+    # WARNING: Paho Java client does not work in this test because of "Untranslated MqttException - RC: 0"
+    # Add this client here after this issue will be fixed
     @mqtt3 @sdk-java
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
@@ -1900,11 +1901,6 @@ Feature: GGMQ-1
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v3     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
-
-    @mqtt3 @paho-java
-    Examples:
-      | mqtt-v | name        | agent                                       | recipe                  |
-      | v3     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
     @mqtt3 @paho-python
     Examples:
@@ -1920,11 +1916,6 @@ Feature: GGMQ-1
     Examples:
       | mqtt-v | name        | agent                                       | recipe                  |
       | v5     | mosquitto-c | aws.greengrass.client.MqttMosquittoClient   | client_mosquitto_c.yaml |
-
-    @mqtt5 @paho-java
-    Examples:
-      | mqtt-v | name        | agent                                       | recipe                  |
-      | v5     | paho-java   | aws.greengrass.client.Mqtt5JavaPahoClient   | client_java_paho.yaml   |
 
     @mqtt5 @paho-python
     Examples:


### PR DESCRIPTION
**Issue #, if available:**
Implement GGMQ scenario based on GGAD-1-T25

**Description of changes:**
- Add T25 scenario
- Add new step - rename a connection

**Why is this change necessary:**
Implement scenarios

**How was this change tested:**
Run scenario locally

**Test results:**
```
Given my device is registered as a Thing....................................passed
And my device is running Greengrass.........................................passed
When I create a Greengrass deployment with components.......................passed
And I create client device "publisher"......................................passed
And I create client device "subscriber".....................................passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:.passed
And I update my Greengrass deployment configuration, setting the component aws.greengrass.client.Mqtt5PythonPahoClient configuration to:.passed
When I associate "publisher" with ggc.......................................passed
When I associate "subscriber" with ggc......................................passed
And I deploy the Greengrass deployment configuration........................passed
Then the Greengrass deployment is COMPLETED on the device after 5 minutes...passed
And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes.passed
Then I discover core device broker as "localMqttBroker1" from "publisher" in OTF.passed
Then I discover core device broker as "localMqttBroker2" from "subscriber" in OTF.passed
And I connect device "publisher" on aws.greengrass.client.Mqtt5PythonPahoClient to "localMqttBroker1" using mqtt "v5".passed
And I connect device "subscriber" on aws.greengrass.client.Mqtt5PythonPahoClient to "localMqttBroker2" using mqtt "v5".passed
When I subscribe "subscriber" to "iot_data_0" with qos 1....................passed
When I publish from "publisher" to "iot_data_0" with qos 1 and message "Test message" and expect status 0.passed
And message "Test message" received on "subscriber" from "iot_data_0" topic within 5 seconds.passed
And I rename connection "publisher" to "publisher_old"......................passed
And I connect device "publisher" on aws.greengrass.client.Mqtt5PythonPahoClient to "localMqttBroker1" using mqtt "v5".passed
When I publish from "publisher" to "iot_data_0" with qos 1 and message "Connect again" and expect status 0.passed
And message "Connect again" received on "subscriber" from "iot_data_0" topic within 5 seconds.passed
```
All clients (except Java Paho):
```
[INFO ] 2023-08-01 15:54:25.075 [main] StepTrackingReporting - Passed: 'GGMQ-1-T25-v3-sdk-java: As a customer, I connect with same client id twice (not reconnect) and be able to publish and subscribe to messages.'
[INFO ] 2023-08-01 15:54:25.075 [main] StepTrackingReporting - Passed: 'GGMQ-1-T25-v3-mosquitto-c: As a customer, I connect with same client id twice (not reconnect) and be able to publish and subscribe to messages.'
[INFO ] 2023-08-01 15:54:25.075 [main] StepTrackingReporting - Passed: 'GGMQ-1-T25-v3-paho-python: As a customer, I connect with same client id twice (not reconnect) and be able to publish and subscribe to messages.'
[INFO ] 2023-08-01 15:54:25.075 [main] StepTrackingReporting - Passed: 'GGMQ-1-T25-v5-sdk-java: As a customer, I connect with same client id twice (not reconnect) and be able to publish and subscribe to messages.'
[INFO ] 2023-08-01 15:54:25.075 [main] StepTrackingReporting - Passed: 'GGMQ-1-T25-v5-mosquitto-c: As a customer, I connect with same client id twice (not reconnect) and be able to publish and subscribe to messages.'
[INFO ] 2023-08-01 15:54:25.075 [main] StepTrackingReporting - Passed: 'GGMQ-1-T25-v5-paho-python: As a customer, I connect with same client id twice (not reconnect) and be able to publish and subscribe to messages.'
```
Client Log:
```
2023-08-01T17:41:50.820Z [INFO] (pool-2-thread-23) aws.greengrass.client.Mqtt5JavaPahoClient: shell-runner-start. {scriptName=services.aws.greengrass.client.Mqtt5JavaPahoClient.lifecycle.Run, serviceName=aws.greengrass.client.Mqtt5JavaPahoClient, currentState=STARTING, command=["java -jar /tmp/gg-testing-12375312970262000714/gg-df6909aca85d4c94507b/package..."]}
2023-08-01T17:41:54.454Z [INFO] (Copier) aws.greengrass.client.Mqtt5JavaPahoClient: stdout. [INFO ] 2023-08-01 20:41:54.440 [main] GRPCLinkImpl - Making gPRC client connection with 172.21.0.1:45553 as aws.greengrass.client.Mqtt5JavaPahoClient.... {scriptName=services.aws.greengrass.client.Mqtt5JavaPahoClient.lifecycle.Run, serviceName=aws.greengrass.client.Mqtt5JavaPahoClient, currentState=RUNNING}
2023-08-01T17:41:54.482Z [INFO] (Copier) aws.greengrass.client.Mqtt5JavaPahoClient: stdout. WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.. {scriptName=services.aws.greengrass.client.Mqtt5JavaPahoClient.lifecycle.Run, serviceName=aws.greengrass.client.Mqtt5JavaPahoClient, currentState=RUNNING}
2023-08-01T17:41:56.192Z [INFO] (Copier) aws.greengrass.client.Mqtt5JavaPahoClient: stdout. [INFO ] 2023-08-01 20:41:56.189 [main] GRPCLinkImpl - Client connection with Control is established, local address is 192.168.100.20. {scriptName=services.aws.greengrass.client.Mqtt5JavaPahoClient.lifecycle.Run, serviceName=aws.greengrass.client.Mqtt5JavaPahoClient, currentState=RUNNING}
2023-08-01T17:41:56.330Z [INFO] (Copier) aws.greengrass.client.Mqtt5JavaPahoClient: stdout. [INFO ] 2023-08-01 20:41:56.330 [main] GRPCControlServer - GRPCControlServer created and listed on 192.168.100.20:39165. {scriptName=services.aws.greengrass.client.Mqtt5JavaPahoClient.lifecycle.Run, serviceName=aws.greengrass.client.Mqtt5JavaPahoClient, currentState=RUNNING}
2023-08-01T17:41:56.730Z [INFO] (Copier) aws.greengrass.client.Mqtt5JavaPahoClient: stdout. [INFO ] 2023-08-01 20:41:56.724 [main] GRPCLinkImpl - Handle gRPC requests. {scriptName=services.aws.greengrass.client.Mqtt5JavaPahoClient.lifecycle.Run, serviceName=aws.greengrass.client.Mqtt5JavaPahoClient, currentState=RUNNING}
2023-08-01T17:41:56.730Z [INFO] (Copier) aws.greengrass.client.Mqtt5JavaPahoClient: stdout. [INFO ] 2023-08-01 20:41:56.724 [main] GRPCControlServer - Server awaitTermination. {scriptName=services.aws.greengrass.client.Mqtt5JavaPahoClient.lifecycle.Run, serviceName=aws.greengrass.client.Mqtt5JavaPahoClient, currentState=RUNNING}
2023-08-01T17:42:21.621Z [INFO] (Copier) aws.greengrass.client.Mqtt5JavaPahoClient: stdout. [INFO ] 2023-08-01 20:42:21.620 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId gg-df6909aca85d4c94507b-publisher broker 192.168.100.20:8883. {scriptName=services.aws.greengrass.client.Mqtt5JavaPahoClient.lifecycle.Run, serviceName=aws.greengrass.client.Mqtt5JavaPahoClient, currentState=RUNNING}
2023-08-01T17:42:23.870Z [INFO] (Copier) aws.greengrass.client.Mqtt5JavaPahoClient: stdout. [INFO ] 2023-08-01 20:42:23.870 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId gg-df6909aca85d4c94507b-subscriber broker 192.168.100.20:8883. {scriptName=services.aws.greengrass.client.Mqtt5JavaPahoClient.lifecycle.Run, serviceName=aws.greengrass.client.Mqtt5JavaPahoClient, currentState=RUNNING}
2023-08-01T17:42:25.138Z [INFO] (Copier) aws.greengrass.client.Mqtt5JavaPahoClient: stdout. [INFO ] 2023-08-01 20:42:25.138 [grpc-default-executor-0] GRPCControlServer - Subscription: filter 'iot_data_0' QoS 1 noLocal false retainAsPublished false retainHandling 0. {scriptName=services.aws.greengrass.client.Mqtt5JavaPahoClient.lifecycle.Run, serviceName=aws.greengrass.client.Mqtt5JavaPahoClient, currentState=RUNNING}
2023-08-01T17:42:25.139Z [INFO] (Copier) aws.greengrass.client.Mqtt5JavaPahoClient: stdout. [INFO ] 2023-08-01 20:42:25.139 [grpc-default-executor-0] GRPCControlServer - Subscribe: connectionId 2 for 1 filters. {scriptName=services.aws.greengrass.client.Mqtt5JavaPahoClient.lifecycle.Run, serviceName=aws.greengrass.client.Mqtt5JavaPahoClient, currentState=RUNNING}
2023-08-01T17:42:25.169Z [INFO] (Copier) aws.greengrass.client.Mqtt5JavaPahoClient: stdout. [INFO ] 2023-08-01 20:42:25.169 [grpc-default-executor-0] GRPCControlServer - Subscribe response: connectionId 2 reason codes [1] reason string ''. {scriptName=services.aws.greengrass.client.Mqtt5JavaPahoClient.lifecycle.Run, serviceName=aws.greengrass.client.Mqtt5JavaPahoClient, currentState=RUNNING}
2023-08-01T17:42:25.200Z [INFO] (Copier) aws.greengrass.client.Mqtt5JavaPahoClient: stdout. [INFO ] 2023-08-01 20:42:25.199 [grpc-default-executor-0] GRPCControlServer - Publish: connectionId 1 topic 'iot_data_0' QoS 1 retain false. {scriptName=services.aws.greengrass.client.Mqtt5JavaPahoClient.lifecycle.Run, serviceName=aws.greengrass.client.Mqtt5JavaPahoClient, currentState=RUNNING}
2023-08-01T17:42:25.217Z [INFO] (Copier) aws.greengrass.client.Mqtt5JavaPahoClient: stdout. [INFO ] 2023-08-01 20:42:25.213 [MQTT Call: gg-df6909aca85d4c94507b-publisher] MqttConnectionImpl - Delivery completion is true. {scriptName=services.aws.greengrass.client.Mqtt5JavaPahoClient.lifecycle.Run, serviceName=aws.greengrass.client.Mqtt5JavaPahoClient, currentState=RUNNING}
2023-08-01T17:42:25.217Z [INFO] (Copier) aws.greengrass.client.Mqtt5JavaPahoClient: stdout. [INFO ] 2023-08-01 20:42:25.214 [grpc-default-executor-0] GRPCControlServer - Publish response: connectionId 1 reason code 0 reason string ''. {scriptName=services.aws.greengrass.client.Mqtt5JavaPahoClient.lifecycle.Run, serviceName=aws.greengrass.client.Mqtt5JavaPahoClient, currentState=RUNNING}
2023-08-01T17:42:25.231Z [INFO] (Copier) aws.greengrass.client.Mqtt5JavaPahoClient: stdout. [INFO ] 2023-08-01 20:42:25.230 [MQTT Call: gg-df6909aca85d4c94507b-subscriber] MqttConnectionImpl - Received MQTT message: connectionId 2 topic 'iot_data_0' QoS 1 retain false. {scriptName=services.aws.greengrass.client.Mqtt5JavaPahoClient.lifecycle.Run, serviceName=aws.greengrass.client.Mqtt5JavaPahoClient, currentState=RUNNING}
2023-08-01T17:42:25.232Z [INFO] (Copier) aws.greengrass.client.Mqtt5JavaPahoClient: stdout. [INFO ] 2023-08-01 20:42:25.232 [MQTT Call: gg-df6909aca85d4c94507b-subscriber] MqttConnectionImpl - Received MQTT message has payload format indicator 'false'. {scriptName=services.aws.greengrass.client.Mqtt5JavaPahoClient.lifecycle.Run, serviceName=aws.greengrass.client.Mqtt5JavaPahoClient, currentState=RUNNING}
2023-08-01T17:42:25.260Z [INFO] (Copier) aws.greengrass.client.Mqtt5JavaPahoClient: stdout. [INFO ] 2023-08-01 20:42:25.261 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId gg-df6909aca85d4c94507b-publisher broker 192.168.100.20:8883. {scriptName=services.aws.greengrass.client.Mqtt5JavaPahoClient.lifecycle.Run, serviceName=aws.greengrass.client.Mqtt5JavaPahoClient, currentState=RUNNING}
2023-08-01T17:42:26.468Z [INFO] (Copier) aws.greengrass.client.Mqtt5JavaPahoClient: stdout. [INFO ] 2023-08-01 20:42:26.467 [MQTT Rec: gg-df6909aca85d4c94507b-publisher] MqttConnectionImpl - MQTT connectionId 1 disconnected error 'null' disconnectInfo 'com.aws.greengrass.testing.mqtt5.client.GRPCClient$DisconnectInfo@42609add'. {scriptName=services.aws.greengrass.client.Mqtt5JavaPahoClient.lifecycle.Run, serviceName=aws.greengrass.client.Mqtt5JavaPahoClient, currentState=RUNNING}
2023-08-01T17:42:26.477Z [INFO] (Copier) aws.greengrass.client.Mqtt5JavaPahoClient: stdout. [INFO ] 2023-08-01 20:42:26.476 [grpc-default-executor-0] GRPCControlServer - Publish: connectionId 3 topic 'iot_data_0' QoS 1 retain false. {scriptName=services.aws.greengrass.client.Mqtt5JavaPahoClient.lifecycle.Run, serviceName=aws.greengrass.client.Mqtt5JavaPahoClient, currentState=RUNNING}
2023-08-01T17:42:26.486Z [INFO] (Copier) aws.greengrass.client.Mqtt5JavaPahoClient: stdout. [INFO ] 2023-08-01 20:42:26.483 [grpc-default-executor-0] GRPCControlServer - Publish response: connectionId 3 reason code 0 reason string ''. {scriptName=services.aws.greengrass.client.Mqtt5JavaPahoClient.lifecycle.Run, serviceName=aws.greengrass.client.Mqtt5JavaPahoClient, currentState=RUNNING}
2023-08-01T17:42:26.487Z [INFO] (Copier) aws.greengrass.client.Mqtt5JavaPahoClient: stdout. [INFO ] 2023-08-01 20:42:26.485 [MQTT Call: gg-df6909aca85d4c94507b-subscriber] MqttConnectionImpl - Received MQTT message: connectionId 2 topic 'iot_data_0' QoS 1 retain false. {scriptName=services.aws.greengrass.client.Mqtt5JavaPahoClient.lifecycle.Run, serviceName=aws.greengrass.client.Mqtt5JavaPahoClient, currentState=RUNNING}
2023-08-01T17:42:26.487Z [INFO] (Copier) aws.greengrass.client.Mqtt5JavaPahoClient: stdout. [INFO ] 2023-08-01 20:42:26.486 [MQTT Call: gg-df6909aca85d4c94507b-subscriber] MqttConnectionImpl - Received MQTT message has payload format indicator 'false'. {scriptName=services.aws.greengrass.client.Mqtt5JavaPahoClient.lifecycle.Run, serviceName=aws.greengrass.client.Mqtt5JavaPahoClient, currentState=RUNNING}
2023-08-01T17:42:26.498Z [INFO] (Copier) aws.greengrass.client.Mqtt5JavaPahoClient: stdout. [INFO ] 2023-08-01 20:42:26.495 [MQTT Call: gg-df6909aca85d4c94507b-publisher] MqttConnectionImpl - Delivery completion is true. {scriptName=services.aws.greengrass.client.Mqtt5JavaPahoClient.lifecycle.Run, serviceName=aws.greengrass.client.Mqtt5JavaPahoClient, currentState=RUNNING}
2023-08-01T17:42:27.392Z [INFO] (Copier) aws.greengrass.client.Mqtt5JavaPahoClient: Run script exited. {exitCode=137, serviceName=aws.greengrass.client.Mqtt5JavaPahoClient, currentState=STOPPING}
```
Test console log:
```
sudo -E java -Dggc.archive=greengrass-nucleus-latest.zip -Dtest.log.path=logs -Dtags="@GGMQ-1-T25 and @mqtt5 and @paho-java" -jar testing-features/target/client-devices-auth-testing-features.jar
[sudo] password for egor: 
WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
[INFO ] 2023-08-01 20:40:10.095 [main] GreengrassContextModule - Extracting greengrass-nucleus-latest.zip into /tmp/gg-testing-12375312970262000714/greengrass
[INFO ] 2023-08-01 20:40:10.610 [main] LoggerSteps - OTF Version is otf-1.2.0-SNAPSHOT
[INFO ] 2023-08-01 20:40:10.610 [main] LoggerSteps - Attaching thread context to scenario: 'GGMQ-1-T25-v5-paho-java: As a customer, I connect with same client id twice (not reconnect) and be able to publish and subscribe to messages.'
[INFO ] 2023-08-01 20:40:11.705 [main] AbstractAWSResourceLifecycle - Created GreengrassCoreDevice in GreengrassV2Lifecycle
[INFO ] 2023-08-01 20:40:12.298 [main] AbstractAWSResourceLifecycle - Created IotPolicy in IotLifecycle
[INFO ] 2023-08-01 20:40:13.523 [main] AbstractAWSResourceLifecycle - Created IamPolicy in IamLifecycle
[INFO ] 2023-08-01 20:40:13.984 [main] AbstractAWSResourceLifecycle - Created IamRole in IamLifecycle
[INFO ] 2023-08-01 20:40:14.342 [main] AbstractAWSResourceLifecycle - Created IotRoleAlias in IotLifecycle
[INFO ] 2023-08-01 20:40:14.511 [main] AbstractAWSResourceLifecycle - Created IotPolicy in IotLifecycle
[INFO ] 2023-08-01 20:40:14.669 [main] AbstractAWSResourceLifecycle - Created IotThingGroup in IotLifecycle
[INFO ] 2023-08-01 20:40:15.641 [main] AbstractAWSResourceLifecycle - Created IotCertificate in IotLifecycle
[INFO ] 2023-08-01 20:40:15.810 [main] AbstractAWSResourceLifecycle - Created IotThing in IotLifecycle
[INFO ] 2023-08-01 20:40:16.469 [main] RegistrationSteps - IoT Role alias not ready yet, got 400: {"message":"Unable to assume the role, or the role to assume does not exist"}
[INFO ] 2023-08-01 20:40:22.866 [main] RegistrationSteps - IoT Role alias returned 200, credentials should be good to go!
[INFO ] 2023-08-01 20:40:23.060 [main] feature - Finished step: 'my device is registered as a Thing' with status PASSED
[INFO ] 2023-08-01 20:40:24.311 [main] DefaultGreengrass - Starting Greengrass on pid 19618
[INFO ] 2023-08-01 20:40:24.312 [main] feature - Finished step: 'my device is running Greengrass' with status PASSED
[INFO ] 2023-08-01 20:40:27.354 [main] AbstractAWSResourceLifecycle - Created S3Bucket in S3Lifecycle
[INFO ] 2023-08-01 20:40:36.252 [main] AbstractAWSResourceLifecycle - Created S3Object in S3Lifecycle
[INFO ] 2023-08-01 20:40:36.253 [main] RecipeComponentPreparationService - Uploaded /tmp/gg-testing-12375312970262000714/df6909aca85d4c94507b/components/aws.greengrass.client.Mqtt5JavaPahoClient/aws.greengrass.client.Mqtt5JavaPahoClient.jar to s3://gg-df6909aca85d4c94507b-gg-component-store/local-store/artifacts/aws.greengrass.client.Mqtt5JavaPahoClient.jar
[INFO ] 2023-08-01 20:40:37.016 [main] AbstractAWSResourceLifecycle - Created GreengrassComponent in GreengrassV2Lifecycle
[INFO ] 2023-08-01 20:40:37.016 [main] RecipeComponentPreparationService - Created component aws.greengrass.client.Mqtt5JavaPahoClient:1.0.0-df6909aca85d4c94507b from /local-store/recipes/client_java_paho.yaml
[INFO ] 2023-08-01 20:40:37.017 [main] feature - Finished step: 'I create a Greengrass deployment with components' with status PASSED
[INFO ] 2023-08-01 20:40:37.172 [main] EngineControlImpl - MQTT client control gRPC server started, listening on 45553
[INFO ] 2023-08-01 20:40:37.172 [main] MqttControlSteps - MQTT clients control started gRPC service on port 45553 addresses [172.21.0.1, 172.18.0.1, 172.17.0.1, 192.168.100.20]
[INFO ] 2023-08-01 20:40:37.318 [main] AbstractAWSResourceLifecycle - Created IotPolicy in IotLifecycle
[INFO ] 2023-08-01 20:40:38.064 [main] AbstractAWSResourceLifecycle - Created IotCertificate in IotLifecycle
[INFO ] 2023-08-01 20:40:38.065 [main] AbstractAWSResourceLifecycle - Created IotThing in IotLifecycle
[INFO ] 2023-08-01 20:40:38.065 [main] feature - Finished step: 'I create client device "publisher"' with status PASSED
[INFO ] 2023-08-01 20:40:38.224 [main] AbstractAWSResourceLifecycle - Created IotPolicy in IotLifecycle
[INFO ] 2023-08-01 20:40:39.025 [main] AbstractAWSResourceLifecycle - Created IotCertificate in IotLifecycle
[INFO ] 2023-08-01 20:40:39.025 [main] AbstractAWSResourceLifecycle - Created IotThing in IotLifecycle
[INFO ] 2023-08-01 20:40:39.025 [main] feature - Finished step: 'I create client device "subscriber"' with status PASSED
[INFO ] 2023-08-01 20:40:39.169 [main] feature - Finished step: 'I associate "publisher" with ggc' with status PASSED
[INFO ] 2023-08-01 20:40:39.292 [main] feature - Finished step: 'I associate "subscriber" with ggc' with status PASSED
[INFO ] 2023-08-01 20:40:39.306 [main] feature - Finished step: 'I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:' with status PASSED
[INFO ] 2023-08-01 20:40:39.307 [main] feature - Finished step: 'I update my Greengrass deployment configuration, setting the component aws.greengrass.client.Mqtt5JavaPahoClient configuration to:' with status PASSED
[INFO ] 2023-08-01 20:40:39.685 [main] AbstractAWSResourceLifecycle - Created GreengrassDeployment in GreengrassV2Lifecycle
[INFO ] 2023-08-01 20:40:39.685 [main] DeploymentSteps - Created Greengrass deployment: e095b5e0-4101-4a63-b2b1-9954248cf8ce
[INFO ] 2023-08-01 20:40:39.685 [main] feature - Finished step: 'I deploy the Greengrass deployment configuration' with status PASSED
[INFO ] 2023-08-01 20:41:56.062 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId aws.greengrass.client.Mqtt5JavaPahoClient
[INFO ] 2023-08-01 20:41:56.359 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId aws.greengrass.client.Mqtt5JavaPahoClient address 192.168.100.20 port 39165
[INFO ] 2023-08-01 20:41:56.362 [grpc-default-executor-0] EngineControlImpl - Created new agent control for aws.greengrass.client.Mqtt5JavaPahoClient on 192.168.100.20:39165
[INFO ] 2023-08-01 20:41:56.604 [grpc-default-executor-0] MqttControlSteps - Agent aws.greengrass.client.Mqtt5JavaPahoClient is connected
[INFO ] 2023-08-01 20:42:18.724 [main] feature - Finished step: 'the Greengrass deployment is COMPLETED on the device after 5 minutes' with status PASSED
[INFO ] 2023-08-01 20:42:19.754 [main] feature - Finished step: 'the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes' with status PASSED
[INFO ] 2023-08-01 20:42:20.772 [main] MqttControlSteps - Discovered data for broker localMqttBroker1:
[INFO ] 2023-08-01 20:42:20.774 [main] MqttControlSteps - groupId greengrassV2-coreDevice-gg-df6909aca85d4c94507b-ggc-thing with 1 CA
[INFO ] 2023-08-01 20:42:20.774 [main] MqttControlSteps - Core with thing Arn arn:aws:iot:eu-central-1:285891398846:thing/gg-df6909aca85d4c94507b-ggc-thing
[INFO ] 2023-08-01 20:42:20.775 [main] MqttControlSteps - Connectivity info: id 192.168.100.20 host 192.168.100.20 port 8883
[INFO ] 2023-08-01 20:42:20.777 [main] feature - Finished step: 'I discover core device broker as "localMqttBroker1" from "publisher" in OTF' with status PASSED
[INFO ] 2023-08-01 20:42:21.481 [main] MqttControlSteps - Discovered data for broker localMqttBroker2:
[INFO ] 2023-08-01 20:42:21.481 [main] MqttControlSteps - groupId greengrassV2-coreDevice-gg-df6909aca85d4c94507b-ggc-thing with 1 CA
[INFO ] 2023-08-01 20:42:21.481 [main] MqttControlSteps - Core with thing Arn arn:aws:iot:eu-central-1:285891398846:thing/gg-df6909aca85d4c94507b-ggc-thing
[INFO ] 2023-08-01 20:42:21.481 [main] MqttControlSteps - Connectivity info: id 192.168.100.20 host 192.168.100.20 port 8883
[INFO ] 2023-08-01 20:42:21.481 [main] feature - Finished step: 'I discover core device broker as "localMqttBroker2" from "subscriber" in OTF' with status PASSED
[INFO ] 2023-08-01 20:42:21.482 [main] MqttControlSteps - Creating MQTT connection with broker localMqttBroker1 to address 192.168.100.20:8883 as Thing gg-df6909aca85d4c94507b-publisher on aws.greengrass.client.Mqtt5JavaPahoClient using MQTT v5
[INFO ] 2023-08-01 20:42:23.805 [main] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
retainAvailable: true
maximumPacketSize: 268435455
'
[INFO ] 2023-08-01 20:42:23.863 [main] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-08-01 20:42:23.863 [main] MqttControlSteps - Connection with broker localMqttBroker1 established to address 192.168.100.20:8883 as Thing gg-df6909aca85d4c94507b-publisher on aws.greengrass.client.Mqtt5JavaPahoClient
[INFO ] 2023-08-01 20:42:23.863 [main] feature - Finished step: 'I connect device "publisher" on aws.greengrass.client.Mqtt5JavaPahoClient to "localMqttBroker1" using mqtt "v5"' with status PASSED
[INFO ] 2023-08-01 20:42:23.864 [main] MqttControlSteps - Creating MQTT connection with broker localMqttBroker2 to address 192.168.100.20:8883 as Thing gg-df6909aca85d4c94507b-subscriber on aws.greengrass.client.Mqtt5JavaPahoClient using MQTT v5
[INFO ] 2023-08-01 20:42:25.117 [main] AgentControlImpl - Created connection with id 2 CONNACK 'sessionPresent: false
retainAvailable: true
maximumPacketSize: 268435455
'
[INFO ] 2023-08-01 20:42:25.124 [main] AgentControlImpl - createMqttConnection: MQTT connectionId 2 created
[INFO ] 2023-08-01 20:42:25.124 [main] MqttControlSteps - Connection with broker localMqttBroker2 established to address 192.168.100.20:8883 as Thing gg-df6909aca85d4c94507b-subscriber on aws.greengrass.client.Mqtt5JavaPahoClient
[INFO ] 2023-08-01 20:42:25.125 [main] feature - Finished step: 'I connect device "subscriber" on aws.greengrass.client.Mqtt5JavaPahoClient to "localMqttBroker2" using mqtt "v5"' with status PASSED
[INFO ] 2023-08-01 20:42:25.126 [main] MqttControlSteps - Create MQTT subscription for Thing gg-df6909aca85d4c94507b-subscriber to topics filter iot_data_0 with QoS 1 no local false retain handling MQTT5_RETAIN_SEND_AT_SUBSCRIPTION
[INFO ] 2023-08-01 20:42:25.127 [main] AgentControlImpl - SubscribeMqtt: subscribe on connection 2
[INFO ] 2023-08-01 20:42:25.174 [main] MqttControlSteps - MQTT subscription has on topics filter iot_data_0 been created with reason code 1
[INFO ] 2023-08-01 20:42:25.174 [main] feature - Finished step: 'I subscribe "subscriber" to "iot_data_0" with qos 1' with status PASSED
[INFO ] 2023-08-01 20:42:25.175 [main] MqttControlSteps - Publishing MQTT message 'Test message' as Thing gg-df6909aca85d4c94507b-publisher to topic iot_data_0 with QoS 1 retain false payload format indicator null message expire interval null response topic null correlation data null
[INFO ] 2023-08-01 20:42:25.177 [main] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic iot_data_0
[INFO ] 2023-08-01 20:42:25.224 [main] MqttControlSteps - MQTT message 'Test message' has been succesfully published
[INFO ] 2023-08-01 20:42:25.225 [main] feature - Finished step: 'I publish from "publisher" to "iot_data_0" with qos 1 and message "Test message"' with status PASSED
[INFO ] 2023-08-01 20:42:25.225 [main] MqttControlSteps - Awaiting for MQTT message 'Test message' with retain null payload format indicator null message expiry interval null response topic null correlation data null on topic 'iot_data_0' on Thing 'gg-df6909aca85d4c94507b-subscriber' for 5 seconds
[INFO ] 2023-08-01 20:42:25.252 [grpc-default-executor-0] GRPCDiscoveryServer - OnReceiveMessage: agentId aws.greengrass.client.Mqtt5JavaPahoClient connectionId 2 topic iot_data_0 QoS 1
[INFO ] 2023-08-01 20:42:25.253 [main] feature - Finished step: 'message "Test message" received on "subscriber" from "iot_data_0" topic within 5 seconds' with status PASSED
[INFO ] 2023-08-01 20:42:25.254 [main] MqttControlSteps - Connection gg-df6909aca85d4c94507b-publisher was renamed to gg-df6909aca85d4c94507b-publisher_old
[INFO ] 2023-08-01 20:42:25.254 [main] feature - Finished step: 'I rename connection "publisher" to "publisher_old"' with status PASSED
[INFO ] 2023-08-01 20:42:25.254 [main] MqttControlSteps - Creating MQTT connection with broker localMqttBroker1 to address 192.168.100.20:8883 as Thing gg-df6909aca85d4c94507b-publisher on aws.greengrass.client.Mqtt5JavaPahoClient using MQTT v5
[INFO ] 2023-08-01 20:42:25.253 [grpc-default-executor-0] MqttControlSteps - Message received on connection with name gg-df6909aca85d4c94507b-subscriber: topic: "iot_data_0"
payload: "Test message"
qos: MQTT_QOS_1
payloadFormatIndicator: false

[INFO ] 2023-08-01 20:42:26.470 [main] AgentControlImpl - Created connection with id 3 CONNACK 'sessionPresent: false
retainAvailable: true
maximumPacketSize: 268435455
'
[INFO ] 2023-08-01 20:42:26.470 [main] AgentControlImpl - createMqttConnection: MQTT connectionId 3 created
[INFO ] 2023-08-01 20:42:26.470 [main] MqttControlSteps - Connection with broker localMqttBroker1 established to address 192.168.100.20:8883 as Thing gg-df6909aca85d4c94507b-publisher on aws.greengrass.client.Mqtt5JavaPahoClient
[INFO ] 2023-08-01 20:42:26.470 [main] feature - Finished step: 'I connect device "publisher" on aws.greengrass.client.Mqtt5JavaPahoClient to "localMqttBroker1" using mqtt "v5"' with status PASSED
[INFO ] 2023-08-01 20:42:26.471 [main] MqttControlSteps - Publishing MQTT message 'Connect again' as Thing gg-df6909aca85d4c94507b-publisher to topic iot_data_0 with QoS 1 retain false payload format indicator null message expire interval null response topic null correlation data null
[INFO ] 2023-08-01 20:42:26.471 [main] AgentControlImpl - PublishMqtt: publishing on connectionId 3 topic iot_data_0
[INFO ] 2023-08-01 20:42:26.498 [grpc-default-executor-0] GRPCDiscoveryServer - OnReceiveMessage: agentId aws.greengrass.client.Mqtt5JavaPahoClient connectionId 2 topic iot_data_0 QoS 1
[INFO ] 2023-08-01 20:42:26.498 [grpc-default-executor-0] MqttControlSteps - Message received on connection with name gg-df6909aca85d4c94507b-subscriber: topic: "iot_data_0"
payload: "Connect again"
qos: MQTT_QOS_1
payloadFormatIndicator: false

[INFO ] 2023-08-01 20:42:26.497 [main] MqttControlSteps - MQTT message 'Connect again' has been succesfully published
[INFO ] 2023-08-01 20:42:26.498 [main] feature - Finished step: 'I publish from "publisher" to "iot_data_0" with qos 1 and message "Connect again"' with status PASSED
[INFO ] 2023-08-01 20:42:26.500 [main] MqttControlSteps - Awaiting for MQTT message 'Connect again' with retain null payload format indicator null message expiry interval null response topic null correlation data null on topic 'iot_data_0' on Thing 'gg-df6909aca85d4c94507b-subscriber' for 5 seconds
[INFO ] 2023-08-01 20:42:26.500 [main] feature - Finished step: 'message "Connect again" received on "subscriber" from "iot_data_0" topic within 5 seconds' with status PASSED
[INFO ] 2023-08-01 20:42:26.581 [grpc-default-executor-0] GRPCDiscoveryServer - OnMqttDisconnect: agentId aws.greengrass.client.Mqtt5JavaPahoClient connectionId 1 disconnect 'reasonCode: 142
' error ''
[INFO ] 2023-08-01 20:42:26.584 [grpc-default-executor-0] MqttControlSteps - MQTT client disconnected. Error: 
[INFO ] 2023-08-01 20:42:44.001 [main] DefaultGreengrass - Stopped Greengrass on pid 19618
[INFO ] 2023-08-01 20:42:44.535 [main] AbstractAWSResourceLifecycle - Removed S3Object in S3Lifecycle
[INFO ] 2023-08-01 20:42:44.972 [main] AbstractAWSResourceLifecycle - Removed S3Bucket in S3Lifecycle
[INFO ] 2023-08-01 20:42:46.298 [main] AbstractAWSResourceLifecycle - Removed IamRole in IamLifecycle
[INFO ] 2023-08-01 20:42:46.838 [main] AbstractAWSResourceLifecycle - Removed IamPolicy in IamLifecycle
[INFO ] 2023-08-01 20:42:47.367 [main] AbstractAWSResourceLifecycle - Removed IotThing in IotLifecycle
[INFO ] 2023-08-01 20:42:47.813 [main] AbstractAWSResourceLifecycle - Removed IotCertificate in IotLifecycle
[INFO ] 2023-08-01 20:42:48.034 [main] AbstractAWSResourceLifecycle - Removed IotPolicy in IotLifecycle
[INFO ] 2023-08-01 20:42:48.307 [main] AbstractAWSResourceLifecycle - Removed IotThing in IotLifecycle
[INFO ] 2023-08-01 20:42:48.705 [main] AbstractAWSResourceLifecycle - Removed IotCertificate in IotLifecycle
[INFO ] 2023-08-01 20:42:48.945 [main] AbstractAWSResourceLifecycle - Removed IotPolicy in IotLifecycle
[INFO ] 2023-08-01 20:42:49.197 [main] AbstractAWSResourceLifecycle - Removed IotThing in IotLifecycle
[INFO ] 2023-08-01 20:42:49.643 [main] AbstractAWSResourceLifecycle - Removed IotCertificate in IotLifecycle
[INFO ] 2023-08-01 20:42:49.765 [main] AbstractAWSResourceLifecycle - Removed IotThingGroup in IotLifecycle
[INFO ] 2023-08-01 20:42:49.961 [main] AbstractAWSResourceLifecycle - Removed IotPolicy in IotLifecycle
[INFO ] 2023-08-01 20:42:50.069 [main] AbstractAWSResourceLifecycle - Removed IotRoleAlias in IotLifecycle
[INFO ] 2023-08-01 20:42:50.285 [main] AbstractAWSResourceLifecycle - Removed IotPolicy in IotLifecycle
[INFO ] 2023-08-01 20:42:50.766 [main] AbstractAWSResourceLifecycle - Removed GreengrassDeployment in GreengrassV2Lifecycle
[INFO ] 2023-08-01 20:42:51.001 [main] AbstractAWSResourceLifecycle - Removed GreengrassComponent in GreengrassV2Lifecycle
[INFO ] 2023-08-01 20:42:51.263 [main] AbstractAWSResourceLifecycle - Removed GreengrassCoreDevice in GreengrassV2Lifecycle
[INFO ] 2023-08-01 20:42:51.263 [main] AWSResourcesSteps - Successfully removed externally created resources
[INFO ] 2023-08-01 20:42:51.267 [main] AgentControlImpl - shutting down channel with agent id aws.greengrass.client.Mqtt5JavaPahoClient
[INFO ] 2023-08-01 20:42:51.276 [main] AgentControlImpl - channel terminated with agent id aws.greengrass.client.Mqtt5JavaPahoClient
[INFO ] 2023-08-01 20:42:51.276 [main] MqttControlSteps - Agent aws.greengrass.client.Mqtt5JavaPahoClient is disconnected
[INFO ] 2023-08-01 20:42:51.289 [main] EngineControlImpl - gRPC MQTT client control server stopped
[INFO ] 2023-08-01 20:42:51.301 [main] LoggerSteps - Clearing thread context on scenario: 'GGMQ-1-T25-v5-paho-java: As a customer, I connect with same client id twice (not reconnect) and be able to publish and subscribe to messages.'
[INFO ] 2023-08-01 20:42:51.313 [main] StepTrackingReporting - Passed: 'GGMQ-1-T25-v5-paho-java: As a customer, I connect with same client id twice (not reconnect) and be able to publish and subscribe to messages.'
[INFO ] 2023-08-01 20:42:51.513 [Thread-1] AWSResourcesCleanupModule - Cleaned up TestContext{testId=TestId{prefix=gg, id=df6909aca85d4c94507b}, testDirectory=/tmp/gg-testing-12375312970262000714/gg-df6909aca85d4c94507b, testResultsPath=logs, cleanupContext=CleanupContext{persistAWSResources=false, persistInstalledSoftware=false, persistGeneratedFiles=false}, initializationContext=InitializationContext{persistModes=[], persistAWSResources=false, persistInstalledSoftware=false, persistGeneratedFiles=false}, logLevel=INFO, installRoot=/tmp/gg-testing-12375312970262000714/gg-df6909aca85d4c94507b, currentUser=root, coreThingName=gg-df6909aca85d4c94507b-ggc-thing, coreVersion=2.11.1, tesRoleName=, hsmConfigured=false, trustedPluginsPaths=[]}
[INFO ] 2023-08-01 20:42:51.514 [Thread-1] AWSResourcesCleanupModule - Cleaned up com.aws.greengrass.testing.resources.AWSResources@b4b352d4
[INFO ] 2023-08-01 20:42:51.515 [Thread-1] AWSResourcesCleanupModule - Cleaned up com.aws.greengrass.testing.api.device.local.LocalDevice@12e12ac9
[INFO ] 2023-08-01 20:42:51.530 [Thread-1] AWSResourcesCleanupModule - Cleaned up GreengrassContext{version=2.11.1, tempDirectory=/tmp/gg-testing-12375312970262000714, cleanupContext=CleanupContext{persistAWSResources=false, persistInstalledSoftware=false, persistGeneratedFiles=false}}
[INFO ] 2023-08-01 20:42:51.533 [Thread-1] AWSResourcesCleanupModule - Cleaned up com.aws.greengrass.testing.resources.iam.IamLifecycle$$EnhancerByGuice$$29755102@e14b7a97
[INFO ] 2023-08-01 20:42:51.533 [Thread-1] AWSResourcesCleanupModule - Cleaned up com.aws.greengrass.testing.resources.greengrass.GreengrassV2Lifecycle$$EnhancerByGuice$$22233735@1f55939a
```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
