### PR TITLE
fix(cis): retry get shadow operation

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitor.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitor.java
@@ -219,7 +219,7 @@ public class CISShadowMonitor implements Consumer<NetworkStateProvider.Connectio
                         (e) -> LOGGER.atError()
                                 .log("Error processing shadowDeltaUpdatedSubscription Response", e))
                 .get();
-        LOGGER.atInfo().log("Subscribed to shadow update delta topic");
+        LOGGER.atDebug().log("Subscribed to shadow update delta topic");
 
         GetShadowSubscriptionRequest getShadowSubscriptionRequest = new GetShadowSubscriptionRequest();
         getShadowSubscriptionRequest.thingName = shadowName;
@@ -229,7 +229,7 @@ public class CISShadowMonitor implements Consumer<NetworkStateProvider.Connectio
                         onGetShadowAccepted,
                         (e) -> LOGGER.atError().log("Error processing getShadowSubscription Response", e))
                 .get();
-        LOGGER.atInfo().log("Subscribed to shadow get accepted topic");
+        LOGGER.atDebug().log("Subscribed to shadow get accepted topic");
 
         GetShadowSubscriptionRequest getShadowRejectedSubscriptionRequest = new GetShadowSubscriptionRequest();
         getShadowRejectedSubscriptionRequest.thingName = shadowName;
@@ -239,7 +239,7 @@ public class CISShadowMonitor implements Consumer<NetworkStateProvider.Connectio
                         onGetShadowRejected,
                         (e) -> LOGGER.atError().log("Error processing get shadow rejected response", e))
                 .get();
-        LOGGER.atInfo().log("Subscribed to shadow get rejected topic");
+        LOGGER.atDebug().log("Subscribed to shadow get rejected topic");
     }
 
     private void processCISShadow(GetShadowResponse response) {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitor.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitor.java
@@ -189,7 +189,6 @@ public class CISShadowMonitor implements Consumer<NetworkStateProvider.Connectio
     /**
      * Start shadow monitor.
      */
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     public void startMonitor() {
         fetchCISShadowAsync();
     }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitor.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitor.java
@@ -160,6 +160,7 @@ public class CISShadowMonitor implements Consumer<NetworkStateProvider.Connectio
      * Stop shadow monitor.
      */
     public void stopMonitor() {
+        subscribed.set(false);
         cancelFetchCISShadow();
     }
 

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitor.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitor.java
@@ -95,14 +95,14 @@ public class CISShadowMonitor implements Consumer<NetworkStateProvider.Connectio
         if (stopped.get()) {
             return;
         }
-        reportShadowReceived();
+        signalShadowResponseReceived();
         processCISShadow(resp);
     };
     private final Consumer<ErrorResponse> onGetShadowRejected = err -> {
         if (stopped.get()) {
             return;
         }
-        reportShadowReceived();
+        signalShadowResponseReceived();
     };
 
     private final Object getShadowLock = new Object();
@@ -409,7 +409,10 @@ public class CISShadowMonitor implements Consumer<NetworkStateProvider.Connectio
         subscribed.set(true);
     }
 
