### PR TITLE
fix: delete thing from local registry if validation fails

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/certificateauthority/BackgroundRefreshTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/certificateauthority/BackgroundRefreshTest.java
@@ -189,8 +189,8 @@ public class BackgroundRefreshTest {
 
         // Check state before refresh of thing attachments
         ThingRegistry thingRegistry = kernel.getContext().get(ThingRegistry.class);
-        Thing ogThingA = thingRegistry.getOrCreateThing(thingOne.get());
-        Thing ogThingB = thingRegistry.getOrCreateThing(thingTwo.get());
+        Thing ogThingA = thingRegistry.getOrCreateThing(thingOne.get()).getLeft();
+        Thing ogThingB = thingRegistry.getOrCreateThing(thingTwo.get()).getLeft();
         assertEquals(ogThingA.certificateLastAttachedOn(ogCertA.getCertificateId()).get().toEpochMilli(),
                 now.toEpochMilli());
         assertEquals(ogThingB.certificateLastAttachedOn(ogCertB.getCertificateId()).get().toEpochMilli(),

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/iot/infra/ThingRegistry.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/iot/infra/ThingRegistry.java
@@ -10,6 +10,7 @@ import com.aws.greengrass.clientdevices.auth.configuration.RuntimeConfiguration;
 import com.aws.greengrass.clientdevices.auth.iot.Thing;
 import com.aws.greengrass.clientdevices.auth.iot.dto.ThingV1DTO;
 import com.aws.greengrass.clientdevices.auth.iot.events.ThingUpdated;
+import com.aws.greengrass.util.Pair;
 
 import java.time.Instant;
 import java.util.Map;
@@ -38,14 +39,15 @@ public class ThingRegistry {
      * Get or create a Thing.
      *
      * @param thingName ThingName
-     * @return Thing object
+     * @return Thing object and if the thing was newly created
      */
-    public Thing getOrCreateThing(String thingName) {
+    public Pair<Thing, Boolean> getOrCreateThing(String thingName) {
         Thing thing = getThingInternal(thingName);
         if (thing == null) {
             thing = createThing(thingName);
+            return new Pair<>(thing, true);
         }
-        return thing;
+        return new Pair<>(thing, false);
     }
 
     /**


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
`getOrCreateThing` writes to our config which is necessary to perform the validation, but if validation failed and the thing hasn't been seen before, then we make sure to delete the thing from our config.


**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
