### PR TITLE
fix(uat): use CURRENT for classpath component in second deployments

### DIFF
--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/AgentControl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/AgentControl.java
@@ -93,7 +93,7 @@ public interface AgentControl {
      * Shutdown whole agent.
      *
      * @param reason shutdown reason
-     * @throws StatusRuntimeException on errors
+     * @throws io.grpc.StatusRuntimeException on errors
      */
     void shutdownAgent(String reason);
 
@@ -103,7 +103,7 @@ public interface AgentControl {
      *
      * @param discoveryRequest the request with clients name and credentials
      * @return the reply with connectivity information of IoT Core device broker
-     * @throws StatusRuntimeException on errors
+     * @throws io.grpc.StatusRuntimeException on errors
      */
     CoreDeviceDiscoveryReply discoveryCoreDevice(@NonNull CoreDeviceDiscoveryRequest discoveryRequest);
 }

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/ConnectionControl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/api/ConnectionControl.java
@@ -74,7 +74,7 @@ public interface ConnectionControl {
      * @param subscriptionId optional subscription id
      * @param subscriptions MQTT subscriptions
      * @return reply to subscribe
-     * @throws StatusRuntimeException on errors
+     * @throws io.grpc.StatusRuntimeException on errors
      */
     default MqttSubscribeReply subscribeMqtt(Integer subscriptionId, @NonNull Mqtt5Subscription... subscriptions) {
         final List<Mqtt5Properties> userProperties = null;
@@ -88,7 +88,7 @@ public interface ConnectionControl {
      * @param userProperties optional MQTT v5.0 user properties
      * @param subscriptions MQTT subscriptions
      * @return reply to subscribe
-     * @throws StatusRuntimeException on errors
+     * @throws io.grpc.StatusRuntimeException on errors
      */
     MqttSubscribeReply subscribeMqtt(Integer subscriptionId, List<Mqtt5Properties> userProperties,
                                      @NonNull Mqtt5Subscription... subscriptions);
@@ -98,7 +98,7 @@ public interface ConnectionControl {
      *
      * @param message message to publish
      * @return publish's response
-     * @throws StatusRuntimeException on errors
+     * @throws io.grpc.StatusRuntimeException on errors
      */
     MqttPublishReply publishMqtt(@NonNull Mqtt5Message message);
 
@@ -108,7 +108,7 @@ public interface ConnectionControl {
      *
      * @param filters topic filters to unsubscribe
      * @return reply to unsubscribe
-     * @throws StatusRuntimeException on errors
+     * @throws io.grpc.StatusRuntimeException on errors
      */
     default MqttSubscribeReply unsubscribeMqtt(@NonNull String... filters) {
         final List<Mqtt5Properties> userProperties = null;
@@ -121,7 +121,7 @@ public interface ConnectionControl {
      * @param userProperties optional MQTT v5.0 user properties
      * @param filters topic filters to unsubscribe
      * @return reply to unsubscribe
-     * @throws StatusRuntimeException on errors
+     * @throws io.grpc.StatusRuntimeException on errors
      */
     MqttSubscribeReply unsubscribeMqtt(List<Mqtt5Properties> userProperties, @NonNull String... filters);
 
@@ -129,7 +129,7 @@ public interface ConnectionControl {
      * Close MQTT connection to the broker.
      *
      * @param reason reason code of disconnection as specified by MQTT v5.0 in DISCONNECT packet
-     * @throws StatusRuntimeException on errors
+     * @throws io.grpc.StatusRuntimeException on errors
      */
     default void closeMqttConnection(int reason) {
         closeMqttConnection(reason, null);
@@ -140,7 +140,7 @@ public interface ConnectionControl {
      *
      * @param reason reason code of disconnection as specified by MQTT v5.0 in DISCONNECT packet
      * @param userProperties optional MQTT v5.0 user properties
-     * @throws StatusRuntimeException on errors
+     * @throws io.grpc.StatusRuntimeException on errors
      */
     void closeMqttConnection(int reason, List<Mqtt5Properties> userProperties);
 }

--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/AgentControlImpl.java
@@ -225,7 +225,7 @@ public class AgentControlImpl implements AgentControl {
      *
      * @param subscribeRequest subscribe request
      * @return reply to subscribe
-     * @throws StatusRuntimeException on errors
+     * @throws io.grpc.StatusRuntimeException on errors
      */
     MqttSubscribeReply subscribeMqtt(@NonNull MqttSubscribeRequest subscribeRequest) {
         int connectionId = subscribeRequest.getConnectionId().getConnectionId();
@@ -238,7 +238,7 @@ public class AgentControlImpl implements AgentControl {
      *
      * @param unsubscribeRequest unsubscribe request
      * @return reply to unsubscribe
-     * @throws StatusRuntimeException on errors
+     * @throws io.grpc.StatusRuntimeException on errors
      */
     MqttSubscribeReply unsubscribeMqtt(@NonNull MqttUnsubscribeRequest unsubscribeRequest) {
         int connectionId = unsubscribeRequest.getConnectionId().getConnectionId();
@@ -251,7 +251,7 @@ public class AgentControlImpl implements AgentControl {
      *
      * @param publishRequest publish request
      * @return reply to publish
-     * @throws StatusRuntimeException on errors
+     * @throws io.grpc.StatusRuntimeException on errors
      */
     MqttPublishReply publishMqtt(@NonNull MqttPublishRequest publishRequest) {
         int connectionId = publishRequest.getConnectionId().getConnectionId();
@@ -264,7 +264,7 @@ public class AgentControlImpl implements AgentControl {
      * Close MQTT connection to the broker.
      *
      * @param closeRequest parameters of MQTT disconnect
-     * @throws StatusRuntimeException on errors
+     * @throws io.grpc.StatusRuntimeException on errors
      */
     void closeMqttConnection(@NonNull MqttCloseRequest closeRequest) {
         blockingStub.closeMqttConnection(closeRequest);

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -304,6 +304,7 @@ public class MqttControlSteps {
      * Convert boolean string to value.
      *
      * @param value the string value of boolean
+     * @return boolean object of value
      */
     @SuppressWarnings("PMD.UnnecessaryAnnotationValueElement")
     @ParameterType(value = "true|True|TRUE|false|False|FALSE")
@@ -315,6 +316,7 @@ public class MqttControlSteps {
      * Convert boolean or null string to nullable value.
      *
      * @param value the string value of boolean or null
+     * @return boolean object of value or null
      */
     @SuppressWarnings("PMD.UnnecessaryAnnotationValueElement")
     @ParameterType(value = "true|True|TRUE|false|False|FALSE|null|NULL")
@@ -1152,7 +1154,6 @@ public class MqttControlSteps {
      * @param clientDeviceId the user defined client device id
      * @param value the duration of time to wait for message
      * @param unit the time unit to wait
-     * @throws TimeoutException when matched message was not received in specified duration of time
      * @throws RuntimeException on internal errors
      * @throws InterruptedException then thread has been interrupted
      */
@@ -1167,7 +1168,6 @@ public class MqttControlSteps {
      * @param clientDeviceId the user defined client device id
      * @param value the duration of time to wait for message
      * @param unit the time unit to wait
-     * @throws TimeoutException when matched message was not received in specified duration of time
      * @throws RuntimeException on internal errors
      * @throws InterruptedException then thread has been interrupted
      */

--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -11,10 +11,10 @@ Feature: GGMQ-1
   @GGMQ-1-T1
   Scenario Outline: GGMQ-1-T1-<mqtt-v>-<name>: As a customer, I can connect, subscribe/publish at QoS 0 and 1 and receive using client application to MQTT topic
     When I create a Greengrass deployment with components
-      | aws.greengrass.clientdevices.Auth        | LATEST                                  |
-      | aws.greengrass.clientdevices.mqtt.EMQX   | LATEST                                  |
-      | aws.greengrass.clientdevices.IPDetector  | LATEST                                  |
-      | <agent>                                  | classpath:/local-store/recipes/<recipe> |
+      | aws.greengrass.clientdevices.Auth       | LATEST                                  |
+      | aws.greengrass.clientdevices.mqtt.EMQX  | LATEST                                  |
+      | aws.greengrass.clientdevices.IPDetector | LATEST                                  |
+      | <agent>                                 | classpath:/local-store/recipes/<recipe> |
     And I create client device "clientDeviceTest"
     When I associate "clientDeviceTest" with ggc
     And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:
@@ -189,10 +189,10 @@ Feature: GGMQ-1
     And I disconnect device "clientDeviceTest" with reason code 0
 
     When I create a Greengrass deployment with components
-      | aws.greengrass.clientdevices.Auth       | LATEST |
-      | aws.greengrass.clientdevices.mqtt.EMQX  | LATEST |
-      | aws.greengrass.clientdevices.IPDetector | LATEST |
-      | <agent>                                 | LATEST |
+      | aws.greengrass.clientdevices.Auth       | LATEST  |
+      | aws.greengrass.clientdevices.mqtt.EMQX  | LATEST  |
+      | aws.greengrass.clientdevices.IPDetector | LATEST  |
+      | <agent>                                 | CURRENT |
     And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:
     """
 {
@@ -223,7 +223,7 @@ Feature: GGMQ-1
 }
     """
     And I deploy the Greengrass deployment configuration
-    Then the Greengrass deployment is COMPLETED on the device after 2 minutes
+    Then the Greengrass deployment is COMPLETED on the device after 299 seconds
     And the aws.greengrass.clientdevices.mqtt.EMQX log on the device contains the line "is running now!." within 1 minutes
 
     And I discover core device broker as "default_broker" from "clientDeviceTest" in OTF
@@ -577,10 +577,10 @@ Feature: GGMQ-1
   @GGMQ-1-T13
   Scenario Outline: GGMQ-1-T13-<mqtt-v>-<name>: As a customer, I can connect two GGADs and send message from one GGAD to the other based on CDA configuration
     When I create a Greengrass deployment with components
-      | aws.greengrass.clientdevices.Auth        | LATEST                                  |
-      | aws.greengrass.clientdevices.mqtt.EMQX   | LATEST                                  |
-      | aws.greengrass.clientdevices.IPDetector  | LATEST                                  |
-      | <agent>                                  | classpath:/local-store/recipes/<recipe> |
+      | aws.greengrass.clientdevices.Auth       | LATEST                                  |
+      | aws.greengrass.clientdevices.mqtt.EMQX  | LATEST                                  |
+      | aws.greengrass.clientdevices.IPDetector | LATEST                                  |
+      | <agent>                                 | classpath:/local-store/recipes/<recipe> |
 
     And I create client device "publisher"
     And I create client device "subscriber"
@@ -656,10 +656,10 @@ Feature: GGMQ-1
     And I disconnect device "publisher" with reason code 0
 
     When I create a Greengrass deployment with components
-      | aws.greengrass.clientdevices.Auth        | LATEST |
-      | aws.greengrass.clientdevices.mqtt.EMQX   | LATEST |
-      | aws.greengrass.clientdevices.IPDetector  | LATEST |
-      | <agent>                                  | LATEST |
+      | aws.greengrass.clientdevices.Auth       | LATEST  |
+      | aws.greengrass.clientdevices.mqtt.EMQX  | LATEST  |
+      | aws.greengrass.clientdevices.IPDetector | LATEST  |
+      | <agent>                                 | CURRENT |
 
     And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:
     """
@@ -1316,11 +1316,11 @@ Feature: GGMQ-1
   @GGMQ-1-T20
   Scenario Outline: GGMQ-1-T20-<mqtt-v>-<name>: As a customer, I can associate and connect GGADs with GGC over custom port
     When I create a Greengrass deployment with components
-      | aws.greengrass.clientdevices.Auth        | LATEST                                  |
-      | aws.greengrass.clientdevices.mqtt.EMQX   | LATEST                                  |
-      | aws.greengrass.clientdevices.IPDetector  | LATEST                                  |
-      | aws.greengrass.Cli                       | LATEST                                  |
-      | <agent>                                  | classpath:/local-store/recipes/<recipe> |
+      | aws.greengrass.clientdevices.Auth       | LATEST                                  |
+      | aws.greengrass.clientdevices.mqtt.EMQX  | LATEST                                  |
+      | aws.greengrass.clientdevices.IPDetector | LATEST                                  |
+      | aws.greengrass.Cli                      | LATEST                                  |
+      | <agent>                                 | classpath:/local-store/recipes/<recipe> |
     And I create client device "basic_connect"
     And I create client device "basic_connect_2"
     When I associate "basic_connect" with ggc
@@ -1478,10 +1478,10 @@ Feature: GGMQ-1
   @GGMQ-1-T21
   Scenario Outline: GGMQ-1-T21-<mqtt-v>-<name>: As a customer, I change the connectivity ip address and GGADs are able to connect via IPD
     When I create a Greengrass deployment with components
-      | aws.greengrass.clientdevices.Auth        | LATEST                                  |
-      | aws.greengrass.clientdevices.mqtt.EMQX   | LATEST                                  |
-      | aws.greengrass.clientdevices.IPDetector  | LATEST                                  |
-      | <agent>                                  | classpath:/local-store/recipes/<recipe> |
+      | aws.greengrass.clientdevices.Auth       | LATEST                                  |
+      | aws.greengrass.clientdevices.mqtt.EMQX  | LATEST                                  |
+      | aws.greengrass.clientdevices.IPDetector | LATEST                                  |
+      | <agent>                                 | classpath:/local-store/recipes/<recipe> |
     And I create client device "basic_connect"
     When I associate "basic_connect" with ggc
     And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:
@@ -1673,11 +1673,11 @@ Feature: GGMQ-1
   @GGMQ-1-T24
   Scenario Outline: GGMQ-1-T24-<mqtt-v>-<name>: As a customer, I can reset CDA config and update it and CDA will use the new config
     When I create a Greengrass deployment with components
-      | aws.greengrass.clientdevices.Auth        | LATEST                                  |
-      | aws.greengrass.clientdevices.mqtt.EMQX   | LATEST                                  |
-      | aws.greengrass.clientdevices.IPDetector  | LATEST                                  |
-      | aws.greengrass.Cli                       | LATEST                                  |
-      | <agent>                                  | classpath:/local-store/recipes/<recipe> |
+      | aws.greengrass.clientdevices.Auth       | LATEST                                  |
+      | aws.greengrass.clientdevices.mqtt.EMQX  | LATEST                                  |
+      | aws.greengrass.clientdevices.IPDetector | LATEST                                  |
+      | aws.greengrass.Cli                      | LATEST                                  |
+      | <agent>                                 | classpath:/local-store/recipes/<recipe> |
     And I create client device "publisher"
     And I create client device "subscriber"
 
@@ -1828,10 +1828,10 @@ Feature: GGMQ-1
   @GGMQ-1-T25
   Scenario Outline: GGMQ-1-T25-<mqtt-v>-<name>: As a customer, I connect with same client id twice (not reconnect) and be able to publish and subscribe to messages.
     When I create a Greengrass deployment with components
-      | aws.greengrass.clientdevices.Auth        | LATEST                                  |
-      | aws.greengrass.clientdevices.mqtt.EMQX   | LATEST                                  |
-      | aws.greengrass.clientdevices.IPDetector  | LATEST                                  |
-      | <agent>                                  | classpath:/local-store/recipes/<recipe> |
+      | aws.greengrass.clientdevices.Auth       | LATEST                                  |
+      | aws.greengrass.clientdevices.mqtt.EMQX  | LATEST                                  |
+      | aws.greengrass.clientdevices.IPDetector | LATEST                                  |
+      | <agent>                                 | classpath:/local-store/recipes/<recipe> |
     And I create client device "publisher"
     And I create client device "subscriber"
     When I associate "publisher" with ggc
@@ -1940,10 +1940,10 @@ Feature: GGMQ-1
   @GGMQ-1-T26
   Scenario Outline: GGMQ-1-T26-<mqtt-v>-<name>: As a customer, my GGAD stays connected when CDA rotates cert for EMQX broker
     When I create a Greengrass deployment with components
-      | aws.greengrass.clientdevices.Auth        | LATEST                                  |
-      | aws.greengrass.clientdevices.mqtt.EMQX   | LATEST                                  |
-      | aws.greengrass.clientdevices.IPDetector  | LATEST                                  |
-      | <agent>                                  | classpath:/local-store/recipes/<recipe> |
+      | aws.greengrass.clientdevices.Auth       | LATEST                                  |
+      | aws.greengrass.clientdevices.mqtt.EMQX  | LATEST                                  |
+      | aws.greengrass.clientdevices.IPDetector | LATEST                                  |
+      | <agent>                                 | classpath:/local-store/recipes/<recipe> |
     And I create client device "clientDeviceTest"
     When I associate "clientDeviceTest" with ggc
     And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:
@@ -2055,10 +2055,10 @@ Feature: GGMQ-1
   @GGMQ-1-T27 @OffTheNetwork
   Scenario Outline: GGMQ-1-T27-<mqtt-v>-<name>: As a customer, my Greengrass-issued certificate does not rotate when mqtt reconnects
     When I create a Greengrass deployment with components
-      | aws.greengrass.clientdevices.Auth        | LATEST                                  |
-      | aws.greengrass.clientdevices.mqtt.EMQX   | LATEST                                  |
-      | aws.greengrass.clientdevices.IPDetector  | LATEST                                  |
-      | <agent>                                  | classpath:/local-store/recipes/<recipe> |
+      | aws.greengrass.clientdevices.Auth       | LATEST                                  |
+      | aws.greengrass.clientdevices.mqtt.EMQX  | LATEST                                  |
+      | aws.greengrass.clientdevices.IPDetector | LATEST                                  |
+      | <agent>                                 | classpath:/local-store/recipes/<recipe> |
     And I create client device "clientDeviceTest"
     When I associate "clientDeviceTest" with ggc
     And I update my Greengrass deployment configuration, setting the component aws.greengrass.Nucleus configuration to:
@@ -2764,10 +2764,10 @@ Feature: GGMQ-1
   @GGMQ-1-T103
   Scenario Outline: GGMQ-1-T103-<mqtt-v>-<name>: As a customer, I can discover Core device broker in AWS IoT device SDK-based client
     When I create a Greengrass deployment with components
-      | aws.greengrass.clientdevices.Auth        | LATEST                                  |
-      | aws.greengrass.clientdevices.mqtt.EMQX   | LATEST                                  |
-      | aws.greengrass.clientdevices.IPDetector  | LATEST                                  |
-      | <agent>                                  | classpath:/local-store/recipes/<recipe> |
+      | aws.greengrass.clientdevices.Auth       | LATEST                                  |
+      | aws.greengrass.clientdevices.mqtt.EMQX  | LATEST                                  |
+      | aws.greengrass.clientdevices.IPDetector | LATEST                                  |
+      | <agent>                                 | classpath:/local-store/recipes/<recipe> |
     And I create client device "clientDeviceTest"
     When I associate "clientDeviceTest" with ggc
     And I update my Greengrass deployment configuration, setting the component aws.greengrass.clientdevices.Auth configuration to:


### PR DESCRIPTION
**Issue #, if available:**
Use new "CURRENT" version feature of OTF in scenarios
Joined with javadoc comment updates

**Description of changes:**
- Replace LATEST to CURRENT version of client in second deployment of T2 and T13 scenarios
- Tune scenario formatting
- Update javadoc comments to resolve generation issues

**Why is this change necessary:**
Switch to new OTF "CURRENT" version feature

**How was this change tested:**
Automatically on Linux via github CI + CodeBuild.
Manually on Windows.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