-    private void reportShadowReceived() {
+    /**
+     * Called when a shadow response, either accepted or rejected, is received.
+     */
+    private void signalShadowResponseReceived() {
         CompletableFuture<?> shadowReceived = this.getShadowResponseReceived.get();
         if (shadowReceived != null) {
             shadowReceived.complete(null);

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitor.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitor.java
@@ -59,19 +59,12 @@ public class CISShadowMonitor implements Consumer<NetworkStateProvider.Connectio
     private static final String CIS_SHADOW_SUFFIX = "-gci";
     private static final String VERSION = "version";
 
-    private static final RetryUtils.RetryConfig SUBSCRIBE_TO_TOPICS_RETRY_CONFIG =
-            RetryUtils.RetryConfig.builder()
-                    .initialRetryInterval(Duration.ofSeconds(1L))
-                    .maxRetryInterval(Duration.ofSeconds(30L))
-                    .maxAttempt(Integer.MAX_VALUE)
-                    .retryableExceptions(Collections.singletonList(Exception.class))
-                    .build();
     private static final RetryUtils.RetryConfig GET_CONNECTIVITY_RETRY_CONFIG =
             RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofMinutes(1L))
                     .maxRetryInterval(Duration.ofMinutes(30L)).maxAttempt(Integer.MAX_VALUE)
                     .retryableExceptions(Arrays.asList(ThrottlingException.class, InternalServerException.class))
                     .build();
-    private static final RetryUtils.RetryConfig GET_CIS_SHADOW_RETRY_CONFIG =
+    private static final RetryUtils.RetryConfig ALWAYS_RETRY_CONFIG =
             RetryUtils.RetryConfig.builder()
                     .initialRetryInterval(Duration.ofSeconds(1L))
                     .maxRetryInterval(Duration.ofSeconds(30L))
@@ -339,7 +332,7 @@ public class CISShadowMonitor implements Consumer<NetworkStateProvider.Connectio
             getShadowTask = executorService.submit(() -> {
                 try {
                     RetryUtils.runWithRetry(
-                            SUBSCRIBE_TO_TOPICS_RETRY_CONFIG,
+                            ALWAYS_RETRY_CONFIG,
                             () -> {
                                 subscribeToShadowTopics();
                                 return null;
@@ -356,7 +349,7 @@ public class CISShadowMonitor implements Consumer<NetworkStateProvider.Connectio
 
                 try {
                     RetryUtils.runWithRetry(
-                            GET_CIS_SHADOW_RETRY_CONFIG,
+                            ALWAYS_RETRY_CONFIG,
                             () -> {
                                 CompletableFuture<?> shadowGetResponseReceived = new CompletableFuture<>();
                                 this.getShadowResponseReceived.set(shadowGetResponseReceived);

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitorTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitorTest.java
@@ -292,7 +292,9 @@ class CISShadowMonitorTest {
         // optionally wait for the monitor to process the get shadow response.
         if (scenario.isSerialShadowUpdates()) {
             boolean monitorExpectedToUpdateReportedState =
-                    scenario.getConnectivityProviderMode() != FakeConnectivityInformation.Mode.FAIL_ONCE;
+                    scenario.getConnectivityProviderMode() != FakeConnectivityInformation.Mode.FAIL_ONCE
+                            && scenario.getNumShadowUpdatePublishFailures() == 0;
+            waitForSubscriptions();
             waitForMonitorToProcessUpdate(updateProcessedByMonitor, monitorExpectedToUpdateReportedState);
         }
 
@@ -357,6 +359,10 @@ class CISShadowMonitorTest {
         } catch (InterruptedException e) {
             fail(e);
         }
+    }
+
+    private void waitForSubscriptions() throws InterruptedException {
+        TestHelpers.eventuallyTrue(() -> shadowClient.subscriptions.size() == 3);
     }
 
     private void updateShadowDesiredState(Map<String, Object> reported, boolean publishDuplicateMessage) {

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitorTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitorTest.java
@@ -101,8 +101,6 @@ class CISShadowMonitorTest {
                 SHADOW_NAME,
                 connectivityInfoProvider
         );
-        // avoid unnecessary waiting
-        cisShadowMonitor.setMqttOperationTimeoutSeconds(1L);
     }
 
     @AfterEach

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitorTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitorTest.java
@@ -8,6 +8,7 @@ package com.aws.greengrass.clientdevices.auth.connectivity;
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateGenerator;
 import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationException;
 import com.aws.greengrass.clientdevices.auth.helpers.TestHelpers;
+import com.aws.greengrass.clientdevices.auth.iot.NetworkStateFake;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.Pair;
 import com.aws.greengrass.util.Utils;
@@ -90,16 +91,20 @@ class CISShadowMonitorTest {
     @Mock
     CertificateGenerator certificateGenerator;
 
+    NetworkStateFake networkStateProvider = new NetworkStateFake();
+
     CISShadowMonitor cisShadowMonitor;
 
     @BeforeEach
     void setup() {
         cisShadowMonitor = new CISShadowMonitor(
+                networkStateProvider,
                 shadowClientConnection,
                 shadowClient,
                 executor,
                 SHADOW_NAME,
-                connectivityInfoProvider
+                connectivityInfoProvider,
+                () -> 100
         );
     }
 
@@ -224,6 +229,9 @@ class CISShadowMonitorTest {
         if (scenario.getCreateShadowAfterDelay() == null) {
             putInitialShadowState.run();
         }
+
+        // TODO offline scenario
+        networkStateProvider.goOnline();
 
         cisShadowMonitor.addToMonitor(certificateGenerator);
         cisShadowMonitor.startMonitor();

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/NetworkStateFake.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/NetworkStateFake.java
@@ -13,7 +13,7 @@ import java.util.function.Consumer;
 
 public class NetworkStateFake implements NetworkStateProvider {
     private final List<Consumer<ConnectionState>> handlers = new ArrayList<>();
-    private NetworkStateProvider.ConnectionState connectionState;
+    private NetworkStateProvider.ConnectionState connectionState = ConnectionState.NETWORK_DOWN;
 
     @Override
     public void registerHandler(Consumer<ConnectionState> networkChangeHandler) {


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

On startup, CIS shadow monitor requests the latest CIS shadow via an MQTT request, and will update certificates with host information accordingly.  However, there is a subtle race where nucleus' mqtt client may reset during this CIS shadow get operation (e.g. due to device configuration changing).

This PR adds retry logic when fetching CIS shadows, to ensure we are resilient to failures.  We can simply wait until we receive a get shadow response, which is either:
* get shadow accepted
* get shadow rejected

Accepted is the happy path. We requested a shadow and we received it.  Rejected means the shadow doesn't exist yet; there's no need to retry because we'll get a delta update when the shadow is eventually created.

**Why is this change necessary:**
If get shadow fails when CDA starts up, server certificates may not be populated with the proper SANs, causing TLS connections between clients and local broker to fail.

**How was this change tested:**

Unit tests

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
