### PR TITLE
chore: add integ test for removing resources from policy

### DIFF
--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/policy/empty-config.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/policy/empty-config.yaml
@@ -1,0 +1,12 @@
+---
+services:
+  aws.greengrass.Nucleus:
+    configuration:
+      runWithDefault:
+        posixUser: nobody
+        windowsUser: integ-tester
+      logging:
+        level: "DEBUG"
+  main:
+    dependencies:
+      - aws.greengrass.clientdevices.Auth

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/GroupDefinition.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/GroupDefinition.java
@@ -9,6 +9,7 @@ import com.aws.greengrass.clientdevices.auth.configuration.parser.ASTStart;
 import com.aws.greengrass.clientdevices.auth.configuration.parser.ParseException;
 import com.aws.greengrass.clientdevices.auth.configuration.parser.RuleExpression;
 import com.aws.greengrass.clientdevices.auth.session.Session;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import lombok.Builder;
@@ -21,12 +22,15 @@ import java.io.StringReader;
 @JsonDeserialize(builder = GroupDefinition.GroupDefinitionBuilder.class)
 public class GroupDefinition {
 
+    @JsonIgnore
     ASTStart expressionTree;
+    String selectionRule;
     String policyName;
 
 
     @Builder
     GroupDefinition(@NonNull String selectionRule, @NonNull String policyName) throws ParseException {
+        this.selectionRule = selectionRule;
         this.expressionTree = new RuleExpression(new StringReader(selectionRule)).Start();
         this.policyName = policyName;
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adding some more test coverage at the integration level.  Tests that if resource A is removed from a policy, that we immediately are no longer able to publish to it

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
