### PR TITLE
chore: cleanup exception messaging

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/GetClientDeviceAuthTokenTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/GetClientDeviceAuthTokenTest.java
@@ -254,13 +254,13 @@ class GetClientDeviceAuthTokenTest {
     void GIVEN_brokerWithValidCredentials_WHEN_GetClientDeviceAuthTokenFails_THEN_throwServiceError(
             ExtensionContext context) throws Exception {
         kernel.getContext().put(SessionManager.class, sessionManager);
-        ignoreExceptionOfType(context, CloudServiceInteractionException.class);
+        ignoreExceptionOfType(context, AuthenticationException.class);
         startNucleusWithConfig("cda.yaml");
         Map<String, String> mqttCredentialMap =
                 ImmutableMap.of("clientId", "some-client-id", "username", null, "password", null, "certificatePem",
                         "-----BEGIN CERTIFICATE-----" + System.lineSeparator() + "PEM=" + System.lineSeparator()
                                 + "-----END CERTIFICATE-----" + System.lineSeparator());
-        when(sessionManager.createSession("mqtt", mqttCredentialMap)).thenThrow(CloudServiceInteractionException.class);
+        when(sessionManager.createSession("mqtt", mqttCredentialMap)).thenThrow(AuthenticationException.class);
 
         try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
                 "BrokerWithGetClientDeviceAuthTokenPermission")) {
@@ -273,7 +273,7 @@ class GetClientDeviceAuthTokenTest {
             Exception err = assertThrows(Exception.class, () -> {
                 clientDeviceAuthToken(ipcClient, request, null);
             });
-            assertEquals(err.getCause().getClass(), ServiceError.class);
+            assertEquals(InvalidCredentialError.class, err.getCause().getClass());
         }
     }
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/GetClientDeviceAuthTokenTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/ipc/GetClientDeviceAuthTokenTest.java
@@ -10,7 +10,6 @@ import com.aws.greengrass.clientdevices.auth.iot.IotAuthClientFake;
 import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.clientdevices.auth.ClientDevicesAuthService;
 import com.aws.greengrass.clientdevices.auth.exception.AuthenticationException;
