### PR TITLE
fix(uat): ease race between MQTT connect and agent reconnect

### DIFF
--- a/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
+++ b/uat/mqtt-client-control/src/main/java/com/aws/greengrass/testing/mqtt/client/control/implementation/EngineControlImpl.java
@@ -178,9 +178,10 @@ public class EngineControlImpl implements EngineControl, DiscoveryEvents {
             } else {
                 logger.atInfo().log("Agent {} relocated to {}:{}", agentId, address, port);
                 agents.remove(agentId);
-                stopAgent(agentId, agentControl, false);
-                // recursion
+                // recursion just to add new relocated agent
                 onDiscoveryAgent(agentId, address, port);
+                // stop can take long time (about 2 seconds)
+                stopAgent(agentId, agentControl, false);
             }
         }
     }

--- a/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
+++ b/uat/testing-features/src/main/java/com/aws/greengrass/steps/MqttControlSteps.java
@@ -759,9 +759,6 @@ public class MqttControlSteps {
         }
 
 
-        // get agent control by componentId
-        AgentControl agentControl = getAgentControl(componentId);
-
         // request for new MQTT connection
         final String clientDeviceThingName = getClientDeviceThingName(clientDeviceId);
 
@@ -777,6 +774,9 @@ public class MqttControlSteps {
                      brokerId, host, port, clientDeviceThingName, componentId, mqttVersion);
             MqttConnectRequest request = buildMqttConnectRequest(
                     clientDeviceThingName, caList, host, port, version);
+            // get agent control by componentId as late as possible to reduce race probability
+            AgentControl agentControl = getAgentControl(componentId);
+
             try {
                 ConnectionControl connectionControl
                         = agentControl.createMqttConnection(request, connectionEvents);


### PR DESCRIPTION
**Issue #, if available:**
Ease the race between MQTT connection and re-connection of agent

**Description of changes:**
- Move stop old agent control after linking new
- Move getting agent control to as late as possible

**Why is this change necessary:**
When MQTT client component is restarted for example during second deployment it obtain new gRPC control port and re-connecting to control. Engine control creates new agent control instance and update internal map of agents. We have race between that process coming from lower layers (gRPC connection) and scenario step creates MQTT connection for that client. 
When the step wins the race it try to create MQTT connection on dead agent control.
We can't resolve the race completely without explicit synchronization for example waiting until client reconnects to the control again. But we can reduce probability of fails by move some parts of code.


**How was this change tested:**
Automatically on github CI and CodeBuild

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
