### PR TITLE
chore: deflake rest of MetricsEmitterTest

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/metrics/MetricsEmitterTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/metrics/MetricsEmitterTest.java
@@ -328,7 +328,9 @@ public class MetricsEmitterTest {
     }
 
     private void assertMetricEmitted(Metric metric) throws InterruptedException {
-        verify(clientDeviceAuthMetrics, Mockito.timeout(2000L).atLeastOnce()).emitMetrics();
+        // let the emitter run multiple times,
+        // allows us to verify later that extra metrics weren't emitted
+        verify(clientDeviceAuthMetrics, Mockito.timeout(3000L).atLeast(2)).emitMetrics();
         // metrics are emitted periodically from when CDA started.
         // to avoid a race with the verification above, we simply wait for the first non-empty metrics to be emitted.
         assertTrue(eventuallyTrue(() -> clientDeviceAuthMetrics.getCollectedMetrics() != null));


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Continuation of https://github.com/aws-greengrass/aws-greengrass-client-device-auth/pull/420, extended to the whole `MetricsEmitterTest`.

Previously we waited for `emitMetrics` to be called to signal a metric was reported, but even with https://github.com/aws-greengrass/aws-greengrass-client-device-auth/pull/420 there is still a race between calling the API and `emitMetrics` (GIVEN_kernelRunningWithMetricsConfig_WHEN_subscribeToCertificateUpdate_THEN_successMetricEmitted, for example was failing unit tests when attempting to make the same change).

To ignore the race, we can capture the first (non empty) list of metrics, and wait for metric emitter to run at least another cycle and verify no extra methods are emitted.  This would verify that for one API call, we get exactly one metric emit.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
