### PR TITLE
fix: validate config and error service during startup

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/policy/PolicyTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/policy/PolicyTest.java
@@ -146,9 +146,9 @@ public class PolicyTest {
             "malformed-variable.yaml",
             "unknown-variable.yaml"
     })
-    void GIVEN_invalid_cda_policy_WHEN_cda_startups_THEN_cda_errors(String configFile, ExtensionContext context) {
+    void GIVEN_invalid_cda_policy_WHEN_cda_startups_THEN_cda_broken(String configFile, ExtensionContext context) {
         ignoreExceptionOfType(context, PolicyException.class);
-        startNucleus(configFile, State.ERRORED);
+        startNucleus(configFile, State.BROKEN);
     }
 
     @Value

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/policy/PolicyTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/policy/PolicyTest.java
@@ -141,6 +141,31 @@ public class PolicyTest {
                 .build()));
     }
 
+    @Test
+    void GIVEN_cda_running_WHEN_policy_updated_with_invalid_policy_variable_THEN_cda_broken(ExtensionContext context) throws Exception {
+        ignoreExceptionOfType(context, PolicyException.class);
+        startNucleus("empty-config.yaml");
+        //CDA is RUNNING
+
+        Runnable mainRunning = createServiceStateChangeWaiter(kernel,
+                ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME, 30, State.BROKEN);
+
+        // merge bad policy config
+        replacePolicy(GroupConfiguration.builder()
+                .definitions(Utils.immutableMap("group1", GroupDefinition.builder()
+                        .policyName("policyA")
+                        .selectionRule("thingName: myThing")
+                        .build()))
+                .policies(Utils.immutableMap("policyA", Utils.immutableMap("statement1", AuthorizationPolicyStatement.builder()
+                        .statementDescription("invalid policy variable")
+                        .operations(Stream.of("mqtt:publish").collect(Collectors.toSet()))
+                        .resources(Stream.of("mqtt:topic:${iot:Connection.Thing.Unknown}").collect(Collectors.toSet()))
+                        .effect(AuthorizationPolicyStatement.Effect.ALLOW)
+                        .build())))
+                .build());
+        mainRunning.run();
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {
             "malformed-variable.yaml",

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/policy/PolicyTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/policy/PolicyTest.java
@@ -145,9 +145,8 @@ public class PolicyTest {
     void GIVEN_cda_running_WHEN_policy_updated_with_invalid_policy_variable_THEN_cda_broken(ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, PolicyException.class);
         startNucleus("empty-config.yaml");
-        //CDA is RUNNING
 
-        Runnable mainRunning = createServiceStateChangeWaiter(kernel,
+        Runnable waitForBroken = createServiceStateChangeWaiter(kernel,
                 ClientDevicesAuthService.CLIENT_DEVICES_AUTH_SERVICE_NAME, 30, State.BROKEN);
 
         // merge bad policy config
@@ -163,7 +162,7 @@ public class PolicyTest {
                         .effect(AuthorizationPolicyStatement.Effect.ALLOW)
                         .build())))
                 .build());
-        mainRunning.run();
+        waitForBroken.run();
     }
 
     @ParameterizedTest

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -216,7 +216,8 @@ public class ClientDevicesAuthService extends PluginService {
         context.get(CertificateManager.class).startMonitors();
         try {
             subscribeToConfigChanges();
-            validateConfig();
+            // Validate CDA policy to force CDA to break on bad config policies before CDA reaches RUNNING
+            lookupAndValidateDeviceGroups();
         } catch (IllegalArgumentException | PolicyException e) {
             serviceErrored(e);
             return;
@@ -270,7 +271,8 @@ public class ClientDevicesAuthService extends PluginService {
         GroupConfiguration groupConfiguration;
 
         try {
-            groupConfiguration = validateConfig();
+            // Lookup and validate DeviceGroups to ensure CDA errors on bad CDA policy changes
+            groupConfiguration = lookupAndValidateDeviceGroups();
         } catch (IllegalArgumentException | PolicyException e) {
             serviceErrored(e);
             return;
@@ -279,7 +281,7 @@ public class ClientDevicesAuthService extends PluginService {
         context.get(GroupManager.class).setGroupConfiguration(groupConfiguration);
     }
 
-    private GroupConfiguration validateConfig() throws IllegalArgumentException, PolicyException {
+    private GroupConfiguration lookupAndValidateDeviceGroups() throws IllegalArgumentException, PolicyException {
         GroupConfiguration groupConfiguration;
         Topics deviceGroupTopics = this.config.lookupTopics(CONFIGURATION_CONFIG_KEY, DEVICE_GROUPS_TOPICS);
         groupConfiguration = MAPPER.convertValue(deviceGroupTopics.toPOJO(), GroupConfiguration.class);

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -281,7 +281,7 @@ public class ClientDevicesAuthService extends PluginService {
         context.get(GroupManager.class).setGroupConfiguration(groupConfiguration);
     }
 
-    private GroupConfiguration lookupAndValidateDeviceGroups() throws IllegalArgumentException, PolicyException {
+    private GroupConfiguration lookupAndValidateDeviceGroups() throws PolicyException {
         GroupConfiguration groupConfiguration;
         Topics deviceGroupTopics = this.config.lookupTopics(CONFIGURATION_CONFIG_KEY, DEVICE_GROUPS_TOPICS);
         groupConfiguration = MAPPER.convertValue(deviceGroupTopics.toPOJO(), GroupConfiguration.class);


### PR DESCRIPTION
**Description of changes:**
Validate CDA config during startup and force CDA to error if a validation exception is thrown.

**Why is this change necessary:**
Without this change, CDA will not reach the broken state when there is a bad config.

**How was this change tested:**
Integration testing

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
