### PR TITLE
feat: add benchmarking

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,9 @@
+# Client Device Auth Benchmarking
+
+Benchmarks for main code paths in CDA, such as policy evaluation.
+
+## Quick Start
+
+```
+./run-benchmarks.sh
+```

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+    SPDX-License-Identifier: Apache-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.aws.greengrass</groupId>
+    <artifactId>client-devices-auth-benchmark</artifactId>
+    <name>benchmark</name>
+    <version>2.5.0-SNAPSHOT</version>
+
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.aws.greengrass</groupId>
+            <artifactId>client-devices-auth</artifactId>
+            <version>2.5.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jmh.version>1.23</jmh.version>
+        <javac.target>1.8</javac.target>
+        <uberjar.name>benchmarks</uberjar.name>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <compilerVersion>${javac.target}</compilerVersion>
+                    <source>${javac.target}</source>
+                    <target>${javac.target}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.2</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>${uberjar.name}</finalName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <!--
+                                        Shading signed JARs will fail without this.
+                                        http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                                    -->
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2</url>
+        </pluginRepository>
+    </pluginRepositories>
+</project>

--- a/benchmark/run-benchmarks.sh
+++ b/benchmark/run-benchmarks.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+# install CDA locally
+cd ./..
+mvn clean install -DskipTests
+cd -
+
+# build benchmark project
+mvn clean package
+
+# run all benchmarks
+java -jar target/benchmarks.jar

--- a/benchmark/src/main/java/com/aws/greengrass/clientdevices/auth/benchmark/RuleExpressionEvaluationBenchmark.java
+++ b/benchmark/src/main/java/com/aws/greengrass/clientdevices/auth/benchmark/RuleExpressionEvaluationBenchmark.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.benchmark;
+
+import com.aws.greengrass.clientdevices.auth.configuration.ExpressionVisitor;
+import com.aws.greengrass.clientdevices.auth.configuration.parser.ASTStart;
+import com.aws.greengrass.clientdevices.auth.configuration.parser.RuleExpression;
+import com.aws.greengrass.clientdevices.auth.session.Session;
+import com.aws.greengrass.clientdevices.auth.session.attribute.AttributeProvider;
+import com.aws.greengrass.clientdevices.auth.session.attribute.DeviceAttribute;
+import com.aws.greengrass.clientdevices.auth.session.attribute.WildcardSuffixAttribute;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+
+import java.io.StringReader;
+
+
+public class RuleExpressionEvaluationBenchmark {
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void evaluateThingExpressionWithThingName() throws Exception {
+        ASTStart tree = new RuleExpression(new StringReader("thingName: MyThingName")).Start();
+        Session session = new FakeSession("MyThingName");
+        new ExpressionVisitor().visit(tree, session);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void evaluateWildcardPrefixThingExpressionWithThingName() throws Exception {
+        ASTStart tree = new RuleExpression(new StringReader("thingName: *ThingName")).Start();
+        Session session = new FakeSession("MyThingName");
+        new ExpressionVisitor().visit(tree, session);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void evaluateWildcardSuffixThingExpressionWithThingName() throws Exception {
+        ASTStart tree = new RuleExpression(new StringReader("thingName: MyThing*")).Start();
+        Session session = new FakeSession("MyThingName");
+        new ExpressionVisitor().visit(tree, session);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void evaluateWildcardPrefixAndSuffixThingExpressionWithThingName() throws Exception {
+        ASTStart tree = new RuleExpression(new StringReader("thingName: *ThingName*")).Start();
+        Session session = new FakeSession("MyThingName");
+        new ExpressionVisitor().visit(tree, session);
+    }
+
+    static class FakeSession implements Session {
+
+        private final DeviceAttribute attribute;
+
+        FakeSession(String thingName) {
+            this.attribute = new WildcardSuffixAttribute(thingName);
+        }
+
+        @Override
+        public AttributeProvider getAttributeProvider(String attributeProviderNameSpace) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public DeviceAttribute getSessionAttribute(String attributeNamespace, String attributeName) {
+            return attribute;
+        }
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Introduce benchmarking to the repo, using JMH (also used in Nucleus repo). For now, added some basic benchmarks for evaluating thingName selection expressions.  Benchmarks can be run using the `run-benchmarks.sh` convenience script.  Future work is to add more benchmarks and have them run in github and report metrics.

**Why is this change necessary:**

So we can get performance numbers on key code paths in CDA, to better inform implementations and allow us to improve over time

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
