### PR TITLE
chore(fips): update endpoint overwrite method

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.6.0-SNAPSHOT</version>
+            <version>2.13.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.aws.greengrass</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.17.81</version>
+                <version>2.20.138</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -73,13 +73,13 @@
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.6.0-SNAPSHOT</version>
+            <version>2.13.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.aws.greengrass</groupId>
             <artifactId>nucleus</artifactId>
-            <version>2.6.0-SNAPSHOT</version>
+            <version>2.13.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/certificateauthority/OfflineAuthenticationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/certificateauthority/OfflineAuthenticationTest.java
@@ -20,6 +20,7 @@ import com.aws.greengrass.clientdevices.auth.iot.IotAuthClientFake;
 import com.aws.greengrass.clientdevices.auth.iot.NetworkStateFake;
 import com.aws.greengrass.dependency.State;
 import com.aws.greengrass.lifecyclemanager.Kernel;
+import com.aws.greengrass.mqttclient.MqttRequestException;
 import com.aws.greengrass.mqttclient.spool.SpoolerStoreException;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 
@@ -46,6 +47,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -172,7 +174,8 @@ public class OfflineAuthenticationTest {
     @Test
     void GIVEN_clientConnectsWhileOnline_WHEN_offline_THEN_clientCanConnect(ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, NoSuchFileException.class);
-
+        ignoreExceptionOfType(context, MqttRequestException.class);
+        ignoreExceptionOfType(context, ExecutionException.class);
         // Given
         network.goOnline();
 
@@ -198,7 +201,8 @@ public class OfflineAuthenticationTest {
     void GIVEN_clientConnectsWhileOnline_WHEN_offlineAndTtlExpired_THEN_clientCanNotConnect(ExtensionContext context)
             throws Exception {
         ignoreExceptionOfType(context, NoSuchFileException.class);
-
+        ignoreExceptionOfType(context, MqttRequestException.class);
+        ignoreExceptionOfType(context, ExecutionException.class);
         // Given
         network.goOnline();
         Instant now = Instant.now();
@@ -230,6 +234,8 @@ public class OfflineAuthenticationTest {
     void GIVEN_clientConnectsWhileOnline_WHEN_offlineAndCertificateRevoked_THEN_backOnlineAndClientRejected(
             ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, NoSuchFileException.class);
+        ignoreExceptionOfType(context, MqttRequestException.class);
+        ignoreExceptionOfType(context, ExecutionException.class);
         // Given
         network.goOnline();
 
@@ -260,6 +266,8 @@ public class OfflineAuthenticationTest {
     void GIVEN_clientConnectsWhileOnline_WHEN_offlineAndCertDetachedFromThing_THEN_backOnlineAndClientRejected(
             ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, NoSuchFileException.class);
+        ignoreExceptionOfType(context, MqttRequestException.class);
+        ignoreExceptionOfType(context, ExecutionException.class);
         // Given
         network.goOnline();
 
@@ -291,6 +299,8 @@ public class OfflineAuthenticationTest {
             ExtensionContext context) throws Exception {
         ignoreExceptionOfType(context, NoSuchFileException.class);
         ignoreExceptionOfType(context, InvalidCertificateException.class);
+        ignoreExceptionOfType(context, MqttRequestException.class);
+        ignoreExceptionOfType(context, ExecutionException.class);
         // Given
         network.goOnline();
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
1. Updating the dependencies
2. Update method to provide ggv2dataclient endpoint
3. Ignoring device offline exceptions in unit testing since we're targeting authentication and the device offline related exceptions are expected

**Why is this change necessary:**
It's used to support fips feature where the endpoint should be override earlier than built-in useFips function
**How was this change tested:**
With UAT
**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
