### PR TITLE
feat: re-introduce clientCertificateValiditySeconds config

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/CertificatesConfig.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/CertificatesConfig.java
@@ -16,16 +16,21 @@ public class CertificatesConfig {
 
     static final int MAX_SERVER_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 10; // 10 days
     static final int MIN_SERVER_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 2; // 2 days
+    static final int MAX_CLIENT_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 10; // 10 days
+    static final int MIN_CLIENT_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 2; // 2 days
     static final int DEFAULT_SERVER_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 7; // 7 days
     static final int DEFAULT_CLIENT_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 7; // 7 days
     static final boolean DEFAULT_DISABLE_CERTIFICATE_ROTATION = false;
 
     private static final String CERTIFICATES_CONFIGURATION = "certificates";
     private static final String SERVER_CERT_VALIDITY_SECONDS = "serverCertificateValiditySeconds";
+    private static final String CLIENT_CERT_VALIDITY_SECONDS = "clientCertificateValiditySeconds";
     private static final String DISABLE_CERTIFICATE_ROTATION = "disableCertificateRotation";
 
     static final String[] PATH_SERVER_CERT_EXPIRY_SECONDS =
             {KernelConfigResolver.CONFIGURATION_CONFIG_KEY, CERTIFICATES_CONFIGURATION, SERVER_CERT_VALIDITY_SECONDS};
+    static final String[] PATH_CLIENT_CERT_EXPIRY_SECONDS =
+            {KernelConfigResolver.CONFIGURATION_CONFIG_KEY, CERTIFICATES_CONFIGURATION, CLIENT_CERT_VALIDITY_SECONDS};
     static final String[] PATH_DISABLE_CERTIFICATE_ROTATION =
             {KernelConfigResolver.CONFIGURATION_CONFIG_KEY, CERTIFICATES_CONFIGURATION, DISABLE_CERTIFICATE_ROTATION};
 
@@ -63,7 +68,20 @@ public class CertificatesConfig {
      * @return Client certificate validity in seconds
      */
     public int getClientCertValiditySeconds() {
-        return DEFAULT_CLIENT_CERT_EXPIRY_SECONDS;
+        int configuredValidityPeriod = Coerce.toInt(configuration.findOrDefault(DEFAULT_CLIENT_CERT_EXPIRY_SECONDS,
+                PATH_CLIENT_CERT_EXPIRY_SECONDS));
+        if (configuredValidityPeriod > MAX_CLIENT_CERT_EXPIRY_SECONDS) {
+            LOGGER.atWarn().kv(CLIENT_CERT_VALIDITY_SECONDS, configuredValidityPeriod)
+                    .kv("maxAllowable", MAX_CLIENT_CERT_EXPIRY_SECONDS)
+                    .log("Using maximum allowable duration for client certificate validity period");
+            return MAX_CLIENT_CERT_EXPIRY_SECONDS;
+        } else if (configuredValidityPeriod < MIN_CLIENT_CERT_EXPIRY_SECONDS) {
+            LOGGER.atWarn().kv(CLIENT_CERT_VALIDITY_SECONDS, configuredValidityPeriod)
+                    .kv("minAllowable", MAX_CLIENT_CERT_EXPIRY_SECONDS)
+                    .log("Using minimum allowable duration for client certificate validity period");
+            return MIN_CLIENT_CERT_EXPIRY_SECONDS;
+        }
+        return configuredValidityPeriod;
     }
 
     /**

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/CertificatesConfig.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/CertificatesConfig.java
@@ -17,7 +17,7 @@ public class CertificatesConfig {
     static final int MAX_SERVER_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 10; // 10 days
     static final int MIN_SERVER_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 2; // 2 days
     static final int MAX_CLIENT_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 10; // 10 days
-    static final int MIN_CLIENT_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 2; // 2 days
+    static final int MIN_CLIENT_CERT_EXPIRY_SECONDS = 60; // 1 minute
     static final int DEFAULT_SERVER_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 7; // 7 days
     static final int DEFAULT_CLIENT_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 7; // 7 days
     static final boolean DEFAULT_DISABLE_CERTIFICATE_ROTATION = false;

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/certificate/CertificatesConfigTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/certificate/CertificatesConfigTest.java
@@ -74,7 +74,7 @@ public class CertificatesConfigTest {
 
     @Test
     public void GIVEN_smallClientCertValidity_WHEN_getClientCertValiditySeconds_THEN_returnsMinExpiry() {
-        configurationTopics.lookup(CertificatesConfig.PATH_CLIENT_CERT_EXPIRY_SECONDS).withValue(60 * 60 * 24); // 1 day
+        configurationTopics.lookup(CertificatesConfig.PATH_CLIENT_CERT_EXPIRY_SECONDS).withValue(30);
         assertThat(certificatesConfig.getClientCertValiditySeconds(),
                 is(equalTo(CertificatesConfig.MIN_CLIENT_CERT_EXPIRY_SECONDS)));
     }

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/certificate/CertificatesConfigTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/certificate/CertificatesConfigTest.java
@@ -64,4 +64,18 @@ public class CertificatesConfigTest {
                 is(equalTo(CertificatesConfig.DEFAULT_CLIENT_CERT_EXPIRY_SECONDS)));
     }
 
+    @Test
+    public void GIVEN_largeClientCertValidity_WHEN_getClientCertValiditySeconds_THEN_returnsMaxExpiry() {
+        configurationTopics.lookup(CertificatesConfig.PATH_CLIENT_CERT_EXPIRY_SECONDS)
+                .withValue(2 * CertificatesConfig.MAX_CLIENT_CERT_EXPIRY_SECONDS);
+        assertThat(certificatesConfig.getClientCertValiditySeconds(),
+                is(equalTo(CertificatesConfig.MAX_CLIENT_CERT_EXPIRY_SECONDS)));
+    }
+
+    @Test
+    public void GIVEN_smallClientCertValidity_WHEN_getClientCertValiditySeconds_THEN_returnsMinExpiry() {
+        configurationTopics.lookup(CertificatesConfig.PATH_CLIENT_CERT_EXPIRY_SECONDS).withValue(60 * 60 * 24); // 1 day
+        assertThat(certificatesConfig.getClientCertValiditySeconds(),
+                is(equalTo(CertificatesConfig.MIN_CLIENT_CERT_EXPIRY_SECONDS)));
+    }
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Same as https://github.com/aws-greengrass/aws-greengrass-client-device-auth/pull/61, with a modification lowering the minimum validity seconds value to 1 minute.  The reason for this is to allow UATs to test rotation within a reasonable period.


**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