-import com.aws.greengrass.clientdevices.auth.exception.CloudServiceInteractionException;
 import com.aws.greengrass.clientdevices.auth.session.SessionManager;
 import com.aws.greengrass.lifecyclemanager.GlobalStateChangeListener;
 import com.aws.greengrass.lifecyclemanager.GreengrassService;

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/CertificateManager.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/CertificateManager.java
@@ -348,14 +348,16 @@ public class CertificateManager {
      *
      * @param thingName   Core device name
      * @param certificate the CA to upload to IoT core. Which will be provided by cloud discovery
-     * @throws CertificateEncodingException If unable to get certificate encoding
-     * @throws KeyStoreException            If unable to retrieve the certificate
-     * @throws IOException                  If unable to read certificate
-     * @throws DeviceConfigurationException If unable to retrieve Greengrass V2 Data client
+     * @throws CertificateEncodingException     If unable to get certificate encoding
+     * @throws KeyStoreException                If unable to retrieve the certificate
+     * @throws IOException                      If unable to read certificate
+     * @throws DeviceConfigurationException     If unable to retrieve Greengrass V2 Data client
+     * @throws CloudServiceInteractionException If cloud call fails
      */
     @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.AvoidRethrowingException"})
     public void uploadCoreDeviceCAs(String thingName, X509Certificate certificate)
-            throws CertificateEncodingException, KeyStoreException, IOException, DeviceConfigurationException {
+            throws CertificateEncodingException, KeyStoreException, IOException,
+            DeviceConfigurationException, CloudServiceInteractionException {
         String certificatePem = CertificateHelper.toPem(certificate);
 
         List<Class> retryAbleExceptions =

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/exception/CloudServiceInteractionException.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/exception/CloudServiceInteractionException.java
@@ -5,7 +5,7 @@
 
 package com.aws.greengrass.clientdevices.auth.exception;
 
-public class CloudServiceInteractionException extends RuntimeException {
+public class CloudServiceInteractionException extends Exception {
 
     private static final long serialVersionUID = -1L;
 

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Certificate.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Certificate.java
@@ -155,7 +155,7 @@ public class Certificate implements AttributeProvider {
         metadataTrustDurationMinutes.set(newTrustDuration);
     }
 
-    private boolean isStatusTrusted() {
+    public boolean isStatusTrusted() {
         Instant validTill = statusLastUpdated.plus(metadataTrustDurationMinutes.get(), ChronoUnit.MINUTES);
         return validTill.isAfter(Instant.now());
     }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClient.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClient.java
@@ -41,13 +41,13 @@ import java.util.stream.Stream;
 import javax.inject.Inject;
 
 public interface IotAuthClient {
-    Optional<String> getActiveCertificateId(String certificatePem);
+    Optional<String> getActiveCertificateId(String certificatePem) throws CloudServiceInteractionException;
 
     Optional<Certificate> getIotCertificate(String certificatePem) throws InvalidCertificateException;
 
-    boolean isThingAttachedToCertificate(Thing thing, Certificate certificate);
+    boolean isThingAttachedToCertificate(Thing thing, Certificate certificate) throws CloudServiceInteractionException;
 
-    boolean isThingAttachedToCertificate(Thing thing, String certificateId);
+    boolean isThingAttachedToCertificate(Thing thing, String certificateId) throws CloudServiceInteractionException;
 
 
     Stream<List<AssociatedClientDevice>> getThingsAssociatedWithCoreDevice();
@@ -77,7 +77,7 @@ public interface IotAuthClient {
 
         @Override
         @SuppressWarnings("PMD.AvoidCatchingGenericException")
-        public Optional<String> getActiveCertificateId(String certificatePem) {
+        public Optional<String> getActiveCertificateId(String certificatePem) throws CloudServiceInteractionException {
             if (Utils.isEmpty(certificatePem)) {
                 throw new IllegalArgumentException("Certificate PEM is empty");
             }
@@ -135,7 +135,8 @@ public interface IotAuthClient {
         }
 
         @Override
-        public boolean isThingAttachedToCertificate(Thing thing, Certificate certificate) {
+        public boolean isThingAttachedToCertificate(Thing thing, Certificate certificate)
+                throws CloudServiceInteractionException {
             if (Objects.isNull(certificate)) {
                 return false;
             }
@@ -144,7 +145,8 @@ public interface IotAuthClient {
 
         @Override
         @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.AvoidDuplicateLiterals"})
-        public boolean isThingAttachedToCertificate(Thing thing, String certificateId) {
+        public boolean isThingAttachedToCertificate(Thing thing, String certificateId)
+                throws CloudServiceInteractionException {
             if (thing == null || Utils.isEmpty(thing.getThingName())) {
                 throw new IllegalArgumentException("No thing name available to validate");
             }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/usecases/VerifyThingAttachedToCertificate.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/usecases/VerifyThingAttachedToCertificate.java
@@ -61,7 +61,7 @@ public class VerifyThingAttachedToCertificate
                 .build();
     }
 
-    private Result verifyFromCloud(Thing thing, String certificateId) {
+    private Result verifyFromCloud(Thing thing, String certificateId) throws CloudServiceInteractionException {
         logger.atDebug().kv("thing", thing.getThingName()).kv("certificate", certificateId)
                 .log("Network up, verifying thing attached to certificate from cloud");
 
@@ -111,7 +111,6 @@ public class VerifyThingAttachedToCertificate
             if (isNetworkUp()) {
                 return verifyFromCloud(thing, dto.getCertificateId());
             }
-
             return verifyLocally(thing, dto.getCertificateId());
         } catch (CloudServiceInteractionException e) {
             return verifyLocally(thing, dto.getCertificateId());

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/certificate/BackgroundCertificateRefreshTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/certificate/BackgroundCertificateRefreshTest.java
@@ -365,8 +365,8 @@ public class BackgroundCertificateRefreshTest {
         ArgumentCaptor<VerifyThingAttachedToCertificateDTO> doCaptor =
                 ArgumentCaptor.forClass(VerifyThingAttachedToCertificateDTO.class);
 
-        when(verifyThingAttachedToCertificateMock.apply(doCaptor.capture())).thenThrow(
-                new CloudServiceInteractionException("Failed to verify association")).thenReturn(
+        when(verifyThingAttachedToCertificateMock.apply(doCaptor.capture())).thenReturn(
+                VerifyThingAttachedToCertificate.Result.builder().thingHasValidAttachmentToCertificate(false).build()).thenReturn(
                         VerifyThingAttachedToCertificate.Result.builder().thingHasValidAttachmentToCertificate(true).build());
         Instant twentyFourHoursLater = now.plus(Duration.ofHours(24));
         mockInstant(twentyFourHoursLater.toEpochMilli());

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClientTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClientTest.java
@@ -70,7 +70,7 @@ public class IotAuthClientTest {
     }
 
     @Test
-    void GIVEN_certificatePem_and_cloudProperResponse_WHEN_getActiveCertificateId_THEN_certificateIdReturned() {
+    void GIVEN_certificatePem_and_cloudProperResponse_WHEN_getActiveCertificateId_THEN_certificateIdReturned() throws CloudServiceInteractionException {
         VerifyClientDeviceIdentityResponse response =
                 VerifyClientDeviceIdentityResponse.builder().clientDeviceCertificateId("certificateId").build();
         when(client.verifyClientDeviceIdentity(any(VerifyClientDeviceIdentityRequest.class))).thenReturn(response);
@@ -83,7 +83,7 @@ public class IotAuthClientTest {
     }
 
     @Test
-    void GIVEN_cloudThrowValidationException_WHEN_getActiveCertificateId_THEN_returnNull(ExtensionContext context) {
+    void GIVEN_cloudThrowValidationException_WHEN_getActiveCertificateId_THEN_returnNull(ExtensionContext context) throws CloudServiceInteractionException {
         ignoreExceptionOfType(context, ValidationException.class);
         when(client.verifyClientDeviceIdentity(any(VerifyClientDeviceIdentityRequest.class))).thenThrow(
                 ValidationException.class);
@@ -130,7 +130,7 @@ public class IotAuthClientTest {
     }
 
     @Test
-    void GIVEN_certificateAndThing_and_cloudVerificationSuccess_WHEN_isThingAttachedToCertificate_THEN_returnTrue() {
+    void GIVEN_certificateAndThing_and_cloudVerificationSuccess_WHEN_isThingAttachedToCertificate_THEN_returnTrue() throws CloudServiceInteractionException {
         when(thing.getThingName()).thenReturn("thingName");
         when(certificate.getCertificateId()).thenReturn("certificateId");
         when(client.verifyClientDeviceIoTCertificateAssociation(
@@ -145,8 +145,7 @@ public class IotAuthClientTest {
     }
 
     @Test
-    void GIVEN_cloudThrowValidationException_WHEN_isThingAttachedToCertificate_THEN_returnFalse(
-            ExtensionContext context) {
+    void GIVEN_cloudThrowValidationException_WHEN_isThingAttachedToCertificate_THEN_returnFalse(ExtensionContext context) throws CloudServiceInteractionException{
         ignoreExceptionOfType(context, ValidationException.class);
         when(thing.getThingName()).thenReturn("thingName");
         when(certificate.getCertificateId()).thenReturn("certificateId");

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactoryTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactoryTest.java
@@ -82,7 +82,7 @@ public class MqttSessionFactoryTest {
 
     @Test
     void GIVEN_credentialsWithUnknownClientId_WHEN_createSession_THEN_throwsAuthenticationException()
-            throws InvalidCertificateException {
+            throws InvalidCertificateException, CloudServiceInteractionException {
         when(mockNetworkState.getConnectionState()).thenReturn(NetworkStateProvider.ConnectionState.NETWORK_UP);
         when(mockCertificateRegistry.getCertificateFromPem(any())).thenReturn(
                 Optional.of(CertificateFake.activeCertificate()));
@@ -102,7 +102,7 @@ public class MqttSessionFactoryTest {
 
     @Test
     void GIVEN_credentialsWithCertificate_WHEN_createSession_AND_cloudError_THEN_throwsAuthenticationException()
-            throws InvalidCertificateException {
+            throws InvalidCertificateException, CloudServiceInteractionException {
         when(mockNetworkState.getConnectionState()).thenReturn(NetworkStateProvider.ConnectionState.NETWORK_UP);
         when(mockCertificateRegistry.getCertificateFromPem(any())).thenReturn(
                 Optional.of(CertificateFake.activeCertificate()));
@@ -115,7 +115,7 @@ public class MqttSessionFactoryTest {
 
     @Test
     void GIVEN_credentialsWithValidClientId_WHEN_createSession_THEN_returnsSession()
-            throws AuthenticationException, InvalidCertificateException {
+            throws AuthenticationException, InvalidCertificateException, CloudServiceInteractionException {
         when(mockNetworkState.getConnectionState()).thenReturn(NetworkStateProvider.ConnectionState.NETWORK_UP);
         when(mockThingRegistry.getOrCreateThing("clientId")).thenReturn(Thing.of("clientId"));
         when(mockThingRegistry.getThing(any())).thenReturn(Thing.of("clientId"));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

* Have more specific exception messages in `CreateIoTThingSession` to disambiguate failures.
* Make `CloudServiceInteractionException` a checked exception

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
