### PR TITLE
feat: mqtt-style resource wildcard matching

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/policy/PolicyTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/policy/PolicyTest.java
@@ -273,6 +273,19 @@ public class PolicyTest {
                                 .operation("mqtt:publish")
                                 .resource("mqtt:topic:myThing/world")
                                 .expectedResult(false)
+                                .build(),
+                        // mqtt wildcards eval not supported
+                        AuthZRequest.builder()
+                                .thingName("myThing")
+                                .operation("mqtt:subscribe")
+                                .resource("mqtt:topic:myThing/test/test/*")
+                                .expectedResult(false)
+                                .build(),
+                        AuthZRequest.builder()
+                                .thingName("myThing")
+                                .operation("mqtt:subscribe")
+                                .resource("mqtt:topic:myThing/#/test/*")
+                                .expectedResult(true)
                                 .build()
                 )),
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/policy/PolicyTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/policy/PolicyTest.java
@@ -274,7 +274,7 @@ public class PolicyTest {
                                 .resource("mqtt:topic:myThing/world")
                                 .expectedResult(false)
                                 .build(),
-                        // mqtt wildcards eval not supported
+                        // mqtt wildcards eval not supported by default
                         AuthZRequest.builder()
                                 .thingName("myThing")
                                 .operation("mqtt:subscribe")
@@ -285,6 +285,27 @@ public class PolicyTest {
                                 .thingName("myThing")
                                 .operation("mqtt:subscribe")
                                 .resource("mqtt:topic:myThing/#/test/*")
+                                .expectedResult(true)
+                                .build()
+                )),
+
+                Arguments.of("mqtt-wildcards-in-resource.yaml", Arrays.asList(
+                        AuthZRequest.builder()
+                                .thingName("myThing")
+                                .operation("mqtt:publish")
+                                .resource("mqtt:topic:*/myThing/*")
+                                .expectedResult(true)
+                                .build(),
+                        AuthZRequest.builder()
+                                .thingName("myThing")
+                                .operation("mqtt:publish")
+                                .resource("mqtt:topic:hello/myThing/world")
+                                .expectedResult(true)
+                                .build(),
+                        AuthZRequest.builder()
+                                .thingName("myThing")
+                                .operation("mqtt:subscribe")
+                                .resource("mqtt:topic:myThing/test/test/test/test")
                                 .expectedResult(true)
                                 .build()
                 )),

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/policy/mqtt-wildcards-in-resource.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/policy/mqtt-wildcards-in-resource.yaml
@@ -1,0 +1,35 @@
+---
+services:
+  aws.greengrass.Nucleus:
+    configuration:
+      runWithDefault:
+        posixUser: nobody
+        windowsUser: integ-tester
+      logging:
+        level: "DEBUG"
+  aws.greengrass.clientdevices.Auth:
+    configuration:
+      enableMqttWildcardEvaluation: true
+      deviceGroups:
+        formatVersion: "2021-03-05"
+        definitions:
+          myThing:
+            selectionRule: "thingName: myThing"
+            policyName: "thingAccessPolicy"
+        policies:
+          thingAccessPolicy:
+            publish:
+              statementDescription: "mqtt publish"
+              operations:
+                - "mqtt:publish"
+              resources:
+                - "mqtt:topic:*/myThing/*"
+            subscribe:
+              statementDescription: "mqtt subscribe"
+              operations:
+                - "mqtt:subscribe"
+              resources:
+                - "mqtt:topic:${iot:Connection.Thing.ThingName}/+/test/#"
+  main:
+    dependencies:
+      - aws.greengrass.clientdevices.Auth

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/policy/wildcards-in-resource-type.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/policy/wildcards-in-resource-type.yaml
@@ -17,12 +17,18 @@ services:
             policyName: "thingAccessPolicy"
         policies:
           thingAccessPolicy:
-            policyStatement:
+            publish:
               statementDescription: "mqtt publish"
               operations:
                 - "mqtt:publish"
               resources:
                 - "mqtt:topic:*/myThing/*"
+            subscribe:
+              statementDescription: "mqtt subscribe"
+              operations:
+                - "mqtt:subscribe"
+              resources:
+                - "mqtt:topic:myThing/#/test/*"
   main:
     dependencies:
       - aws.greengrass.clientdevices.Auth

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -170,6 +170,8 @@ public class ClientDevicesAuthService extends PluginService {
     private void onConfigurationChanged() {
         try {
             cdaConfiguration = CDAConfiguration.from(cdaConfiguration, getConfig());
+            // TODO decouple
+            context.get(PermissionEvaluationUtils.class).setCdaConfiguration(cdaConfiguration);
         } catch (URISyntaxException e) {
             serviceErrored(e);
         }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Proposes a new configuration option, `enableMqttWildcardEvaluation`, to allow policy resources to be evaluated using MQTT wildcard.

e.g.

```
       policies:
          thingAccessPolicy:
            subscribe:
              statementDescription: "mqtt subscribe"
              operations:
                - "mqtt:subscribe"
              resources:
                - "mqtt:topic:${iot:Connection.Thing.ThingName}/+/test/#"
```

Allows client devices to subscribe to `thingName/path/test/path1/path2`, for example

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
