### PR TITLE
fix: limit client IDs to 65,535

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/handlers/CAConfigurationChangedHandler.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/handlers/CAConfigurationChangedHandler.java
@@ -49,7 +49,7 @@ public class CAConfigurationChangedHandler implements Consumer<CAConfigurationCh
      * @param event Certificate authority configuration change event
      */
     @Override
-    public void accept(CAConfigurationChanged event) {
+    public synchronized void accept(CAConfigurationChanged event) {
         CAConfiguration configuration = event.getConfiguration();
 
         try {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/usecases/ConfigureCustomCertificateAuthority.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/usecases/ConfigureCustomCertificateAuthority.java
@@ -45,10 +45,6 @@ public class ConfigureCustomCertificateAuthority implements UseCases.UseCase<Voi
 
     @Override
     public Void apply(CAConfiguration configuration) throws UseCaseException {
-        // TODO: We need to synchronize the changes that configuration has on the state of the service. There is
-        //  a possibility that 2 threads run different use cases and change the certificate authority concurrently
-        //  causing potential race conditions
-
         try {
             logger.info("Configuring custom certificate authority.");
             // NOTE: We will pull the configureCustomCA out of the certificate Manager to here

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/usecases/ConfigureManagedCertificateAuthority.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/usecases/ConfigureManagedCertificateAuthority.java
@@ -46,10 +46,6 @@ public class ConfigureManagedCertificateAuthority implements UseCases.UseCase<Vo
         // TODO: We should not be passing the entire configuration just what changed. We are just doing it for
         //  its convenience but eventually syncing the runtime config can be its own use case triggered by events.
 
-        // TODO: We need to synchronize the changes that configuration has on the state of the service. There is
-        //  a possibility that 2 threads run different use cases and change the certificate authority concurrently
-        //  causing potential race conditions
-
         logger.info("Configuring Greengrass managed certificate authority.");
 
         try {

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/usecases/CreateIoTThingSession.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/usecases/CreateIoTThingSession.java
@@ -51,6 +51,10 @@ public class CreateIoTThingSession implements UseCases.UseCase<Session, CreateSe
      */
     @Override
     public Session apply(CreateSessionDTO dto) throws AuthenticationException {
+        if (dto.getThingName() != null && dto.getThingName().length() > 65_535) {
+            throw new AuthenticationException("Thing name is too long");
+        }
+
         Certificate certificate = getActiveCertificateFromRegistry(dto);
         String thingName = dto.getThingName();
         Thing thing = thingRegistry.getOrCreateThing(thingName);

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactory.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactory.java
@@ -45,7 +45,7 @@ public class MqttSessionFactory implements SessionFactory {
     }
 
     private Session createIotThingSession(MqttCredential mqttCredential) throws AuthenticationException {
-        // NOTE: We should remove  calling this useCase from here, but for now it serves its purpose. We will
+        // NOTE: We should remove calling this useCase from here, but for now it serves its purpose. We will
         //  refactor this later
         CreateIoTThingSession useCase = useCases.get(CreateIoTThingSession.class);
         CreateSessionDTO command = new CreateSessionDTO(mqttCredential.clientId, mqttCredential.certificatePem);

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactoryTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactoryTest.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
@@ -98,6 +99,15 @@ public class MqttSessionFactoryTest {
             throws InvalidCertificateException {
         when(mockCertificateRegistry.getCertificateFromPem(any())).thenReturn(Optional.empty());
         Assertions.assertThrows(AuthenticationException.class, () -> mqttSessionFactory.createSession(credentialMap));
+    }
+
+    @Test
+    void GIVEN_credentialsWithLongClientId_WHEN_createSession_THEN_throwsAuthenticationException() {
+        AuthenticationException ex = Assertions.assertThrows(AuthenticationException.class,
+                () -> mqttSessionFactory.createSession(
+                        ImmutableMap.of("certificatePem", "PEM", "clientId", new String(new byte[65536]), "username",
+                                "", "password", "")));
+        assertThat(ex.getMessage(), containsString("too long"));
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
MQTT client IDs are at most 65,535 by the current MQTT 5 specification. Add a limit to our code if the MQTT broker itself does not do the validation.

**Why is this change necessary:**

**How was this change tested:**
Added a test

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
