### PR TITLE
fix(uat): switch from in-files to in-memory persistence module in paho-java

### DIFF
--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt311/client/paho/Mqtt311ConnectionImpl.java
@@ -24,6 +24,7 @@ import org.eclipse.paho.client.mqttv3.MqttAsyncClient;
 import org.eclipse.paho.client.mqttv3.MqttCallback;
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -189,9 +190,9 @@ public class Mqtt311ConnectionImpl implements MqttConnection {
      */
     private IMqttAsyncClient createAsyncClient(MqttLib.ConnectionParams connectionParams)
             throws org.eclipse.paho.client.mqttv3.MqttException {
-        String uri = createUri(connectionParams.getHost(), connectionParams.getPort(),
-                connectionParams.getCert() != null);
-        return new MqttAsyncClient(uri, connectionParams.getClientId());
+        final boolean hasTls = connectionParams.getCert() != null;
+        final String uri = createUri(connectionParams.getHost(), connectionParams.getPort(), hasTls);
+        return new MqttAsyncClient(uri, connectionParams.getClientId(), new MemoryPersistence());
     }
 
     private MqttConnectOptions convertParams(MqttLib.ConnectionParams connectionParams)

--- a/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
+++ b/uat/custom-components/client-java-paho/src/main/java/com/aws/greengrass/testing/mqtt5/client/paho/MqttConnectionImpl.java
@@ -23,6 +23,7 @@ import org.eclipse.paho.mqttv5.client.MqttAsyncClient;
 import org.eclipse.paho.mqttv5.client.MqttCallback;
 import org.eclipse.paho.mqttv5.client.MqttConnectionOptions;
 import org.eclipse.paho.mqttv5.client.MqttDisconnectResponse;
+import org.eclipse.paho.mqttv5.client.persist.MemoryPersistence;
 import org.eclipse.paho.mqttv5.common.MqttMessage;
 import org.eclipse.paho.mqttv5.common.MqttSubscription;
 import org.eclipse.paho.mqttv5.common.packet.MqttProperties;
@@ -264,9 +265,10 @@ public class MqttConnectionImpl implements MqttConnection {
      */
     private IMqttAsyncClient createAsyncClient(MqttLib.ConnectionParams connectionParams)
             throws org.eclipse.paho.mqttv5.common.MqttException {
-        String uri = createUri(connectionParams.getHost(), connectionParams.getPort(),
-                connectionParams.getCert() != null);
-        return new MqttAsyncClient(uri, connectionParams.getClientId());
+        final boolean hasTls = connectionParams.getCert() != null;
+        final String uri = createUri(connectionParams.getHost(), connectionParams.getPort(), hasTls);
+
+        return new MqttAsyncClient(uri, connectionParams.getClientId(), new MemoryPersistence());
     }
 
     private void disconnectAndClose(long timeout, int reasonCode, List<Mqtt5Properties> userProperties)


### PR DESCRIPTION
**Issue #, if available:**
Paho Java - exception when publishing during disconnect

**Description of changes:**
- Switch from file to in-memory persistence module in paho-java

**Why is this change necessary:**
Seems in-file persistence module of paho-java library has a bug and throws an exception when we created second connection with the same MQTT client_id.

**How was this change tested:**
Manually by run modified Control app where second connection is established.

**Test results:**
For MQTT v5.0:
Control:
```
[INFO] --- exec-maven-plugin:3.1.0:java (default-cli) @ aws-greengrass-testing-mqtt-client-control ---
[INFO ] 2023-08-01 15:25:42.880 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] ExampleControl - Control: port 47619, with TLS, MQTT v5
[INFO ] 2023-08-01 15:25:43.143 [com.aws.greengrass.testing.mqtt.client.control.ExampleControl.main()] EngineControlImpl - MQTT client control gRPC server started, listening on 47619
[INFO ] 2023-08-01 15:27:07.662 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId paho-java-agent
[INFO ] 2023-08-01 15:27:07.723 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId paho-java-agent address 127.0.0.1 port 35261
[INFO ] 2023-08-01 15:27:07.727 [grpc-default-executor-0] EngineControlImpl - Created new agent control for paho-java-agent on 127.0.0.1:35261
[INFO ] 2023-08-01 15:27:07.775 [grpc-default-executor-0] ExampleControl - Agent paho-java-agent is connected
[INFO ] 2023-08-01 15:27:07.778 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id paho-java-agent
[INFO ] 2023-08-01 15:27:10.792 [pool-2-thread-1] AgentTestScenario - Set CONNECT user property: region, US
[INFO ] 2023-08-01 15:27:10.792 [pool-2-thread-1] AgentTestScenario - Set CONNECT user property: type, JSON
[INFO ] 2023-08-01 15:27:10.793 [pool-2-thread-1] AgentTestScenario - Set CONNECT request response information true
[INFO ] 2023-08-01 15:27:11.920 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: false
receiveMaximum: 100
maximumQoS: 1
retainAvailable: true
maximumPacketSize: 149504
serverKeepAlive: 60
'
[INFO ] 2023-08-01 15:27:11.920 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-08-01 15:27:11.921 [pool-2-thread-1] AgentTestScenario - MQTT connection #1 with id 1 is established
[INFO ] 2023-08-01 15:27:16.927 [pool-2-thread-1] AgentTestScenario - Set SUBSCRIBE user property: region, US
[INFO ] 2023-08-01 15:27:16.927 [pool-2-thread-1] AgentTestScenario - Set SUBSCRIBE user property: type, JSON
[INFO ] 2023-08-01 15:27:16.930 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-08-01 15:27:17.014 [pool-2-thread-1] AgentTestScenario - Subscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-08-01 15:27:27.020 [pool-2-thread-1] AgentTestScenario - Set PUBLISH payload format indicator true
[INFO ] 2023-08-01 15:27:27.020 [pool-2-thread-1] AgentTestScenario - Set PUBLISH message expiry interval 3600
[INFO ] 2023-08-01 15:27:27.020 [pool-2-thread-1] AgentTestScenario - Set PUBLISH response topic /thing1/response/topic
[INFO ] 2023-08-01 15:27:27.021 [pool-2-thread-1] AgentTestScenario - Set PUBLISH correlation data <ByteString@284044eb size=16 contents="correlation_data">
[INFO ] 2023-08-01 15:27:27.022 [pool-2-thread-1] AgentTestScenario - Set PUBLISH user property: region, US
[INFO ] 2023-08-01 15:27:27.022 [pool-2-thread-1] AgentTestScenario - Set PUBLISH user property: type, JSON
[INFO ] 2023-08-01 15:27:27.022 [pool-2-thread-1] AgentTestScenario - Set PUBLISH content type text/plain; charset=utf-8
[INFO ] 2023-08-01 15:27:27.024 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic test/topic
[INFO ] 2023-08-01 15:27:27.071 [pool-2-thread-1] AgentTestScenario - Published connectionId 1 reason code 0 reason string ''
[INFO ] 2023-08-01 15:27:27.078 [grpc-default-executor-0] GRPCDiscoveryServer - OnReceiveMessage: agentId paho-java-agent connectionId 1 topic test/topic QoS 0
[INFO ] 2023-08-01 15:27:27.078 [grpc-default-executor-0] AgentTestScenario - Message received on agentId paho-java-agent connectionId 1 topic test/topic QoS 0 content <ByteString@614fbf66 size=12 contents="Hello World!">
[INFO ] 2023-08-01 15:27:27.079 [grpc-default-executor-0] AgentTestScenario - Message has payload format indicator true
[INFO ] 2023-08-01 15:27:27.079 [grpc-default-executor-0] AgentTestScenario - Message has message expiry interval 3599
[INFO ] 2023-08-01 15:27:27.079 [grpc-default-executor-0] AgentTestScenario - Message has response topic /thing1/response/topic
[INFO ] 2023-08-01 15:27:27.079 [grpc-default-executor-0] AgentTestScenario - Message has correlation data <ByteString@66001c51 size=16 contents="correlation_data">
[INFO ] 2023-08-01 15:27:27.079 [grpc-default-executor-0] AgentTestScenario - Message has user property key region value US
[INFO ] 2023-08-01 15:27:27.079 [grpc-default-executor-0] AgentTestScenario - Message has user property key type value JSON
[INFO ] 2023-08-01 15:27:27.079 [grpc-default-executor-0] AgentTestScenario - Message has content type 'text/plain; charset=utf-8'

[INFO ] 2023-08-01 15:27:32.072 [pool-2-thread-1] AgentTestScenario - Set CONNECT user property: region, US
[INFO ] 2023-08-01 15:27:32.072 [pool-2-thread-1] AgentTestScenario - Set CONNECT user property: type, JSON
[INFO ] 2023-08-01 15:27:32.073 [pool-2-thread-1] AgentTestScenario - Set CONNECT request response information true
[INFO ] 2023-08-01 15:27:32.683 [grpc-default-executor-0] GRPCDiscoveryServer - OnMqttDisconnect: agentId paho-java-agent connectionId 1 disconnect 'reasonCode: 142
' error ''
[INFO ] 2023-08-01 15:27:32.684 [grpc-default-executor-0] AgentTestScenario - MQTT disconnected on agentId paho-java-agent connectionId 1 disconnect 'reasonCode: 142
' error ''
[INFO ] 2023-08-01 15:27:32.692 [pool-2-thread-1] AgentControlImpl - Created connection with id 2 CONNACK 'sessionPresent: false
receiveMaximum: 100
maximumQoS: 1
retainAvailable: true
maximumPacketSize: 149504
serverKeepAlive: 60
'
[INFO ] 2023-08-01 15:27:32.692 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 2 created
[INFO ] 2023-08-01 15:27:32.692 [pool-2-thread-1] AgentTestScenario - MQTT connection #2 with id 2 is established
[INFO ] 2023-08-01 15:27:42.693 [pool-2-thread-1] AgentTestScenario - Set PUBLISH payload format indicator true
[INFO ] 2023-08-01 15:27:42.694 [pool-2-thread-1] AgentTestScenario - Set PUBLISH message expiry interval 3600
[INFO ] 2023-08-01 15:27:42.694 [pool-2-thread-1] AgentTestScenario - Set PUBLISH response topic /thing1/response/topic
[INFO ] 2023-08-01 15:27:42.695 [pool-2-thread-1] AgentTestScenario - Set PUBLISH correlation data <ByteString@46be48e2 size=16 contents="correlation_data">
[INFO ] 2023-08-01 15:27:42.696 [pool-2-thread-1] AgentTestScenario - Set PUBLISH user property: region, US
[INFO ] 2023-08-01 15:27:42.696 [pool-2-thread-1] AgentTestScenario - Set PUBLISH user property: type, JSON
[INFO ] 2023-08-01 15:27:42.697 [pool-2-thread-1] AgentTestScenario - Set PUBLISH content type text/plain; charset=utf-8
[INFO ] 2023-08-01 15:27:42.698 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 2 topic test/topic
[INFO ] 2023-08-01 15:27:42.741 [pool-2-thread-1] AgentTestScenario - Published connectionId 2 reason code 0 reason string ''
[INFO ] 2023-08-01 15:27:47.742 [pool-2-thread-1] AgentTestScenario - Set UNSUBSCRIBE user property: region, US
[INFO ] 2023-08-01 15:27:47.742 [pool-2-thread-1] AgentTestScenario - Set UNSUBSCRIBE user property: type, JSON
[INFO ] 2023-08-01 15:27:47.751 [pool-2-thread-1] AgentControlImpl - UnsubscribeMqtt: unsubscribe on connectionId 1
[ERROR] 2023-08-01 15:27:47.770 [pool-2-thread-1] AgentTestScenario - gRPC error code UNKNOWN: description: null
io.grpc.StatusRuntimeException: UNKNOWN
	at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:271) ~[grpc-stub-1.53.0.jar:1.53.0]
	at io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:252) ~[grpc-stub-1.53.0.jar:1.53.0]
	at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:165) ~[grpc-stub-1.53.0.jar:1.53.0]
	at com.aws.greengrass.testing.mqtt.client.MqttClientControlGrpc$MqttClientControlBlockingStub.unsubscribeMqtt(MqttClientControlGrpc.java:521) ~[classes/:?]
	at com.aws.greengrass.testing.mqtt.client.control.implementation.AgentControlImpl.unsubscribeMqtt(AgentControlImpl.java:237) ~[classes/:?]
	at com.aws.greengrass.testing.mqtt.client.control.implementation.ConnectionControlImpl.unsubscribeMqtt(ConnectionControlImpl.java:137) ~[classes/:?]
	at com.aws.greengrass.testing.mqtt.client.control.AgentTestScenario.testUnsubscribe(AgentTestScenario.java:366) ~[classes/:?]
	at com.aws.greengrass.testing.mqtt.client.control.AgentTestScenario.run(AgentTestScenario.java:201) [classes/:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]
[INFO ] 2023-08-01 15:27:47.777 [pool-2-thread-1] AgentTestScenario - Set DISCONNECT user property: region, US
[INFO ] 2023-08-01 15:27:47.777 [pool-2-thread-1] AgentTestScenario - Set DISCONNECT user property: type, JSON
[INFO ] 2023-08-01 15:27:47.789 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-08-01 15:27:47.789 [pool-2-thread-1] AgentTestScenario - Set DISCONNECT user property: region, US
[INFO ] 2023-08-01 15:27:47.789 [pool-2-thread-1] AgentTestScenario - Set DISCONNECT user property: type, JSON
[INFO ] 2023-08-01 15:27:47.910 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 2 closed
[INFO ] 2023-08-01 15:27:47.918 [pool-2-thread-1] AgentControlImpl - sending shutdown request
[INFO ] 2023-08-01 15:27:47.935 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-08-01 15:27:47.968 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId paho-java-agent reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-08-01 15:27:47.968 [grpc-default-executor-0] AgentControlImpl - shutting down channel with agent id paho-java-agent
[INFO ] 2023-08-01 15:27:47.970 [grpc-default-executor-0] AgentControlImpl - channel terminated with agent id paho-java-agent
[INFO ] 2023-08-01 15:27:47.970 [grpc-default-executor-0] ExampleControl - Agent paho-java-agent is disconnected
```
Client:
```
[INFO] --- exec-maven-plugin:3.1.0:java (default-cli) @ client-devices-auth-uat-client-java-paho ---
[INFO ] 2023-08-01 15:27:07.201 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Making gPRC client connection with 127.0.0.1:47619 as paho-java-agent...
[INFO ] 2023-08-01 15:27:07.681 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Client connection with Control is established, local address is 127.0.0.1
[INFO ] 2023-08-01 15:27:07.719 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - GRPCControlServer created and listed on 127.0.0.1:35261
[INFO ] 2023-08-01 15:27:07.804 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Handle gRPC requests
[INFO ] 2023-08-01 15:27:07.804 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - Server awaitTermination
[INFO ] 2023-08-01 15:27:10.875 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId GGMQ-test-device2 broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[INFO ] 2023-08-01 15:27:11.283 [grpc-default-executor-0] MqttConnectionImpl - CONNECT Tx user property 'region':'US'
[INFO ] 2023-08-01 15:27:11.283 [grpc-default-executor-0] MqttConnectionImpl - CONNECT Tx user property 'type':'JSON'
[INFO ] 2023-08-01 15:27:11.283 [grpc-default-executor-0] MqttConnectionImpl - CONNECT Tx request response information: true
[INFO ] 2023-08-01 15:27:16.938 [grpc-default-executor-0] GRPCControlServer - Subscription: filter 'test/topic' QoS 0 noLocal false retainAsPublished false retainHandling 2
[INFO ] 2023-08-01 15:27:16.939 [grpc-default-executor-0] GRPCControlServer - Subscribe: connectionId 1 for 1 filters
[INFO ] 2023-08-01 15:27:16.940 [grpc-default-executor-0] MqttConnectionImpl - Subscribe MQTT userProperties: region, US
[INFO ] 2023-08-01 15:27:16.940 [grpc-default-executor-0] MqttConnectionImpl - Subscribe MQTT userProperties: type, JSON
[INFO ] 2023-08-01 15:27:17.003 [grpc-default-executor-0] GRPCControlServer - Subscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-08-01 15:27:27.035 [grpc-default-executor-0] GRPCControlServer - Publish: connectionId 1 topic 'test/topic' QoS 1 retain false
[INFO ] 2023-08-01 15:27:27.036 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx payload format indicator 'true'
[INFO ] 2023-08-01 15:27:27.036 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx expiry message interval '3600'
[INFO ] 2023-08-01 15:27:27.037 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx response topic: /thing1/response/topic
[INFO ] 2023-08-01 15:27:27.037 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx correlation data: [99, 111, 114, 114, 101, 108, 97, 116, 105, 111, 110, 95, 100, 97, 116, 97]
[INFO ] 2023-08-01 15:27:27.037 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx user property 'region':'US'
[INFO ] 2023-08-01 15:27:27.037 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx user property 'type':'JSON'
[INFO ] 2023-08-01 15:27:27.037 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx payload content type 'text/plain; charset=utf-8'
[INFO ] 2023-08-01 15:27:27.067 [grpc-default-executor-0] GRPCControlServer - Publish response: connectionId 1 reason code 0 reason string ''
[INFO ] 2023-08-01 15:27:27.067 [MQTT Call: GGMQ-test-device2] MqttConnectionImpl - Delivery completion is true
[INFO ] 2023-08-01 15:27:27.070 [MQTT Call: GGMQ-test-device2] MqttConnectionImpl - Received MQTT message: connectionId 1 topic 'test/topic' QoS 0 retain false
[INFO ] 2023-08-01 15:27:27.071 [MQTT Call: GGMQ-test-device2] MqttConnectionImpl - Received MQTT userProperties: region, US
[INFO ] 2023-08-01 15:27:27.071 [MQTT Call: GGMQ-test-device2] MqttConnectionImpl - Received MQTT userProperties: type, JSON
[INFO ] 2023-08-01 15:27:27.071 [MQTT Call: GGMQ-test-device2] MqttConnectionImpl - Received MQTT message has content type 'text/plain; charset=utf-8'
[INFO ] 2023-08-01 15:27:27.071 [MQTT Call: GGMQ-test-device2] MqttConnectionImpl - Received MQTT message has payload format indicator 'true'
[INFO ] 2023-08-01 15:27:27.071 [MQTT Call: GGMQ-test-device2] MqttConnectionImpl - Received MQTT message has message expiry interval 3599
[INFO ] 2023-08-01 15:27:27.071 [MQTT Call: GGMQ-test-device2] MqttConnectionImpl - Received MQTT message has response topic: /thing1/response/topic
[INFO ] 2023-08-01 15:27:27.071 [MQTT Call: GGMQ-test-device2] MqttConnectionImpl - Received MQTT message has correlation data: [99, 111, 114, 114, 101, 108, 97, 116, 105, 111, 110, 95, 100, 97, 116, 97]


[INFO ] 2023-08-01 15:27:32.084 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId GGMQ-test-device2 broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[INFO ] 2023-08-01 15:27:32.157 [grpc-default-executor-0] MqttConnectionImpl - CONNECT Tx user property 'region':'US'
[INFO ] 2023-08-01 15:27:32.157 [grpc-default-executor-0] MqttConnectionImpl - CONNECT Tx user property 'type':'JSON'
[INFO ] 2023-08-01 15:27:32.158 [grpc-default-executor-0] MqttConnectionImpl - CONNECT Tx request response information: true
[INFO ] 2023-08-01 15:27:32.672 [MQTT Rec: GGMQ-test-device2] MqttConnectionImpl - MQTT connectionId 1 disconnected error 'null' disconnectInfo 'com.aws.greengrass.testing.mqtt5.client.GRPCClient$DisconnectInfo@77b0dee0'

[INFO ] 2023-08-01 15:27:42.702 [grpc-default-executor-0] GRPCControlServer - Publish: connectionId 2 topic 'test/topic' QoS 1 retain false
[INFO ] 2023-08-01 15:27:42.703 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx payload format indicator 'true'
[INFO ] 2023-08-01 15:27:42.703 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx expiry message interval '3600'
[INFO ] 2023-08-01 15:27:42.703 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx response topic: /thing1/response/topic
[INFO ] 2023-08-01 15:27:42.703 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx correlation data: [99, 111, 114, 114, 101, 108, 97, 116, 105, 111, 110, 95, 100, 97, 116, 97]
[INFO ] 2023-08-01 15:27:42.703 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx user property 'region':'US'
[INFO ] 2023-08-01 15:27:42.704 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx user property 'type':'JSON'
[INFO ] 2023-08-01 15:27:42.704 [grpc-default-executor-0] MqttConnectionImpl - PUBLISH Tx payload content type 'text/plain; charset=utf-8'
[INFO ] 2023-08-01 15:27:42.733 [grpc-default-executor-0] GRPCControlServer - Publish response: connectionId 2 reason code 0 reason string ''
[INFO ] 2023-08-01 15:27:42.734 [MQTT Call: GGMQ-test-device2] MqttConnectionImpl - Delivery completion is true
[INFO ] 2023-08-01 15:27:47.759 [grpc-default-executor-0] GRPCControlServer - Unsubscribe: connectionId 1 for [test/topic] filters
[ERROR] 2023-08-01 15:27:47.759 [grpc-default-executor-0] GRPCControlServer - exception during unsubscribe
com.aws.greengrass.testing.mqtt5.client.exceptions.MqttException: MQTT client is not in connected state
	at com.aws.greengrass.testing.mqtt5.client.paho.MqttConnectionImpl.stateCheck(MqttConnectionImpl.java:629) ~[classes/:?]
	at com.aws.greengrass.testing.mqtt5.client.paho.MqttConnectionImpl.unsubscribe(MqttConnectionImpl.java:215) ~[classes/:?]
	at com.aws.greengrass.testing.mqtt5.client.grpc.GRPCControlServer$MqttClientControlImpl.unsubscribeMqtt(GRPCControlServer.java:507) [classes/:?]
	at com.aws.greengrass.testing.mqtt.client.MqttClientControlGrpc$MethodHandlers.invoke(MqttClientControlGrpc.java:663) [classes/:?]
	at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182) [grpc-stub-1.53.0.jar:1.53.0]
	at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:355) [grpc-core-1.53.0.jar:1.53.0]
	at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:867) [grpc-core-1.53.0.jar:1.53.0]
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37) [grpc-core-1.53.0.jar:1.53.0]
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133) [grpc-core-1.53.0.jar:1.53.0]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]
[INFO ] 2023-08-01 15:27:47.784 [grpc-default-executor-0] GRPCControlServer - closeMqttConnection: connectionId 1 reason 4
[INFO ] 2023-08-01 15:27:47.785 [grpc-default-executor-0] MqttConnectionImpl - Disconnect MQTT userProperties: region, US
[INFO ] 2023-08-01 15:27:47.785 [grpc-default-executor-0] MqttConnectionImpl - Disconnect MQTT userProperties: type, JSON
[WARN ] 2023-08-01 15:27:47.785 [grpc-default-executor-0] MqttConnectionImpl - DISCONNECT was not sent on the dead connection
[INFO ] 2023-08-01 15:27:47.792 [grpc-default-executor-0] GRPCControlServer - closeMqttConnection: connectionId 2 reason 4
[INFO ] 2023-08-01 15:27:47.792 [grpc-default-executor-0] MqttConnectionImpl - Disconnect MQTT userProperties: region, US
[INFO ] 2023-08-01 15:27:47.792 [grpc-default-executor-0] MqttConnectionImpl - Disconnect MQTT userProperties: type, JSON
[INFO ] 2023-08-01 15:27:47.929 [grpc-default-executor-0] GRPCControlServer - shutdownAgent: reason 'That's it.'
[INFO ] 2023-08-01 15:27:47.961 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - Server awaitTermination done
[INFO ] 2023-08-01 15:27:47.961 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Shutdown gPRC link
[INFO ] 2023-08-01 15:27:47.975 [com.aws.greengrass.testing.mqtt5.client.Main.main()] Main - Execution done successfully
```

For MQTT v5.0:
Control:
```
./run_for_IoTCore_311.sh 
[INFO ] 2023-08-01 15:41:00.967 [main] ExampleControl - Control: port 47619, with TLS, MQTT v3
[INFO ] 2023-08-01 15:41:01.322 [main] EngineControlImpl - MQTT client control gRPC server started, listening on 47619
[INFO ] 2023-08-01 15:41:40.021 [grpc-default-executor-0] GRPCDiscoveryServer - RegisterAgent: agentId paho-java-agent
[INFO ] 2023-08-01 15:41:40.085 [grpc-default-executor-0] GRPCDiscoveryServer - DiscoveryClient: agentId paho-java-agent address 127.0.0.1 port 38789
[INFO ] 2023-08-01 15:41:40.088 [grpc-default-executor-0] EngineControlImpl - Created new agent control for paho-java-agent on 127.0.0.1:38789
[INFO ] 2023-08-01 15:41:40.134 [grpc-default-executor-0] ExampleControl - Agent paho-java-agent is connected
[INFO ] 2023-08-01 15:41:40.140 [pool-2-thread-1] AgentTestScenario - Playing test scenario for agent id paho-java-agent
[INFO ] 2023-08-01 15:41:44.359 [pool-2-thread-1] AgentControlImpl - Created connection with id 1 CONNACK 'sessionPresent: true
'
[INFO ] 2023-08-01 15:41:44.359 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 1 created
[INFO ] 2023-08-01 15:41:44.359 [pool-2-thread-1] AgentTestScenario - MQTT connection #1 with id 1 is established
[INFO ] 2023-08-01 15:41:49.376 [pool-2-thread-1] AgentControlImpl - SubscribeMqtt: subscribe on connection 1
[INFO ] 2023-08-01 15:41:49.482 [pool-2-thread-1] AgentTestScenario - Subscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-08-01 15:41:59.496 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 1 topic test/topic
[INFO ] 2023-08-01 15:41:59.563 [pool-2-thread-1] AgentTestScenario - Published connectionId 1 reason code 0 reason string ''
[INFO ] 2023-08-01 15:41:59.570 [grpc-default-executor-0] GRPCDiscoveryServer - OnReceiveMessage: agentId paho-java-agent connectionId 1 topic test/topic QoS 0
[INFO ] 2023-08-01 15:41:59.571 [grpc-default-executor-0] AgentTestScenario - Message received on agentId paho-java-agent connectionId 1 topic test/topic QoS 0 content <ByteString@6ca79bbc size=12 contents="Hello World!">



[INFO ] 2023-08-01 15:42:05.182 [pool-2-thread-1] AgentControlImpl - Created connection with id 2 CONNACK 'sessionPresent: true
'
[INFO ] 2023-08-01 15:42:05.183 [pool-2-thread-1] AgentControlImpl - createMqttConnection: MQTT connectionId 2 created
[INFO ] 2023-08-01 15:42:05.183 [pool-2-thread-1] AgentTestScenario - MQTT connection #2 with id 2 is established
[INFO ] 2023-08-01 15:42:05.207 [grpc-default-executor-0] GRPCDiscoveryServer - OnMqttDisconnect: agentId paho-java-agent connectionId 1 disconnect '' error 'Connection lost'
[INFO ] 2023-08-01 15:42:05.207 [grpc-default-executor-0] AgentTestScenario - MQTT disconnected on agentId paho-java-agent connectionId 1 disconnect '' error 'Connection lost'
[INFO ] 2023-08-01 15:42:15.184 [pool-2-thread-1] AgentControlImpl - PublishMqtt: publishing on connectionId 2 topic test/topic
[INFO ] 2023-08-01 15:42:15.231 [pool-2-thread-1] AgentTestScenario - Published connectionId 2 reason code 0 reason string ''
[INFO ] 2023-08-01 15:42:20.242 [pool-2-thread-1] AgentControlImpl - UnsubscribeMqtt: unsubscribe on connectionId 1
[ERROR] 2023-08-01 15:42:20.280 [pool-2-thread-1] AgentTestScenario - gRPC error code UNKNOWN: description: null
io.grpc.StatusRuntimeException: UNKNOWN
	at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:271) ~[grpc-stub-1.53.0.jar:1.53.0]
	at io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:252) ~[grpc-stub-1.53.0.jar:1.53.0]
	at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:165) ~[grpc-stub-1.53.0.jar:1.53.0]
	at com.aws.greengrass.testing.mqtt.client.MqttClientControlGrpc$MqttClientControlBlockingStub.unsubscribeMqtt(MqttClientControlGrpc.java:521) ~[aws-greengrass-testing-mqtt-client-control-1.0-SNAPSHOT.jar:?]
	at com.aws.greengrass.testing.mqtt.client.control.implementation.AgentControlImpl.unsubscribeMqtt(AgentControlImpl.java:237) ~[aws-greengrass-testing-mqtt-client-control-1.0-SNAPSHOT.jar:?]
	at com.aws.greengrass.testing.mqtt.client.control.implementation.ConnectionControlImpl.unsubscribeMqtt(ConnectionControlImpl.java:137) ~[aws-greengrass-testing-mqtt-client-control-1.0-SNAPSHOT.jar:?]
	at com.aws.greengrass.testing.mqtt.client.control.AgentTestScenario.testUnsubscribe(AgentTestScenario.java:366) ~[aws-greengrass-testing-mqtt-client-control-1.0-SNAPSHOT.jar:?]
	at com.aws.greengrass.testing.mqtt.client.control.AgentTestScenario.run(AgentTestScenario.java:201) [aws-greengrass-testing-mqtt-client-control-1.0-SNAPSHOT.jar:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]
[INFO ] 2023-08-01 15:42:20.307 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 1 closed
[INFO ] 2023-08-01 15:42:20.331 [pool-2-thread-1] AgentControlImpl - closeMqttConnection: MQTT connectionId 2 closed
[INFO ] 2023-08-01 15:42:20.338 [pool-2-thread-1] AgentControlImpl - sending shutdown request
[INFO ] 2023-08-01 15:42:20.351 [pool-2-thread-1] AgentControlImpl - shutdown request sent successfully
[INFO ] 2023-08-01 15:42:20.371 [grpc-default-executor-0] GRPCDiscoveryServer - UnregisterAgent: agentId paho-java-agent reason Agent shutdown by OTF request 'That's it.'
[INFO ] 2023-08-01 15:42:20.371 [grpc-default-executor-0] AgentControlImpl - shutting down channel with agent id paho-java-agent
[INFO ] 2023-08-01 15:42:20.373 [grpc-default-executor-0] AgentControlImpl - channel terminated with agent id paho-java-agent
[INFO ] 2023-08-01 15:42:20.373 [grpc-default-executor-0] ExampleControl - Agent paho-java-agent is disconnected
 

```
Client:
```
[INFO] --- exec-maven-plugin:3.1.0:java (default-cli) @ client-devices-auth-uat-client-java-paho ---
[INFO ] 2023-08-01 15:41:39.519 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Making gPRC client connection with 127.0.0.1:47619 as paho-java-agent...
[INFO ] 2023-08-01 15:41:40.043 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Client connection with Control is established, local address is 127.0.0.1
[INFO ] 2023-08-01 15:41:40.080 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - GRPCControlServer created and listed on 127.0.0.1:38789
[INFO ] 2023-08-01 15:41:40.166 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Handle gRPC requests
[INFO ] 2023-08-01 15:41:40.166 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - Server awaitTermination
[INFO ] 2023-08-01 15:41:43.252 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId GGMQ-test-device2 broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[INFO ] 2023-08-01 15:41:44.259 [grpc-default-executor-0] Mqtt311ConnectionImpl - MQTT 3.1.1 connection 1 is establisted
[INFO ] 2023-08-01 15:41:49.398 [grpc-default-executor-0] GRPCControlServer - Subscription: filter 'test/topic' QoS 0 noLocal false retainAsPublished false retainHandling 2
[INFO ] 2023-08-01 15:41:49.398 [grpc-default-executor-0] GRPCControlServer - Subscribe: connectionId 1 for 1 filters
[INFO ] 2023-08-01 15:41:49.478 [grpc-default-executor-0] GRPCControlServer - Subscribe response: connectionId 1 reason codes [0] reason string ''
[INFO ] 2023-08-01 15:41:59.526 [grpc-default-executor-0] GRPCControlServer - Publish: connectionId 1 topic 'test/topic' QoS 1 retain false
[INFO ] 2023-08-01 15:41:59.558 [grpc-default-executor-0] GRPCControlServer - Publish response: connectionId 1 reason code 0 reason string ''
[INFO ] 2023-08-01 15:41:59.558 [MQTT Call: GGMQ-test-device2] Mqtt311ConnectionImpl - Delivery completion is true
[INFO ] 2023-08-01 15:41:59.561 [MQTT Call: GGMQ-test-device2] Mqtt311ConnectionImpl - Received MQTT message: connectionId 1 topic 'test/topic' QoS 0 retain false

[INFO ] 2023-08-01 15:42:04.575 [grpc-default-executor-0] GRPCControlServer - createMqttConnection: clientId GGMQ-test-device2 broker a2rytmonq5cblh-ats.iot.eu-central-1.amazonaws.com:8883
[INFO ] 2023-08-01 15:42:05.173 [grpc-default-executor-0] Mqtt311ConnectionImpl - MQTT 3.1.1 connection 2 is establisted
[INFO ] 2023-08-01 15:42:05.175 [MQTT Rec: GGMQ-test-device2] Mqtt311ConnectionImpl - MQTT connection 1 interrupted, error code Connection lost
[INFO ] 2023-08-01 15:42:15.192 [grpc-default-executor-0] GRPCControlServer - Publish: connectionId 2 topic 'test/topic' QoS 1 retain false
[INFO ] 2023-08-01 15:42:15.224 [grpc-default-executor-0] GRPCControlServer - Publish response: connectionId 2 reason code 0 reason string ''
[INFO ] 2023-08-01 15:42:15.225 [MQTT Call: GGMQ-test-device2] Mqtt311ConnectionImpl - Delivery completion is true
[INFO ] 2023-08-01 15:42:20.253 [grpc-default-executor-0] GRPCControlServer - Unsubscribe: connectionId 1 for [test/topic] filters
[ERROR] 2023-08-01 15:42:20.254 [grpc-default-executor-0] GRPCControlServer - exception during unsubscribe
com.aws.greengrass.testing.mqtt5.client.exceptions.MqttException: MQTT client is not in connected state
	at com.aws.greengrass.testing.mqtt311.client.paho.Mqtt311ConnectionImpl.stateCheck(Mqtt311ConnectionImpl.java:366) ~[classes/:?]
	at com.aws.greengrass.testing.mqtt311.client.paho.Mqtt311ConnectionImpl.unsubscribe(Mqtt311ConnectionImpl.java:167) ~[classes/:?]
	at com.aws.greengrass.testing.mqtt5.client.grpc.GRPCControlServer$MqttClientControlImpl.unsubscribeMqtt(GRPCControlServer.java:507) [classes/:?]
	at com.aws.greengrass.testing.mqtt.client.MqttClientControlGrpc$MethodHandlers.invoke(MqttClientControlGrpc.java:663) [classes/:?]
	at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182) [grpc-stub-1.53.0.jar:1.53.0]
	at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:355) [grpc-core-1.53.0.jar:1.53.0]
	at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:867) [grpc-core-1.53.0.jar:1.53.0]
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37) [grpc-core-1.53.0.jar:1.53.0]
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133) [grpc-core-1.53.0.jar:1.53.0]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]
[INFO ] 2023-08-01 15:42:20.303 [grpc-default-executor-0] GRPCControlServer - closeMqttConnection: connectionId 1 reason 4
[WARN ] 2023-08-01 15:42:20.304 [grpc-default-executor-0] Mqtt311ConnectionImpl - DISCONNECT was not sent on the dead connection
[INFO ] 2023-08-01 15:42:20.304 [grpc-default-executor-0] Mqtt311ConnectionImpl - MQTT 3.1.1 connection 1 has been disconnected
[INFO ] 2023-08-01 15:42:20.309 [grpc-default-executor-0] GRPCControlServer - closeMqttConnection: connectionId 2 reason 4
[INFO ] 2023-08-01 15:42:20.323 [grpc-default-executor-0] Mqtt311ConnectionImpl - MQTT 3.1.1 connection 2 has been disconnected
[INFO ] 2023-08-01 15:42:20.347 [grpc-default-executor-0] GRPCControlServer - shutdownAgent: reason 'That's it.'
[INFO ] 2023-08-01 15:42:20.363 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCControlServer - Server awaitTermination done
[INFO ] 2023-08-01 15:42:20.364 [com.aws.greengrass.testing.mqtt5.client.Main.main()] GRPCLinkImpl - Shutdown gPRC link
[INFO ] 2023-08-01 15:42:20.378 [com.aws.greengrass.testing.mqtt5.client.Main.main()] Main - Execution done successfully

```

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
