### PR TITLE
feat: single character wildcard matching

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/policy/PolicyTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/policy/PolicyTest.java
@@ -273,6 +273,19 @@ public class PolicyTest {
                                 .operation("mqtt:publish")
                                 .resource("mqtt:topic:myThing/world")
                                 .expectedResult(false)
+                                .build(),
+                        // mqtt wildcards eval not supported
+                        AuthZRequest.builder()
+                                .thingName("myThing")
+                                .operation("mqtt:subscribe")
+                                .resource("mqtt:topic:myThing/test/test/*")
+                                .expectedResult(false)
+                                .build(),
+                        AuthZRequest.builder()
+                                .thingName("myThing")
+                                .operation("mqtt:subscribe")
+                                .resource("mqtt:topic:myThing/#/test/*")
+                                .expectedResult(true)
                                 .build()
                 )),
 

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/policy/PolicyTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/policy/PolicyTest.java
@@ -274,7 +274,7 @@ public class PolicyTest {
                                 .resource("mqtt:topic:myThing/world")
                                 .expectedResult(false)
                                 .build(),
-                        // mqtt wildcards eval not supported
+                        // mqtt wildcards eval not supported by default
                         AuthZRequest.builder()
                                 .thingName("myThing")
                                 .operation("mqtt:subscribe")
@@ -285,6 +285,27 @@ public class PolicyTest {
                                 .thingName("myThing")
                                 .operation("mqtt:subscribe")
                                 .resource("mqtt:topic:myThing/#/test/*")
+                                .expectedResult(true)
+                                .build()
+                )),
+
+                Arguments.of("mqtt-wildcards-in-resource.yaml", Arrays.asList(
+                        AuthZRequest.builder()
+                                .thingName("myThing")
+                                .operation("mqtt:publish")
+                                .resource("mqtt:topic:*/myThing/*")
+                                .expectedResult(true)
+                                .build(),
+                        AuthZRequest.builder()
+                                .thingName("myThing")
+                                .operation("mqtt:publish")
+                                .resource("mqtt:topic:hello/myThing/world")
+                                .expectedResult(true)
+                                .build(),
+                        AuthZRequest.builder()
+                                .thingName("myThing")
+                                .operation("mqtt:subscribe")
+                                .resource("mqtt:topic:myThing/test/test/test/test")
                                 .expectedResult(true)
                                 .build()
                 )),

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/policy/PolicyTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/policy/PolicyTest.java
@@ -274,39 +274,33 @@ public class PolicyTest {
                                 .resource("mqtt:topic:myThing/world")
                                 .expectedResult(false)
                                 .build(),
-                        // mqtt wildcards eval not supported by default
+                        // single character eval not supported by default
                         AuthZRequest.builder()
                                 .thingName("myThing")
                                 .operation("mqtt:subscribe")
-                                .resource("mqtt:topic:myThing/test/test/*")
+                                .resource("mqtt:topic:myThing/#/test/abc")
                                 .expectedResult(false)
                                 .build(),
                         AuthZRequest.builder()
                                 .thingName("myThing")
                                 .operation("mqtt:subscribe")
-                                .resource("mqtt:topic:myThing/#/test/*")
+                                .resource("mqtt:topic:myThing/#/test/???")
                                 .expectedResult(true)
                                 .build()
                 )),
 
