### PR TITLE
chore(cis): concurrency fixes and cert gen retries

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitor.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitor.java
@@ -455,6 +455,12 @@ public class CISShadowMonitor implements Consumer<NetworkStateProvider.Connectio
             if (Objects.equals(task1, task2)) {
                 return 0;
             }
+            if (task1 == null) {
+                return -1;
+            }
+            if (task2 == null) {
+                return 1;
+            }
 
             // previous or duplicate shadow version
             if (task1.shadowVersion <= task2.shadowVersion) {
@@ -485,7 +491,7 @@ public class CISShadowMonitor implements Consumer<NetworkStateProvider.Connectio
 
         private boolean isNewTask(ProcessCISShadowTask task) {
             return Stream.of(this.tasks.peekLast(), lastProcessedTask)
-                    .allMatch(t -> t == null || taskComparator.compare(task, t) > 0);
+                    .allMatch(t -> taskComparator.compare(task, t) > 0);
         }
 
         synchronized void removeProcessedTask(ProcessCISShadowTask task) {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitor.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/connectivity/CISShadowMonitor.java
@@ -6,7 +6,6 @@
 package com.aws.greengrass.clientdevices.auth.connectivity;
 
 import com.aws.greengrass.clientdevices.auth.certificate.CertificateGenerator;
-import com.aws.greengrass.clientdevices.auth.exception.CertificateGenerationException;
 import com.aws.greengrass.clientdevices.auth.infra.NetworkStateProvider;
 import com.aws.greengrass.deployment.DeviceConfiguration;
 import com.aws.greengrass.logging.api.Logger;
@@ -16,7 +15,10 @@ import com.aws.greengrass.mqttclient.WrapperMqttClientConnection;
 import com.aws.greengrass.util.Coerce;
 import com.aws.greengrass.util.CrashableSupplier;
 import com.aws.greengrass.util.RetryUtils;
+import lombok.EqualsAndHashCode;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import software.amazon.awssdk.crt.mqtt.MqttClientConnection;
 import software.amazon.awssdk.crt.mqtt.QualityOfService;
 import software.amazon.awssdk.iot.iotshadow.IotShadowClient;
@@ -29,13 +31,11 @@ import software.amazon.awssdk.iot.iotshadow.model.ShadowDeltaUpdatedSubscription
 import software.amazon.awssdk.iot.iotshadow.model.ShadowState;
 import software.amazon.awssdk.iot.iotshadow.model.UpdateShadowRequest;
 import software.amazon.awssdk.services.greengrassv2data.model.ConnectivityInfo;
-import software.amazon.awssdk.services.greengrassv2data.model.InternalServerException;
-import software.amazon.awssdk.services.greengrassv2data.model.ThrottlingException;
 
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -43,27 +43,26 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.inject.Inject;
 
 @SuppressWarnings("PMD.ImmutableField")
 public class CISShadowMonitor implements Consumer<NetworkStateProvider.ConnectionState> {
     private static final Logger LOGGER = LogManager.getLogger(CISShadowMonitor.class);
+    private static final String KV_TASK = "task";
     private static final String CIS_SHADOW_SUFFIX = "-gci";
-    private static final String VERSION = "version";
-
-    private static final RetryUtils.RetryConfig GET_CONNECTIVITY_RETRY_CONFIG =
-            RetryUtils.RetryConfig.builder().initialRetryInterval(Duration.ofMinutes(1L))
-                    .maxRetryInterval(Duration.ofMinutes(30L)).maxAttempt(Integer.MAX_VALUE)
-                    .retryableExceptions(Arrays.asList(ThrottlingException.class, InternalServerException.class))
-                    .build();
     private static final RetryUtils.RetryConfig ALWAYS_RETRY_CONFIG =
             RetryUtils.RetryConfig.builder()
                     .initialRetryInterval(Duration.ofSeconds(1L))
@@ -71,19 +70,21 @@ public class CISShadowMonitor implements Consumer<NetworkStateProvider.Connectio
                     .maxAttempt(Integer.MAX_VALUE)
                     .retryableExceptions(Collections.singletonList(Exception.class))
                     .build();
+    private final CISShadowTaskExecutor taskExecutor = new CISShadowTaskExecutor();
+    private final CISShadowTaskQueue taskQueue = new CISShadowTaskQueue();
 
-    private final Consumer<ShadowDeltaUpdatedEvent> onShadowDeltaUpdated = this::processCISShadow;
+    private final Consumer<ShadowDeltaUpdatedEvent> onShadowDeltaUpdated = resp ->
+            taskQueue.offer(new ProcessCISShadowTask(
+                    resp.version, Coerce.toString(resp.state.get("version")), resp.state));
     private final Consumer<GetShadowResponse> onGetShadowAccepted = resp -> {
         signalShadowResponseReceived();
-        processCISShadow(resp);
+        taskQueue.offer(new ProcessCISShadowTask(
+                resp.version, Coerce.toString(resp.state.desired.get("version")), resp.state.desired));
     };
     private final Consumer<ErrorResponse> onGetShadowRejected = err -> signalShadowResponseReceived();
 
-    private final Object getShadowLock = new Object();
     private Future<?> getShadowTask;
     AtomicReference<CompletableFuture<?>> getShadowResponseReceived = new AtomicReference<>();
-
-    private String lastVersion;
 
     private final Supplier<Integer> mqttOperationTimeoutMillis;
     private MqttClientConnection connection;
@@ -183,6 +184,7 @@ public class CISShadowMonitor implements Consumer<NetworkStateProvider.Connectio
      * Start shadow monitor.
      */
     public void startMonitor() {
+        taskExecutor.start();
         fetchCISShadowAsync();
     }
 
@@ -191,6 +193,7 @@ public class CISShadowMonitor implements Consumer<NetworkStateProvider.Connectio
      */
     public void stopMonitor() {
         cancelFetchCISShadow();
+        taskExecutor.stop();
     }
 
     /**
@@ -211,173 +214,62 @@ public class CISShadowMonitor implements Consumer<NetworkStateProvider.Connectio
         monitoredCertificateGenerators.remove(certificateGenerator);
     }
 
-    private void processCISShadow(GetShadowResponse response) {
-        String cisVersion = Coerce.toString(response.state.desired.get("version"));
-        processCISShadow(cisVersion, response.state.desired);
-    }
-
-    private void processCISShadow(ShadowDeltaUpdatedEvent event) {
-        String cisVersion = Coerce.toString(event.state.get("version"));
-        processCISShadow(cisVersion, event.state);
-    }
-
-    @SuppressWarnings({"PMD.AvoidCatchingGenericException", "PMD.PrematureDeclaration"})
-    private synchronized void processCISShadow(String version, Map<String, Object> desiredState) {
-        if (version == null) {
-            LOGGER.atWarn().log("Ignoring CIS shadow response, version is missing");
-            return;
-        }
-
-        if (Objects.equals(version, lastVersion)) {
-            LOGGER.atInfo().kv(VERSION, version).log("Already processed version. Skipping cert re-generation");
-            updateCISShadowReportedState(desiredState);
-            return;
-        }
-
-        LOGGER.atInfo().log("New CIS version: {}", version);
-
-        // TODO make this cancellable
-        // NOTE: This method executes in an MQTT CRT thread. Since certificate generation is a compute intensive
-        // operation (particularly on low end devices) it is imperative that we process this event asynchronously
-        // to avoid blocking other MQTT subscribers in the Nucleus
-        CompletableFuture.runAsync(() -> {
-
-            Set<String> prevCachedHostAddresses = new HashSet<>(connectivityInformation.getCachedHostAddresses());
-
-            Optional<List<ConnectivityInfo>> connectivityInfo;
-            try {
-                connectivityInfo = RetryUtils.runWithRetry(
-                        GET_CONNECTIVITY_RETRY_CONFIG,
-                        connectivityInformation::getConnectivityInfo,
-                        "get-connectivity",
-                        LOGGER
-                );
-            } catch (InterruptedException e) {
-                LOGGER.atDebug().kv(VERSION, version).cause(e)
-                        .log("Retry workflow for getting connectivity info interrupted");
-                Thread.currentThread().interrupt();
-                return;
-            } catch (Exception e) {
-                LOGGER.atError().kv(VERSION, version).cause(e)
-                        .log("Failed to get connectivity info from cloud. Check that the core device's IoT policy "
-                                + "grants the greengrass:GetConnectivityInfo permission");
-                return;
-            }
-
-            if (!connectivityInfo.isPresent()) {
-                // CIS call failed for either ValidationException or ResourceNotFoundException.
-                // We won't retry in this case, but we will update the CIS shadow reported state
-                // to signal that we have fully processed this version.
-                try {
-                    LOGGER.atInfo().kv(VERSION, version)
-                            .log("No connectivity info found. Skipping cert re-generation");
-                    updateCISShadowReportedState(desiredState);
-                } finally {
-                    // Don't process the same version again
-                    lastVersion = version;
-                }
-                return;
-            }
-
-            // skip cert rotation if connectivity info hasn't changed
-            Set<String> cachedHostAddresses = new HashSet<>(connectivityInformation.getCachedHostAddresses());
-            if (Objects.equals(prevCachedHostAddresses, cachedHostAddresses)) {
-                try {
-                    LOGGER.atInfo().kv(VERSION, version)
-                            .log("Connectivity info hasn't changed. Skipping cert re-generation");
-                    // update the CIS shadow reported state
-                    // to signal that we have fully processed this version.
-                    updateCISShadowReportedState(desiredState);
-                } finally {
-                    // Don't process the same version again
-                    lastVersion = version;
-                }
-                return;
-            }
-
-            try {
-                for (CertificateGenerator cg : monitoredCertificateGenerators) {
-                    cg.generateCertificate(() -> new ArrayList<>(cachedHostAddresses), "connectivity info was updated");
-                }
-                LOGGER.atDebug().log("certificates rotated");
-            } catch (CertificateGenerationException e) {
-                LOGGER.atError().kv(VERSION, version).cause(e).log("Failed to generate new certificates");
-                return;
-            }
-
-            try {
-                // update CIS shadow so reported state matches desired state
-                updateCISShadowReportedState(desiredState);
-            } finally {
-                // Don't process the same version again
-                lastVersion = version;
-            }
-        }, executorService).exceptionally(e -> {
-            LOGGER.atError().kv(VERSION, version).cause(e).log("Unable to handle CIS shadow delta");
-            return null;
-        });
-    }
-
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
-    private void fetchCISShadowAsync() {
+    private synchronized void fetchCISShadowAsync() {
         if (networkStateProvider.getConnectionState() == NetworkStateProvider.ConnectionState.NETWORK_DOWN) {
             // will be retried when online again
             return;
         }
-        synchronized (getShadowLock) {
-            if (getShadowTask != null && !getShadowTask.isDone()) {
-                // operation already in progress
+        if (getShadowTask != null && !getShadowTask.isDone()) {
+            // operation already in progress
+            return;
+        }
+        getShadowTask = executorService.submit(() -> {
+            try {
+                RetryUtils.runWithRetry(
+                        ALWAYS_RETRY_CONFIG,
+                        () -> {
+                            subscribeToShadowTopics();
+                            return null;
+                        },
+                        "subscribe-to-cis-topics",
+                        LOGGER);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            } catch (Exception e) {
+                LOGGER.atError().cause(e).log("Unexpected failure when subscribing to shadow topics");
                 return;
             }
-            getShadowTask = executorService.submit(() -> {
-                try {
-                    RetryUtils.runWithRetry(
-                            ALWAYS_RETRY_CONFIG,
-                            () -> {
-                                subscribeToShadowTopics();
-                                return null;
-                            },
-                            "subscribe-to-cis-topics",
-                            LOGGER);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    return;
-                } catch (Exception e) {
-                    LOGGER.atError().cause(e).log("Unexpected failure when subscribing to shadow topics");
-                    return;
-                }
 
-                try {
-                    RetryUtils.runWithRetry(
-                            ALWAYS_RETRY_CONFIG,
-                            () -> {
-                                CompletableFuture<?> shadowGetResponseReceived = new CompletableFuture<>();
-                                this.getShadowResponseReceived.set(shadowGetResponseReceived);
-                                publishToGetCISShadowTopic().get();
-                                // await shadow get accepted, rejected
-                                long waitForGetResponseTimeout =
-                                        Duration.ofMillis(mqttOperationTimeoutMillis.get())
-                                                .plusSeconds(5L) // buffer
-                                                .toMillis();
-                                shadowGetResponseReceived.get(waitForGetResponseTimeout, TimeUnit.MILLISECONDS);
-                                return null;
-                            },
-                            "get-cis-shadow",
-                            LOGGER);
-                } catch (InterruptedException ignore) {
-                    Thread.currentThread().interrupt();
-                } catch (Exception e) {
-                    LOGGER.atError().cause(e).log("unable to get CIS shadow");
-                }
-            });
-        }
+            try {
+                RetryUtils.runWithRetry(
+                        ALWAYS_RETRY_CONFIG,
+                        () -> {
+                            CompletableFuture<?> shadowGetResponseReceived = new CompletableFuture<>();
+                            this.getShadowResponseReceived.set(shadowGetResponseReceived);
+                            publishToGetCISShadowTopic().get();
+                            // await shadow get accepted, rejected
+                            long waitForGetResponseTimeout =
+                                    Duration.ofMillis(mqttOperationTimeoutMillis.get())
+                                            .plusSeconds(5L) // buffer
+                                            .toMillis();
+                            shadowGetResponseReceived.get(waitForGetResponseTimeout, TimeUnit.MILLISECONDS);
+                            return null;
+                        },
+                        "get-cis-shadow",
+                        LOGGER);
+            } catch (InterruptedException ignore) {
+                Thread.currentThread().interrupt();
+            } catch (Exception e) {
+                LOGGER.atError().cause(e).log("unable to get CIS shadow");
+            }
+        });
     }
 
-    private void cancelFetchCISShadow() {
-        synchronized (getShadowLock) {
-            if (getShadowTask != null) {
-                getShadowTask.cancel(true);
-            }
+    private synchronized void cancelFetchCISShadow() {
+        if (getShadowTask != null) {
+            getShadowTask.cancel(true);
         }
     }
 
@@ -409,28 +301,216 @@ public class CISShadowMonitor implements Consumer<NetworkStateProvider.Connectio
                 });
     }
 
-    /**
-     * Asynchronously update the CIS shadow's reported state for the given shadow version.
-     *
-     * @param reportedState CIS shadow reported state
-     */
-    private void updateCISShadowReportedState(Map<String, Object> reportedState) {
-        UpdateShadowRequest updateShadowRequest = new UpdateShadowRequest();
-        updateShadowRequest.thingName = shadowName.get();
-        updateShadowRequest.state = new ShadowState();
-        updateShadowRequest.state.reported = reportedState == null ? null : new HashMap<>(reportedState);
-        iotShadowClient.PublishUpdateShadow(updateShadowRequest, QualityOfService.AT_LEAST_ONCE).exceptionally(e -> {
-            LOGGER.atWarn().cause(e).log("Unable to update CIS shadow reported state");
-            return null;
-        });
-    }
-
     @Override
     public void accept(NetworkStateProvider.ConnectionState state) {
         if (state == NetworkStateProvider.ConnectionState.NETWORK_UP) {
             fetchCISShadowAsync();
         } else if (state == NetworkStateProvider.ConnectionState.NETWORK_DOWN) {
             cancelFetchCISShadow();
+        }
+    }
+
+    @ToString
+    @EqualsAndHashCode
+    @RequiredArgsConstructor
+    class ProcessCISShadowTask implements Callable<Void> {
+        private final long shadowVersion;
+        private final String cisVersion;
+        private final Map<String, Object> desiredState;
+
+        @Override
+        public Void call() throws Exception {
+            LOGGER.atDebug().kv(KV_TASK, this).log("Processing CIS shadow");
+            try {
+                processCISShadow();
+                LOGGER.atDebug().kv(KV_TASK, this).log("Shadow processing complete");
+                return null;
+            } finally {
+                if (Thread.currentThread().isInterrupted()) {
+                    LOGGER.atDebug().kv(KV_TASK, this)
+                            .log("Shadow processing interrupted");
+                } else {
+                    // always attempt to report shadow update state in case it failed to update previously.
+                    // NOTE: setting reported state is not required, functionality-wise.
+                    //       however, it may be useful for debugging
+                    updateCISShadowReportedState(desiredState);
+                }
+            }
+        }
+
+        @SuppressWarnings({"PMD.AvoidCatchingGenericException",
+                "PMD.SignatureDeclareThrowsException", "PMD.PrematureDeclaration"})
+        private void processCISShadow() throws Exception {
+            Set<String> prevCachedHostAddresses = new HashSet<>(connectivityInformation.getCachedHostAddresses());
+
+            Optional<List<ConnectivityInfo>> connectivityInfo = RetryUtils.runWithRetry(
+                    ALWAYS_RETRY_CONFIG,
+                    connectivityInformation::getConnectivityInfo,
+                    "get-connectivity",
+                    LOGGER
+            );
+
+            if (!connectivityInfo.isPresent()) {
+                // CIS call failed for either ValidationException or ResourceNotFoundException.
+                // We won't retry in this case, but we will update the CIS shadow reported state
+                // to signal that we have fully processed this version.
+                LOGGER.atDebug().kv(KV_TASK, this)
+                        .log("No connectivity info found. Skipping cert re-generation");
+                return;
+            }
+
+            // skip cert rotation if connectivity info hasn't changed
+            Set<String> cachedHostAddresses = new HashSet<>(connectivityInformation.getCachedHostAddresses());
+            if (Objects.equals(prevCachedHostAddresses, cachedHostAddresses)) {
+                LOGGER.atDebug().kv(KV_TASK, this)
+                        .log("Connectivity info hasn't changed. Skipping cert re-generation");
+                return;
+            }
+
+            List<SucceedOnceOperation> certGenOperations = monitoredCertificateGenerators.stream()
+                    .map(cg -> generateCertificateOperation(cg, cachedHostAddresses))
+                    .collect(Collectors.toList());
+            RetryUtils.runWithRetry(
+                    ALWAYS_RETRY_CONFIG,
+                    () -> generateCertificates(certGenOperations),
+                    "generate-certificates",
+                    LOGGER
+            );
+        }
+
+        private SucceedOnceOperation generateCertificateOperation(CertificateGenerator cg, Set<String> hostAddresses) {
+            return new SucceedOnceOperation(() -> {
+                cg.generateCertificate(
+                        () -> new ArrayList<>(hostAddresses), "connectivity info was updated");
+                return null;
+            });
+        }
+
+        @SuppressWarnings("PMD.SignatureDeclareThrowsException")
+        private Void generateCertificates(List<SucceedOnceOperation> certGenOperations) throws Exception {
+            for (SucceedOnceOperation genCert : certGenOperations) {
+                // cert gen may be expensive, so catch interrupts as early as possible
+                if (Thread.currentThread().isInterrupted()) {
+                    throw new InterruptedException("Interrupted while generating certificates");
+                }
+                genCert.apply();
+            }
+            return null;
+        }
+
+        private void updateCISShadowReportedState(Map<String, Object> reportedState) {
+            UpdateShadowRequest updateShadowRequest = new UpdateShadowRequest();
+            updateShadowRequest.thingName = shadowName.get();
+            updateShadowRequest.state = new ShadowState();
+            updateShadowRequest.state.reported = reportedState == null ? null : new HashMap<>(reportedState);
+            iotShadowClient.PublishUpdateShadow(updateShadowRequest, QualityOfService.AT_LEAST_ONCE)
+                    .exceptionally(e -> {
+                        LOGGER.atDebug().cause(e).log("Unable to update CIS shadow reported state");
+                        return null;
+                    });
+        }
+    }
+
+    class CISShadowTaskExecutor {
+        private Future<?> task;
+
+        @SuppressWarnings("PMD.AvoidCatchingGenericException")
+        void start() {
+            stop();
+            task = executorService.submit(() -> {
+                while (!Thread.currentThread().isInterrupted()) {
+                    ProcessCISShadowTask task = null;
+                    try {
+                        // keep task in queue during processing
+                        task = taskQueue.blockingPeek();
+                        task.call();
+                        taskQueue.removeProcessedTask(task);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    } catch (Exception e) {
+                        LOGGER.atError().cause(e).kv(KV_TASK, task).log("Unable to process connectivity shadow. "
+                                + "Certificates may not be updated with most current connectivity info. "
+                                + "If components are experiencing TLS handshake errors, restart Greengrass "
+                                + "to refresh certificates");
+                    }
+                }
+            });
+        }
+
+        void stop() {
+            if (task != null) {
+                task.cancel(true);
+            }
+        }
+    }
+
+    /**
+     * A queue for connectivity shadow responses. Old shadows will be rejected from the queue.
+     */
+    class CISShadowTaskQueue  {
+        private final BlockingDeque<ProcessCISShadowTask> tasks = new LinkedBlockingDeque<>();
+        private ProcessCISShadowTask lastProcessedTask;
+        private final Comparator<ProcessCISShadowTask> taskComparator = (task1, task2) -> {
+            if (Objects.equals(task1, task2)) {
+                return 0;
+            }
+
+            // previous or duplicate shadow version
+            if (task1.shadowVersion <= task2.shadowVersion) {
+                return -1;
+            }
+
+            // duplicate shadow state
+            if (Objects.equals(task2.cisVersion, task1.cisVersion)) {
+                return -1;
+            }
+
+            // task2 is a new request
+            return 1;
+        };
+
+        synchronized boolean offer(@NonNull ProcessCISShadowTask task) {
+            if (!isNewTask(task)) {
+                LOGGER.atDebug().kv(KV_TASK, task).log("Ignoring CIS shadow");
+                return false;
+            }
+            // since we received a newer request, we can discard all older ones,
+            // except the head of the queue, which is the task currently being processed.
+            while (tasks.size() > 1) {
+                tasks.pollLast();
+            }
+            return tasks.offerLast(task);
+        }
+
+        private boolean isNewTask(ProcessCISShadowTask task) {
+            return Stream.of(this.tasks.peekLast(), lastProcessedTask)
+                    .allMatch(t -> t == null || taskComparator.compare(task, t) > 0);
+        }
+
+        synchronized void removeProcessedTask(ProcessCISShadowTask task) {
+            lastProcessedTask = task;
+            tasks.remove(task);
+        }
+
+        /**
+         * Like {@link BlockingDeque#peek()} except it blocks until the queue has at least one element.
+         *
+         * @return head of the queue
+         * @throws InterruptedException if interrupted while waiting
+         */
+        ProcessCISShadowTask blockingPeek() throws InterruptedException {
+            ProcessCISShadowTask task = tasks.takeFirst();
+            synchronized (this) {
+                // elements may have been added to the queue,
+                // recalculate the head of the queue
+                ProcessCISShadowTask head = tasks.pollFirst();
+                if (head != null && taskComparator.compare(head, task) > 0) {
+                    task = head;
+                }
+                tasks.offerFirst(task);
+            }
+            return task;
         }
     }
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

This PR modifies `CISShadowMonitor` to be resilient to race conditions, such as:
1) receiving shadow delta response around the same time as a get shadow response, during startup up or after network connectivity resumes
2) receiving multiple delta responses in quick succession, due to connectivity shadow being updated quickly

...and the chances increase if the core device is low-powered (takes longer to generate certificates).

Currently, there is no mechanism in place to prevent the interleaving connectivity shadow processing (which includes fetching/updating connectivity info, and generating certificates using such info).  Worst case, this can result in server certificates being generated with old/previous host addresses.

To achieve this, I'm using a producer-consumer approach. Producers are incoming shadow requests (get shadow, or shadow delta update).  Consumer is a single thread that processes one request from the queue at a time.  Incoming requests are filtered out if they are deemed stale (previous or duplicate shadow version, duplicate CIS shadow state).  This approach is more complicated than canceling and replacing task with every incoming shadow request, but it ensures the monitor doesn't perform extra work.

Additionally, retry behavior has been modified so that calls to connectivity service and certificate generation are retried indefinitely, until interruption.  Previously, on failures there were no retries so there was no way for recovery, aside from restarting greengrass or waiting/forcing a shadow update.

:warning: Suggestion to reviewers: view diff in split mode

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
