### PR TITLE
fix(uat): resolve undefined step issue in T102

### DIFF
--- a/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
+++ b/uat/testing-features/src/main/resources/greengrass/features/ggmq-1.feature
@@ -2394,7 +2394,7 @@ Feature: GGMQ-1
     When I subscribe "subscriber" to "t102_case8" with qos 0
     And message "Single not retained message in case8" is not received on "subscriber" from "t102_case8" topic within 5 seconds
 
-    And I clear the event storage and reset all MQTT settings to default
+    And I clear the event storage and reset all MQTT settings to defaults
 
     # C. SUBSCRIBE 'retain as published' tests
 


### PR DESCRIPTION
**Issue #, if available:**
UNDEFINED step in T102 scenario

**Description of changes:**
- Correct a mistype in step sentence in T102

 
**Why is this change necessary:**
Without that change T102 silently failed

**How was this change tested:**
Automatically on github CI.

Requires manual check for lines ends with 'with status UNDEFINED' in console output of tests due to probably bug in cucumber: even when undefined step is found whole scenario has PASSED status. The same time status of test correctly appeared in exit code of test command.

Unfortunately 'deployment failed' bug hide actual result of the test command.
 

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