-                Arguments.of("mqtt-wildcards-in-resource.yaml", Arrays.asList(
+                Arguments.of("single-character-wildcards-in-resource.yaml", Arrays.asList(
                         AuthZRequest.builder()
                                 .thingName("myThing")
-                                .operation("mqtt:publish")
-                                .resource("mqtt:topic:*/myThing/*")
-                                .expectedResult(true)
-                                .build(),
-                        AuthZRequest.builder()
-                                .thingName("myThing")
-                                .operation("mqtt:publish")
-                                .resource("mqtt:topic:hello/myThing/world")
+                                .operation("mqtt:subscribe")
+                                .resource("mqtt:topic:myThing/abc/test/a/b")
                                 .expectedResult(true)
                                 .build(),
                         AuthZRequest.builder()
                                 .thingName("myThing")
                                 .operation("mqtt:subscribe")
-                                .resource("mqtt:topic:myThing/test/test/test/test")
-                                .expectedResult(true)
+                                .resource("mqtt:topic:myThing/abcd/test/a/b")
+                                .expectedResult(false)
                                 .build()
                 )),
 

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/policy/mqtt-wildcards-in-resource.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/policy/mqtt-wildcards-in-resource.yaml
@@ -1,0 +1,35 @@
+---
+services:
+  aws.greengrass.Nucleus:
+    configuration:
+      runWithDefault:
+        posixUser: nobody
+        windowsUser: integ-tester
+      logging:
+        level: "DEBUG"
+  aws.greengrass.clientdevices.Auth:
+    configuration:
+      enableMqttWildcardEvaluation: true
+      deviceGroups:
+        formatVersion: "2021-03-05"
+        definitions:
+          myThing:
+            selectionRule: "thingName: myThing"
+            policyName: "thingAccessPolicy"
+        policies:
+          thingAccessPolicy:
+            publish:
+              statementDescription: "mqtt publish"
+              operations:
+                - "mqtt:publish"
+              resources:
+                - "mqtt:topic:*/myThing/*"
+            subscribe:
+              statementDescription: "mqtt subscribe"
+              operations:
+                - "mqtt:subscribe"
+              resources:
+                - "mqtt:topic:${iot:Connection.Thing.ThingName}/+/test/#"
+  main:
+    dependencies:
+      - aws.greengrass.clientdevices.Auth

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/policy/single-character-wildcards-in-resource.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/policy/single-character-wildcards-in-resource.yaml
@@ -9,7 +9,7 @@ services:
         level: "DEBUG"
   aws.greengrass.clientdevices.Auth:
     configuration:
-      enableMqttWildcardEvaluation: true
+      enableSingleCharacterWildcardMatching: true
       deviceGroups:
         formatVersion: "2021-03-05"
         definitions:
@@ -18,18 +18,12 @@ services:
             policyName: "thingAccessPolicy"
         policies:
           thingAccessPolicy:
-            publish:
-              statementDescription: "mqtt publish"
-              operations:
-                - "mqtt:publish"
-              resources:
-                - "mqtt:topic:*/myThing/*"
             subscribe:
               statementDescription: "mqtt subscribe"
               operations:
                 - "mqtt:subscribe"
               resources:
-                - "mqtt:topic:${iot:Connection.Thing.ThingName}/+/test/#"
+                - "mqtt:topic:${iot:Connection.Thing.ThingName}/???/test/*"
   main:
     dependencies:
       - aws.greengrass.clientdevices.Auth

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/policy/wildcards-in-resource-type.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/policy/wildcards-in-resource-type.yaml
@@ -28,7 +28,7 @@ services:
               operations:
                 - "mqtt:subscribe"
               resources:
-                - "mqtt:topic:myThing/#/test/*"
+                - "mqtt:topic:myThing/#/test/???"
   main:
     dependencies:
       - aws.greengrass.clientdevices.Auth

--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/policy/wildcards-in-resource-type.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/policy/wildcards-in-resource-type.yaml
@@ -17,12 +17,18 @@ services:
             policyName: "thingAccessPolicy"
         policies:
           thingAccessPolicy:
-            policyStatement:
+            publish:
               statementDescription: "mqtt publish"
               operations:
                 - "mqtt:publish"
               resources:
                 - "mqtt:topic:*/myThing/*"
+            subscribe:
+              statementDescription: "mqtt subscribe"
+              operations:
+                - "mqtt:subscribe"
+              resources:
+                - "mqtt:topic:myThing/#/test/*"
   main:
     dependencies:
       - aws.greengrass.clientdevices.Auth

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/ClientDevicesAuthService.java
@@ -170,6 +170,8 @@ public class ClientDevicesAuthService extends PluginService {
     private void onConfigurationChanged() {
         try {
             cdaConfiguration = CDAConfiguration.from(cdaConfiguration, getConfig());
+            // TODO decouple
+            context.get(PermissionEvaluationUtils.class).setCdaConfiguration(cdaConfiguration);
         } catch (URISyntaxException e) {
             serviceErrored(e);
         }

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/CDAConfiguration.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/configuration/CDAConfiguration.java
@@ -53,7 +53,7 @@ import static com.aws.greengrass.lifecyclemanager.GreengrassService.RUNTIME_STOR
 @Builder
 public final class CDAConfiguration {
 
-    public static final String ENABLE_MQTT_WILDCARD_EVALUATION = "enableMqttWildcardEvaluation";
+    public static final String ENABLE_MQTT_WILDCARD_EVALUATION = "enableSingleCharacterWildcardMatching";
 
     private final DomainEvents domainEvents;
     private final RuntimeConfiguration runtime;
@@ -62,7 +62,7 @@ public final class CDAConfiguration {
     private final SecurityConfiguration security;
     private final MetricsConfiguration metricsConfiguration;
     @Getter
-    private final boolean enableMqttWildcardEvaluation;
+    private final boolean matchSingleCharacterWildcard;
 
     /**
      * Creates the CDA (Client Device Auth) Service configuration. And allows it to be available in the context with the
@@ -84,7 +84,7 @@ public final class CDAConfiguration {
                 .certificateAuthorityConfiguration(CAConfiguration.from(serviceConfiguration))
                 .security(SecurityConfiguration.from(serviceConfiguration))
                 .metricsConfiguration(MetricsConfiguration.from(serviceConfiguration))
-                .enableMqttWildcardEvaluation(
+                .matchSingleCharacterWildcard(
                         Coerce.toBoolean(serviceConfiguration.find(ENABLE_MQTT_WILDCARD_EVALUATION)))
                 .build();
 

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/util/WildcardTrie.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/util/WildcardTrie.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.util;
+
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class WildcardTrie {
+    private static final String GLOB_WILDCARD = "*";
+    private static final String SINGLE_CHAR_WILDCARD = "?";
+
+    private final Map<String, WildcardTrie> children = new DefaultHashMap<>(WildcardTrie::new);
+
+    private boolean isTerminal;
+    private boolean isGlobWildcard;
+    private boolean isSingleCharWildcard;
+
+    public void add(String subject) {
+        add(subject, true);
+    }
+
+    private WildcardTrie add(String subject, boolean isTerminal) {
+        if (subject == null || subject.isEmpty()) {
+            this.isTerminal |= isTerminal;
+            return this;
+        }
+        StringBuilder currPrefix = new StringBuilder(subject.length());
+        for (int i = 0; i < subject.length(); i++) {
+            char c = subject.charAt(i);
+            if (c == GLOB_WILDCARD.charAt(0)) {
+                return addGlobWildcard(subject, currPrefix.toString(), isTerminal);
+            }
+            if (c == SINGLE_CHAR_WILDCARD.charAt(0)) {
+                return addSingleCharWildcard(subject, currPrefix.toString(), isTerminal);
+            }
+            currPrefix.append(c);
+        }
+        WildcardTrie node = children.get(currPrefix.toString());
+        node.isTerminal |= isTerminal;
+        return node;
+    }
+
+    private WildcardTrie addGlobWildcard(String subject, String currPrefix, boolean isTerminal) {
+        WildcardTrie node = this;
+        node = node.add(currPrefix, false);
+        node = node.children.get(GLOB_WILDCARD);
+        node.isGlobWildcard = true;
+        // wildcard at end of subject is terminal
+        if (subject.length() - currPrefix.length() == 1) {
+            node.isTerminal = isTerminal;
+            return node;
+        }
+        return node.add(subject.substring(currPrefix.length() + 2), true);
+    }
+
+    private WildcardTrie addSingleCharWildcard(String subject, String currPrefix, boolean isTerminal) {
+        WildcardTrie node = this;
+        node = node.add(currPrefix, false);
+        node = node.children.get(SINGLE_CHAR_WILDCARD);
+        node.isSingleCharWildcard = true;
+        // wildcard at end of subject is terminal
+        if (subject.length() - currPrefix.length() == 1) {
+            node.isTerminal = isTerminal;
+            return node;
+        }
+        return node.add(subject.substring(currPrefix.length() + 1), true);
+    }
+
+    public boolean matches(String s) {
+        return matches(s, true);
+    }
+
+    public boolean matches(String s, boolean matchSingleCharWildcard) {
+        if (s == null) {
+            return children.isEmpty();
+        }
+
+        if ((isWildcard() && isTerminal) || (isTerminal && s.isEmpty())) {
+            return true;
+        }
+
+        boolean childMatchesWildcard = children
+                .values()
+                .stream()
+                .filter(WildcardTrie::isWildcard)
+                .filter(childNode -> matchSingleCharWildcard || !childNode.isSingleCharWildcard)
+                .anyMatch(childNode -> childNode.matches(s, matchSingleCharWildcard));
+        if (childMatchesWildcard) {
+            return true;
+        }
+
+        if (matchSingleCharWildcard) {
+            boolean childMatchesSingleCharWildcard = children
+                    .values()
+                    .stream()
+                    .filter(childNode -> childNode.isSingleCharWildcard)
+                    .anyMatch(childNode -> childNode.matches(s, matchSingleCharWildcard));
+            if (childMatchesSingleCharWildcard) {
+                return true;
+            }
+        }
+
+        boolean childMatchesRegularCharacters = children
+                .keySet()
+                .stream()
+                .filter(s::startsWith)
+                .anyMatch(childToken -> {
+                    WildcardTrie childNode = children.get(childToken);
+                    String rest = s.substring(childToken.length());
+                    return childNode.matches(rest, matchSingleCharWildcard);
+                });
+        if (childMatchesRegularCharacters) {
+            return true;
+        }
+
+        if (isWildcard() && !isTerminal) {
+            return findMatchingChildSuffixesAfterWildcard(s, matchSingleCharWildcard)
+                    .entrySet()
+                    .stream()
+                    .anyMatch((e) -> {
+                        String suffix = e.getKey();
+                        WildcardTrie childNode = e.getValue();
+                        return childNode.matches(suffix, matchSingleCharWildcard);
+                    });
+        }
+        return false;
+    }
+
+    private Map<String, WildcardTrie> findMatchingChildSuffixesAfterWildcard(String s, boolean matchSingleCharWildcard) {
+        Map<String, WildcardTrie> matchingSuffixes = new HashMap<>();
+        for (Map.Entry<String, WildcardTrie> e : children.entrySet()) {
+            String childToken = e.getKey();
+            WildcardTrie childNode = e.getValue();
+            int suffixIndex = s.indexOf(childToken);
+            if (matchSingleCharWildcard && suffixIndex > 1) {
+                continue;
+            }
+            while (suffixIndex >= 0) {
+                matchingSuffixes.put(s.substring(suffixIndex + childToken.length()), childNode);
+                suffixIndex = s.indexOf(childToken, suffixIndex + 1);
+            }
+        }
+        return matchingSuffixes;
+    }
+
+    private boolean isWildcard() {
+        return isGlobWildcard || isSingleCharWildcard;
+    }
+
+    @SuppressFBWarnings("EQ_DOESNT_OVERRIDE_EQUALS")
+    private static class DefaultHashMap<K, V> extends HashMap<K, V> {
+        private final transient Supplier<V> defaultVal;
+
+        public DefaultHashMap(Supplier<V> defaultVal) {
+            super();
+            this.defaultVal = defaultVal;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public V get(Object key) {
+            return super.computeIfAbsent((K) key, (k) -> defaultVal.get());
+        }
+
+        @Override
+        public boolean containsKey(Object key) {
+            return super.get(key) != null;
+        }
+    }
+}

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/util/WildcardTrieTest.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/util/WildcardTrieTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.aws.greengrass.clientdevices.auth.util;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+// TODO fix failing cases
+class WildcardTrieTest {
+
+    static Stream<Arguments> validMatches() {
+        return Stream.of(
+                arguments("foo", singletonList("foo")),
+                arguments("foo/bar", singletonList("foo/bar")),
+                // glob wildcard *
+                arguments("*", asList("foo", "foo/bar", "foo/bar/baz", "$foo/bar", "foo*", "foo?", "***", "???")),
+                arguments("*test", asList("test", "*test", "**test", "testtest", "test*test")),
+                arguments("test*", asList("test", "test*", "testA", "test**")),
+                arguments("test*test", asList("testtest", "testAtest", "test*test")),
+                arguments("test*test*", asList("testtest", "testtesttesttest", "test*test*")),
+                arguments("*test*test", asList("Atesttest", "testAtest", "AtestAtest", "testtest", "*test*test")),
+                arguments("*test*test*", asList("testtest", "*test*test*", "Atesttest", "testAtest", "testtestA", "AtestAtest", "testAtestA", "AtestAtestA")),
+                // single character wildcard ?
+                arguments("?", asList("f", "*", "?")),
+                arguments("??", asList("ff", "**", "??", "*?")),
+                arguments("?f?", asList("fff", "f", "ff", "*f", "*f*", "f*"))
+        );
+    }
+
+    @MethodSource("validMatches")
+    @ParameterizedTest
+    void GIVEN_trie_with_wildcards_WHEN_valid_matches_provided_THEN_pass(String pattern, List<String> matches) {
+        WildcardTrie trie = new WildcardTrie();
+        trie.add(pattern);
+        matches.forEach(m -> assertTrue(trie.matches(m)));
+    }
+
+
+    static Stream<Arguments> invalidMatches() {
+        return Stream.of(
+                arguments("foo", singletonList("bar")),
+                arguments("foo/bar", singletonList("bar/foo")),
+                // glob wildcard *
+                arguments("*test", asList("testA", "*testA", "AtestA", "bar")),
+                arguments("test*", asList("Atest", "Atest*", "AtestA", "Atest**", "bar")),
+                arguments("test*test", asList("Atesttest", "AtestAtest", "testAtestA", "testbar")),
+                arguments("test*test*", asList("Atesttest", "AtestAtest", "AtestAtestA", "testbar")),
+                arguments("*test*test", asList("AtestAtestA", "test*bar", "bartest", "testbar")),
+                arguments("*test*test*", asList("AtestAbar", "testbar", "bartest")),
+                // single character wildcard ?
+                arguments("?", asList("aa", "??", "**")),
+                arguments("??", asList("aaa", "???", "***")),
+                arguments("?a?", asList("aaaa", "fff"))
+        );
+    }
+
+    @MethodSource("invalidMatches")
+    @ParameterizedTest
+    void GIVEN_trie_with_wildcards_WHEN_invalid_matches_provided_THEN_fail(String pattern, List<String> matches) {
+        WildcardTrie trie = new WildcardTrie();
+        trie.add(pattern);
+        matches.forEach(m -> assertFalse(trie.matches(m)));
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

⚠️ WIP: still ironing out bugs

Adds new configuration option `enableSingleCharacterWildcardMatching` to allow `?` matching in CDA policy resources.  `?` will match any single character, similar to how IoT Core handles it (https://docs.aws.amazon.com/iot/latest/developerguide/pub-sub-policy.html#pub-sub-policy-cert).  Reason for flag is to ensure CDA version upgrade doesn't make policies already containing a `?` more permissive than originally intended.

**Why is this change necessary:**

To maintain feature parity with IoT Core

**How was this change tested:**

Unit and integration tests

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
