### PR TITLE
fix: do not read response from a closed client

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,7 +21,7 @@ jobs:
         run: ./run-benchmarks.sh
         working-directory: ./benchmark
       - name: Upload Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Benchmark Results
           path: ./benchmark/jmh-result.json

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -37,13 +37,13 @@ jobs:
         shell: cmd
         if: matrix.os == 'windows-latest'
       - name: Upload Failed Test Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Failed Test Report
           path: target/surefire-reports
       - name: Upload Coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: matrix.os == 'ubuntu-latest'
         with:
           name: Coverage Report ${{ matrix.os }}

--- a/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/infra/BackgroundCertificateRefresh.java
+++ b/src/main/java/com/aws/greengrass/clientdevices/auth/certificate/infra/BackgroundCertificateRefresh.java
@@ -202,12 +202,12 @@ public class BackgroundCertificateRefresh implements Runnable, Consumer<NetworkS
                         .build();
 
         try {
-            Stream<List<AssociatedClientDevice>> cloudAssociatedDevices =
+            List<AssociatedClientDevice> cloudAssociatedDevices =
                     RetryUtils.runWithRetry(retryConfig, iotAuthClient::getThingsAssociatedWithCoreDevice,
                             "get-things-associated-with-core-device", logger);
 
             Set<String> cloudThings =
-                    cloudAssociatedDevices.flatMap(List::stream).map(AssociatedClientDevice::thingName)
+                    cloudAssociatedDevices.stream().map(AssociatedClientDevice::thingName)
                             .collect(Collectors.toSet());
 
             return Optional.of(cloudThings);

--- a/src/test/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClientFake.java
+++ b/src/test/java/com/aws/greengrass/clientdevices/auth/iot/IotAuthClientFake.java
@@ -12,6 +12,7 @@ import software.amazon.awssdk.services.greengrassv2.model.AssociatedClientDevice
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -22,7 +23,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
+import java.util.stream.Collectors;
 
 /**
  * IoT Auth Client Fake allows test writers to set up valid and invalid certificates, as well as Thing <-> certificate
@@ -126,11 +127,11 @@ public class IotAuthClientFake implements IotAuthClient {
     }
 
     @Override
-    public Stream<List<AssociatedClientDevice>> getThingsAssociatedWithCoreDevice() {
+    public List<AssociatedClientDevice> getThingsAssociatedWithCoreDevice() {
         ThingsAttachedToCorePaginator paginator = new ThingsAttachedToCorePaginator(
                 new ListClientDevicesAssociatedWithCoreDeviceResponseFetcher(this.thingsAttachedToCore));
 
-        return paginator.stream();
+        return paginator.stream().flatMap(Collection::stream).collect(Collectors.toList());
     }
 
     /**


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**
Whenever a stream response of the associated client devices is read, it  uses the underlying GGv2 client. But with `try-with-resources`, the client is closed as soon as the response is returned and gives the following error

```
Exception in thread "main" java.lang.IllegalStateException: Connection pool shut down
	at org.apache.http.util.Asserts.check(Asserts.java:34)
	at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.requestConnection(PoolingHttpClientConnectionManager.java:269)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:567)
	at software.amazon.awssdk.http.apache.internal.conn.ClientConnectionManagerFactory$Handler.invoke(ClientConnectionManagerFactory.java:80)
	at com.sun.proxy.$Proxy0.requestConnection(Unknown Source)
```

With this change, we read the full response from the stream and convert it to a list so we don't depend on the client after the response is returned.

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
