### PR TITLE
chore: deflake metrics test

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/metrics/MetricsEmitterTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/metrics/MetricsEmitterTest.java
@@ -284,6 +284,11 @@ public class MetricsEmitterTest {
         Metric expectedMetric = buildMetric(METRIC_VERIFY_CLIENT_DEVICE_IDENTITY_SUCCESS);
         startNucleusWithConfig("metricsConfig.yaml");
 
+        //Reset the metric spy and capture the emitted metrics when the emitter runs
+        Mockito.reset(metricSpy);
+        ResultCaptor<List<Metric>> resultMetrics = new ResultCaptor<>();
+        doAnswer(resultMetrics).when(metricSpy).collectMetrics();
+
         //Verify client device identity
         try (EventStreamRPCConnection connection = IPCTestUtils.getEventStreamRpcConnection(kernel,
                 "BrokerSubscribingToCertUpdates")) {
@@ -294,11 +299,6 @@ public class MetricsEmitterTest {
 
             ipcClient.verifyClientDeviceIdentity(request, Optional.empty()).getResponse();
         }
-
-        //Reset the metric spy and capture the emitted metrics when the emitter runs
-        Mockito.reset(metricSpy);
-        ResultCaptor<List<Metric>> resultMetrics = new ResultCaptor<>();
-        doAnswer(resultMetrics).when(metricSpy).collectMetrics();
 
         //Wait for the emitter to run
         Mockito.verify(metricSpy, Mockito.timeout(2000L).atLeastOnce()).emitMetrics();


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Attempt to get rid of null pointers showing up in recent test runs for `GIVEN_kernelRunningWithMetricsConfig_WHEN_verifyClientDeviceIdentity_THEN_successMetricEmitted`

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
