### PR TITLE
chore: decrease min server cert validity

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/CertificatesConfig.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/CertificatesConfig.java
@@ -15,7 +15,7 @@ public class CertificatesConfig {
     private static final Logger LOGGER = LogManager.getLogger(CertificatesConfig.class);
 
     static final int MAX_SERVER_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 10; // 10 days
-    static final int MIN_SERVER_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 2; // 2 days
+    static final int MIN_SERVER_CERT_EXPIRY_SECONDS = 60; // 1 minute
     static final int DEFAULT_SERVER_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 7; // 7 days
     static final int DEFAULT_CLIENT_CERT_EXPIRY_SECONDS = 60 * 60 * 24 * 7; // 7 days
     static final boolean DEFAULT_DISABLE_CERTIFICATE_ROTATION = false;

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/certificate/CertificatesConfigTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/certificate/CertificatesConfigTest.java
@@ -53,7 +53,7 @@ public class CertificatesConfigTest {
 
     @Test
     public void GIVEN_smallServerCertValidity_WHEN_getServerCertValiditySeconds_THEN_returnsMinExpiry() {
-        configurationTopics.lookup(CertificatesConfig.PATH_SERVER_CERT_EXPIRY_SECONDS).withValue(60 * 60 * 24); // 1 day
+        configurationTopics.lookup(CertificatesConfig.PATH_SERVER_CERT_EXPIRY_SECONDS).withValue(30);
         assertThat(certificatesConfig.getServerCertValiditySeconds(),
                 is(equalTo(CertificatesConfig.MIN_SERVER_CERT_EXPIRY_SECONDS)));
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Lower the min value of server cert validity to 1 minute, to allow UATs to test rotation within a reasonable period.

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
