### PR TITLE
fix: limit thing name to 128 characters

### DIFF
--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Thing.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/Thing.java
@@ -32,6 +32,7 @@ public final class Thing implements AttributeProvider, Cloneable {
     public static final String NAMESPACE = "Thing";
     private static final String THING_NAME_ATTRIBUTE = "ThingName";
     private static final String thingNamePattern = "[a-zA-Z0-9\\-_:]+";
+    public static final int MAX_THING_NAME_LENGTH = 128;
     private static final AtomicInteger metadataTrustDurationMinutes =
             new AtomicInteger(DEFAULT_CLIENT_DEVICE_TRUST_DURATION_MINUTES);
 
@@ -58,6 +59,9 @@ public final class Thing implements AttributeProvider, Cloneable {
      * @throws IllegalArgumentException If the given ThingName contains illegal characters
      */
     public static Thing of(String thingName, Map<String, Instant> certificateIds) {
+        if (thingName.length() > MAX_THING_NAME_LENGTH) {
+            throw new IllegalArgumentException("Invalid thing name. Thing name is too long.");
+        }
         if (!Pattern.matches(thingNamePattern, thingName)) {
             throw new IllegalArgumentException("Invalid thing name. The thing name must match \"[a-zA-Z0-9\\-_:]+\".");
         }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/usecases/CreateIoTThingSession.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/usecases/CreateIoTThingSession.java
@@ -21,6 +21,8 @@ import com.aws.greengrass.logging.impl.LogManager;
 
 import javax.inject.Inject;
 
+import static com.aws.greengrass.clientdevices.auth.iot.Thing.MAX_THING_NAME_LENGTH;
+
 public class CreateIoTThingSession implements UseCases.UseCase<Session, CreateSessionDTO> {
     private static final Logger logger = LogManager.getLogger(CreateIoTThingSession.class);
     private final ThingRegistry thingRegistry;
@@ -51,7 +53,7 @@ public class CreateIoTThingSession implements UseCases.UseCase<Session, CreateSe
      */
     @Override
     public Session apply(CreateSessionDTO dto) throws AuthenticationException {
-        if (dto.getThingName() != null && dto.getThingName().length() > 65_535) {
+        if (dto.getThingName() != null && dto.getThingName().length() > MAX_THING_NAME_LENGTH) {
             throw new AuthenticationException("Thing name is too long");
         }
 

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactoryTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/session/MqttSessionFactoryTest.java
@@ -105,7 +105,7 @@ public class MqttSessionFactoryTest {
     void GIVEN_credentialsWithLongClientId_WHEN_createSession_THEN_throwsAuthenticationException() {
         AuthenticationException ex = Assertions.assertThrows(AuthenticationException.class,
                 () -> mqttSessionFactory.createSession(
-                        ImmutableMap.of("certificatePem", "PEM", "clientId", new String(new byte[65536]), "username",
+                        ImmutableMap.of("certificatePem", "PEM", "clientId", new String(new byte[130]), "username",
                                 "", "password", "")));
         assertThat(ex.getMessage(), containsString("too long"));
     }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Limit thing names to 128 characters to fail fast for invalid names.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
