### PR TITLE
fix(uat): install iproute2 package for ip command; remove commands pipeline

### DIFF
--- a/uat/codebuild/uat_linux_buildspec.yaml
+++ b/uat/codebuild/uat_linux_buildspec.yaml
@@ -11,16 +11,18 @@ phases:
   install:
     runtime-versions:
       java: corretto11
+    commands:
+      - apt-get update
+      - apt-get -y install iproute2
   build:
     commands:
       - curl -s https://d2s8p88vqu9w66.cloudfront.net/releases/greengrass-nucleus-latest.zip > /tmp/greengrass-nucleus-latest.zip
       - mvn -DskipTests=false -U -ntp clean verify -f uat/pom.xml
-      - java -Dggc.archive=/tmp/greengrass-nucleus-latest.zip -Dtags="$CUCUMBER_TAGS" -jar uat/testing-features/target/client-devices-auth-testing-features.jar 2>&1 | tee build.log
+      - java -Dggc.archive=/tmp/greengrass-nucleus-latest.zip -Dtags="$CUCUMBER_TAGS" -jar uat/testing-features/target/client-devices-auth-testing-features.jar
 
 artifacts:
   files:
     - 'testResults/**/*'
-    - 'build.log'
   name: 'AuthUatLinuxLogs.zip'
 
 reports:


### PR DESCRIPTION
**Issue #, if available:**
ip command does not found on Code Build with Ubuntu 20.04

**Description of changes:**
- Install iproute2 package for ip command
- Remove pipeline due to hide tests exist status 

**Why is this change necessary:**
Due to ip command does not installed on Code Build box T21 and T26 were failed.
Because pipeline was used to run test command exist code was lost.

**How was this change tested:**
Automatically by run tests on Code Build.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
