### PR TITLE
chore: only run benchmark workflow on prs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,9 +1,6 @@
 name: Benchmarks
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches: '*'
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Don't run benchmarks when `main` is updated.  Forgot to remove this in https://github.com/aws-greengrass/aws-greengrass-client-device-auth/pull/416

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
